### PR TITLE
Hide "RequireServerAuthentication" option

### DIFF
--- a/Google.Solutions.IapDesktop.Application/Services/Persistence/ConnectionSettingsRepository.cs
+++ b/Google.Solutions.IapDesktop.Application/Services/Persistence/ConnectionSettingsRepository.cs
@@ -148,8 +148,14 @@ namespace Google.Solutions.IapDesktop.Application.Services.Persistence
 
     public enum RdpAuthenticationLevel
     {
+        // Likely to fail when using IAP unless the cert has been issued
+        // for "localhost".
         AttemptServerAuthentication = 0,
+
+        // Almsot guaranteed to fail, so do not even display it.
+        [Browsable(false)]
         RequireServerAuthentication = 1,
+
         NoServerAuthentication = 3,
 
         [Browsable(false)]


### PR DESCRIPTION
When using IAP, this authentication level is almost
guaranteed to not work, unless the server's certificate
has been issued for the CN "localhost". Therefore, hide
it in the UI.
