### PR TITLE
Reduce unnecessary stress on RDP control

### DIFF
--- a/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RdpExceptions.cs
+++ b/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RdpExceptions.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;
+using System.Text;
 
 namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
 {
@@ -211,28 +212,37 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
             this.DisconnectReason == 263 ||  // Dismissed server auth warning.
             this.DisconnectReason == 7943;   // Dismissed login prompt.
 
-        public override string Message
+        private static string CreateMessage(int disconnectReason, string description)
         {
-            get
+            var message = new StringBuilder();
+            if (!string.IsNullOrWhiteSpace(description))
             {
-
-                if (knownErrors.TryGetValue(this.DisconnectReason, out string message))
-                {
-                    return message;
-                }
-                else
-                {
-                    return $"Disconnected with unknown error code {this.DisconnectReason}";
-                }
+                message.Append(description);
+                message.Append("\n\n");
             }
+
+            if (knownErrors.TryGetValue(disconnectReason, out string reasonText))
+            {
+                message.Append(reasonText);
+            }
+
+
+            if (message.Length == 0)
+            {
+                message.Append("Disconnected with unknown error code");
+            }
+
+            message.Append($"\n\nError code: {disconnectReason}");
+
+            return message.ToString();
         }
 
         public RdpDisconnectedException(int disconnectReason, string description)
-            : base()
+            : base(CreateMessage(disconnectReason, description))
         {
-            // TODO: use description?
             this.DisconnectReason = disconnectReason;
         }
+
         protected RdpDisconnectedException(SerializationInfo info, StreamingContext context)
             : base(info, context)
         {

--- a/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.cs
+++ b/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.cs
@@ -275,8 +275,17 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
 
         private void RemoteDesktopPane_SizeChanged(object sender, EventArgs e)
         {
-            using (TraceSources.IapDesktop.TraceMethod().WithParameters(this.autoResize))
+            using (TraceSources.IapDesktop.TraceMethod().WithParameters(
+                this.autoResize, this.Size))
             {
+                if (this.Size.Width == 0 || this.Size.Height == 0)
+                {
+                    // Probably the window is being minimized. Ignore
+                    // that event since it merely causes stress on the
+                    // RDP control.
+                    return;
+                }
+
                 UpdateLayout();
 
                 if (this.autoResize)

--- a/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.cs
+++ b/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.cs
@@ -51,6 +51,9 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
         private bool autoResize = false;
         private bool connecting = false;
 
+        // Track the (client area) size of the remote connection.
+        private Size connectionSize;
+
         public VmInstanceReference Instance { get; }
 
         private void UpdateLayout()
@@ -262,7 +265,24 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
                 advancedSettings.allowBackgroundInput = 1;
 
                 this.connecting = true;
+                this.connectionSize = this.Size;
                 this.rdpClient.Connect();
+            }
+        }
+
+        private void ReconnectToResize(Size size)
+        {
+            using (TraceSources.IapDesktop.TraceMethod().WithParameters(this.connectionSize, size))
+            {
+                this.connecting = true;
+
+                // Only resize if the size really changed, otherwise we put unnecessary
+                // stress on the control (especially if events come in quick succession).
+                if (size != this.connectionSize)
+                {
+                    this.connectionSize = size;
+                    this.rdpClient.Reconnect((uint)size.Width, (uint)size.Height);
+                }
             }
         }
 
@@ -366,7 +386,7 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
                 else if (!this.IsConnecting)
                 {
                     // Reconnect to resize remote desktop.
-                    this.rdpClient.Reconnect((uint)this.Size.Width, (uint)this.Size.Height);
+                    ReconnectToResize(this.Size);
                 }
 
                 // Do not fire again.
@@ -381,8 +401,7 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
                 // Adjust desktop size to full screen.
                 var screenSize = Screen.GetBounds(this);
 
-                this.connecting = true;
-                this.rdpClient.Reconnect((uint)screenSize.Width, (uint)screenSize.Height);
+                ReconnectToResize(screenSize.Size);
             }
         }
 
@@ -391,9 +410,7 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
             if (!this.IsConnecting && this.autoResize)
             {
                 // Return to normal size.
-
-                this.connecting = true;
-                this.rdpClient.Reconnect((uint)this.Size.Width, (uint)this.Size.Height);
+                ReconnectToResize(this.Size);
             }
         }
 

--- a/Google.Solutions.IapDesktop/Program.cs
+++ b/Google.Solutions.IapDesktop/Program.cs
@@ -162,6 +162,11 @@ namespace Google.Solutions.IapDesktop
 
             IsLoggingEnabled = false;
 
+#if DEBUG
+            Google.Solutions.IapDesktop.Application.TraceSources.IapDesktop.Listeners.Add(new DefaultTraceListener());
+            Google.Solutions.IapDesktop.Application.TraceSources.IapDesktop.Switch.Level = SourceLevels.Verbose;
+#endif
+
             // Use TLS 1.2 if possible.
             System.Net.ServicePointManager.SecurityProtocol =
                 SecurityProtocolType.Tls12 |


### PR DESCRIPTION
Reduce unnecessary stress on RDP control:
* Avoid resizing the RDP control to (0, 0) when the window is minimized
* Ignore resizing the RDP control when the size has not really changed

Improve error message for disconnects
* Incorporate message provided from control (if any) into exception message.

This is to to address #111