### PR TITLE
Ignore redundant resize event

### DIFF
--- a/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.cs
+++ b/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.cs
@@ -298,13 +298,18 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
         private void RemoteDesktopPane_SizeChanged(object sender, EventArgs e)
         {
             using (TraceSources.IapDesktop.TraceMethod().WithParameters(
-                this.autoResize, this.Size))
+                this.autoResize, this.connectionSize, this.Size))
             {
                 if (this.Size.Width == 0 || this.Size.Height == 0)
                 {
                     // Probably the window is being minimized. Ignore
                     // that event since it merely causes stress on the
                     // RDP control.
+                    return;
+                }
+                else if (this.Size == this.connectionSize)
+                {
+                    // This event is redundant, ignore.
                     return;
                 }
 


### PR DESCRIPTION
This fixes an issue where the pane thought the control
was reconnecting, although it was not, which in turn
caused the Full Screen menu item to be disabled.