### PR TITLE
Set context on initialization

### DIFF
--- a/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
+++ b/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
@@ -331,7 +331,10 @@ namespace Google.Solutions.IapDesktop.Windows
                 this,
                 menu.DropDownItems,
                 ToolStripItemDisplayStyle.Text,
-                this.serviceProvider);
+                this.serviceProvider)
+            {
+                Context = this // There is no real context for this.
+            };
 
             menu.DropDownOpening += (sender, args) =>
             {


### PR DESCRIPTION
This fixes a null reference exception when a command is
invoked via a shortcut (as opposed to opening the menu).

This is to fix #311.