### PR TITLE
b/170453002: Ignore audit events that lack a methodName

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity/Services/Adapters/AuditLogStorageSinkAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity/Services/Adapters/AuditLogStorageSinkAdapter.cs
@@ -283,7 +283,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Services.Adapters
                         // The file might contain empty lines.
                         if (!string.IsNullOrWhiteSpace(line))
                         {
-                            events.Add(EventFactory.FromRecord(LogRecord.Deserialize(line)));
+                            var record = LogRecord.Deserialize(line);
+                            if (record.IsValidAuditLogRecord)
+                            {
+                                events.Add(EventFactory.FromRecord(record));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This is a workaround for b/170388158.