### PR TITLE
Adjust resolution without reconnecting

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.cs
@@ -281,14 +281,38 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
         {
             using (TraceSources.IapDesktop.TraceMethod().WithParameters(this.connectionSize, size))
             {
-                this.connecting = true;
-
                 // Only resize if the size really changed, otherwise we put unnecessary
                 // stress on the control (especially if events come in quick succession).
-                if (size != this.connectionSize)
+                if (size != this.connectionSize && !this.connecting)
                 {
+                    //
+                    // Try to adjust settings without reconnecting - this only works when
+                    // (1) The server is running 2012R2 or newer
+                    // (2) The logon process has completed.
+                    //
+                    try
+                    {
+                        this.rdpClient.UpdateSessionDisplaySettings(
+                            (uint)this.Width,
+                            (uint)this.Height,
+                            (uint)this.Width,
+                            (uint)this.Height,
+                            0,  // Landscape
+                            1,  // No desktop scaling
+                            1); // No device scaling
+                    }
+                    catch (COMException e) when ((uint)e.HResult == UnsafeNativeMethods.E_UNEXPECTED)
+                    {
+                        TraceSources.IapDesktop.TraceWarning("Adjusting desktop size (w/o) reconnect failed.");
+
+                        //
+                        // Revert to classic, reconnect-based resizing.
+                        //
+                        this.connecting = true;
+                        this.rdpClient.Reconnect((uint)size.Width, (uint)size.Height);
+                    }
+
                     this.connectionSize = size;
-                    this.rdpClient.Reconnect((uint)size.Width, (uint)size.Height);
                 }
             }
         }

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Windows/RemoteDesktop/RemoteDesktopPane.cs
@@ -285,31 +285,42 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows.RemoteDesktop
                 // stress on the control (especially if events come in quick succession).
                 if (size != this.connectionSize && !this.connecting)
                 {
-                    //
-                    // Try to adjust settings without reconnecting - this only works when
-                    // (1) The server is running 2012R2 or newer
-                    // (2) The logon process has completed.
-                    //
-                    try
+                    if (this.rdpClient.FullScreen)
                     {
-                        this.rdpClient.UpdateSessionDisplaySettings(
-                            (uint)this.Width,
-                            (uint)this.Height,
-                            (uint)this.Width,
-                            (uint)this.Height,
-                            0,  // Landscape
-                            1,  // No desktop scaling
-                            1); // No device scaling
-                    }
-                    catch (COMException e) when ((uint)e.HResult == UnsafeNativeMethods.E_UNEXPECTED)
-                    {
-                        TraceSources.IapDesktop.TraceWarning("Adjusting desktop size (w/o) reconnect failed.");
-
                         //
-                        // Revert to classic, reconnect-based resizing.
+                        // Full-screen requires a classic, reconnect-based resizing.
                         //
                         this.connecting = true;
                         this.rdpClient.Reconnect((uint)size.Width, (uint)size.Height);
+                    }
+                    else
+                    {
+                        //
+                        // Try to adjust settings without reconnecting - this only works when
+                        // (1) The server is running 2012R2 or newer
+                        // (2) The logon process has completed.
+                        //
+                        try
+                        {
+                            this.rdpClient.UpdateSessionDisplaySettings(
+                                (uint)this.Width,
+                                (uint)this.Height,
+                                (uint)this.Width,
+                                (uint)this.Height,
+                                0,  // Landscape
+                                1,  // No desktop scaling
+                                1); // No device scaling
+                        }
+                        catch (COMException e) when ((uint)e.HResult == UnsafeNativeMethods.E_UNEXPECTED)
+                        {
+                            TraceSources.IapDesktop.TraceWarning("Adjusting desktop size (w/o) reconnect failed.");
+
+                            //
+                            // Revert to classic, reconnect-based resizing.
+                            //
+                            this.connecting = true;
+                            this.rdpClient.Reconnect((uint)size.Width, (uint)size.Height);
+                        }
                     }
 
                     this.connectionSize = size;

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Windows/UnsafeNativeMethods.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Windows/UnsafeNativeMethods.cs
@@ -143,5 +143,7 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows
         public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
 
         public const int SW_RESTORE = 9;
+
+        public const uint E_UNEXPECTED = 0x8000ffff;
     }
 }


### PR DESCRIPTION
Use `IMsRdpClient9::UpdateSessionDisplaySettings` to dynamically adjust resolution whenever possible. Fall back to `Reconnect` when client or server do not support dynamic resolution changes.

This is to fix #115 and #202