### PR TITLE
b/171293988 Fix handling of suspend/resume events in reporting

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity/Events/Lifecycle/ResumeInstanceEvent.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity/Events/Lifecycle/ResumeInstanceEvent.cs
@@ -51,9 +51,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Events.Lifecycle
         // IInstanceStateChangeEvent.
         //---------------------------------------------------------------------
 
-        public bool IsStartingInstance => false;
+        public bool IsStartingInstance => !IsError;
 
-        public bool IsTerminatingInstance => !IsError;
+        public bool IsTerminatingInstance => false;
 
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity/Events/Lifecycle/SuspendInstanceEvent.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity/Events/Lifecycle/SuspendInstanceEvent.cs
@@ -51,9 +51,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Events.Lifecycle
         // IInstanceStateChangeEvent.
         //---------------------------------------------------------------------
 
-        public bool IsStartingInstance => !IsError;
+        public bool IsStartingInstance => false;
 
-        public bool IsTerminatingInstance => false;
+        public bool IsTerminatingInstance => !IsError;
 
     }
 }


### PR DESCRIPTION
Semantics of suspend and resume events was mixed up, leading to suspensions being ignored in instance history