### PR TITLE
Provide descriptive error message when http.sys is disabled.

### DIFF
--- a/Google.Solutions.Common/Auth/GoogleAuthAdapter.cs
+++ b/Google.Solutions.Common/Auth/GoogleAuthAdapter.cs
@@ -90,9 +90,20 @@ namespace Google.Solutions.Common.Auth
 
         public async Task<ICredential> AuthorizeUsingBrowserAsync(CancellationToken token)
         {
-            return await this.installedApp.AuthorizeAsync(
-                StoreUserId,
-                token).ConfigureAwait(false);
+            try
+            {
+                return await this.installedApp.AuthorizeAsync(
+                    StoreUserId,
+                    token);
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // Convert this into an exception with more actionable information.
+                throw new SystemException(
+                    "Authorization failed because the HTTP Server API is not enabled " +
+                    "on your computer. This API is required to complete the OAuth authorization flow.\n\n" +
+                    "To enable the API, open an elevated command prompt and run 'sc config http start= auto'.");
+            }
         }
 
         public bool IsRefreshTokenValid(TokenResponse tokenResponse)


### PR DESCRIPTION
* Include command to re-enable http.sys in message.
* Because re-enabling a driver requires admin privileges, the
  application cannot initiate this by itself.

This is to fix #96.
