### PR TITLE
#27: Ignore backslashes in user reset-response

### DIFF
--- a/sources/Google.Solutions.Common/ApiExtensions/Instance/ResetWindowsUser.cs
+++ b/sources/Google.Solutions.Common/ApiExtensions/Instance/ResetWindowsUser.cs
@@ -162,8 +162,13 @@ namespace Google.Solutions.Common.ApiExtensions.Instance
 
                         logBuffer.Append(logDelta);
 
-                        var response = logBuffer.ToString().Split('\n')
-                            .Where(line => line.Contains(requestPayload.Modulus))
+                        // NB. Old versions of the Windows guest agent wrongly added a '\'
+                        // before every '/' in base64-encoded data. This affects the search
+                        // for the modulus.
+                        var response = logBuffer.ToString()
+                            .Split('\n')
+                            .Where(line => line.Contains(requestPayload.Modulus) || 
+                                           line.Replace("\\/", "/").Contains(requestPayload.Modulus))
                             .FirstOrDefault();
                         if (response == null)
                         {


### PR DESCRIPTION
Old versions of the OS agent wrongly escaped slashes with backslashes,
probably as a result of a bug. The backslashes caused the modulo search to
fail, resulting in a timeout.

This is to fix #27.