### PR TITLE
Force UserVisibilityState event raise when window is shown

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Views/ProjectExplorer/ProjectExplorerTrackingToolWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/ProjectExplorer/ProjectExplorerTrackingToolWindow.cs
@@ -101,6 +101,10 @@ namespace Google.Solutions.IapDesktop.Application.Views.ProjectExplorer
                     // The window is currently not visible to the user, so
                     // do not bother updating it immediately. 
                     this.ignoredNode = node;
+
+                    TraceSources.IapDesktop.TraceVerbose(
+                        "Ignoring switch to {0} because window is not visible", node);
+                    
                     return;
                 }
                 else

--- a/sources/Google.Solutions.IapDesktop.Application/Views/ToolWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/ToolWindow.cs
@@ -46,7 +46,6 @@ namespace Google.Solutions.IapDesktop.Application.Views
             this.CloseSafely();
         }
 
-
         private void ToolWindow_KeyUp(object sender, KeyEventArgs e)
         {
             if (e.Shift && e.KeyCode == Keys.Escape)
@@ -91,6 +90,15 @@ namespace Google.Solutions.IapDesktop.Application.Views
 
             // Move focus to window.
             Activate();
+
+            //
+            // If an auto-hide window loses focus and closes, we fail to 
+            // catch that event. 
+            // To force an update, disregard the cached state and re-raise
+            // the UserVisibilityChanged event.
+            //
+            OnUserVisibilityChanged(true);
+            this.wasUserVisible = true;
         }
 
         protected bool IsAutoHide
@@ -178,7 +186,6 @@ namespace Google.Solutions.IapDesktop.Application.Views
                 this.wasUserVisible = this.IsUserVisible;
             }
         }
-
 
         protected override void OnEnter(EventArgs e)
         {


### PR DESCRIPTION
This fixes an issue where an auto-hide tool window closes
and later does not update properly once it becomes visible
again.