### PR TITLE
b/174133695 Update window title when selection changes

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Views/Properties/PropertiesInspectorWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/Properties/PropertiesInspectorWindow.cs
@@ -69,6 +69,8 @@ namespace Google.Solutions.IapDesktop.Application.Views.Properties
                 m => m.WindowTitle,
                 title =>
                 {
+                    // NB. Update properties separately instead of using multi-assignment,
+                    // otherwise the title does not update properly.
                     this.TabText = title;
                     this.Text = title;
                 }));

--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity/Views/EventLog/EventLogWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity/Views/EventLog/EventLogWindow.cs
@@ -53,7 +53,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Views.EventLog
 
             this.components.Add(this.viewModel.OnPropertyChange(
                 m => m.WindowTitle,
-                title => this.TabText = this.Text = title));
+                title =>
+                {
+                    // NB. Update properties separately instead of using multi-assignment,
+                    // otherwise the title does not update properly.
+                    this.TabText = title;
+                    this.Text = title;
+                }));
 
             // Bind toolbar buttons.
             this.timeFrameComboBox.BindProperty(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity/Views/SerialOutput/SerialOutputWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity/Views/SerialOutput/SerialOutputWindow.cs
@@ -49,7 +49,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Views.SerialOutput
 
             this.components.Add(this.viewModel.OnPropertyChange(
                 m => m.WindowTitle,
-                title => this.TabText = this.Text = title));
+                title =>
+                {
+                    // NB. Update properties separately instead of using multi-assignment,
+                    // otherwise the title does not update properly.
+                    this.TabText = title;
+                    this.Text = title;
+                }));
             this.components.Add(this.viewModel.OnPropertyChange(
                 m => m.Output,
                 text =>

--- a/sources/Google.Solutions.IapDesktop.Extensions.Os/Views/PackageInventory/PackageInventoryWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Os/Views/PackageInventory/PackageInventoryWindow.cs
@@ -65,7 +65,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Views.PackageInventory
 
             this.components.Add(this.viewModel.OnPropertyChange(
                 m => m.WindowTitle,
-                title => this.TabText = this.Text = title));
+                title =>
+                {
+                    // NB. Update properties separately instead of using multi-assignment,
+                    // otherwise the title does not update properly.
+                    this.TabText = title;
+                    this.Text = title;
+                }));
 
             // Bind list.
             this.packageList.BindProperty(


### PR DESCRIPTION
This fixes an issue where the window title was briefly
updated to show the VM name and then switched back to
showing a generic window title.