### PR TITLE
Use consistend end date, avoid DateTime.Now

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity/History/InstanceSetHistoryBuilder.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity/History/InstanceSetHistoryBuilder.cs
@@ -141,7 +141,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.History
                         instance.Status == "RUNNING"
                             ? InstanceState.Running
                             : InstanceState.Terminated,
-                        DateTime.Now,
+                        this.EndDate,
                         instance.Scheduling.NodeAffinities != null && instance.Scheduling.NodeAffinities.Any()
                             ? Tenancies.SoleTenant
                             : Tenancies.Fleet);


### PR DESCRIPTION
This fixes an issue where currently running SPLA instances
were missed by the report because their synthetic placement
was not captured by the date selection filter.