### PR TITLE
Force local login when using generated credentials

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Rdp/Views/Credentials/CredentialsService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Rdp/Views/Credentials/CredentialsService.cs
@@ -109,7 +109,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Rdp.Views.Credentials
             // Save credentials.
             settings.Username.StringValue = credentials.UserName;
             settings.Password.ClearTextValue = credentials.Password;
-            settings.Domain.StringValue = null;
+
+            // NB. The computer might be joined to a domain, therefore force a local logon.
+            settings.Domain.StringValue = ".";
         }
 
         public Task<bool> IsGrantedPermissionToGenerateCredentials(InstanceLocator instance)


### PR DESCRIPTION
When the VM is domain-joined, the "." ensures that the logon
is attempted using the local user instead of a domain user.