### PR TITLE
b/177117188 Fail open if permission check fails

### DIFF
--- a/sources/Google.Solutions.Common/Util/ExceptionExtensions.cs
+++ b/sources/Google.Solutions.Common/Util/ExceptionExtensions.cs
@@ -69,6 +69,11 @@ namespace Google.Solutions.Common.Util
             }
         }
 
+        public static bool IsAccessDeniedError(this Exception e)
+        {
+            return e.Unwrap() is GoogleApiException apiEx && apiEx.Error.Code == 403;
+        }
+
         public static string FullMessage(this Exception exception)
         {
             var fullMessage = new StringBuilder();

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestComputeEngineAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestComputeEngineAdapter.cs
@@ -399,5 +399,20 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
 
             Assert.IsFalse(result);
         }
+
+        [Test]
+        public async Task WhenUserLacksInstanceListPermission_ThenIsGrantedPermissionFailsOpenAndReturnsTrue(
+            [LinuxInstance] ResourceTask<InstanceLocator> testInstance,
+            [Credential(Role = PredefinedRole.IapTunnelUser)] ResourceTask<ICredential> credential)
+        {
+            var locator = await testInstance;
+            var adapter = new ComputeEngineAdapter(await credential);
+
+            var result = await adapter.IsGrantedPermission(
+                locator,
+                Permissions.ComputeInstancesSetMetadata);
+
+            Assert.IsTrue(result);
+        }
     }
 }


### PR DESCRIPTION
Testing permissions requires the 'compute.instances.list'
permission. If the user does not hold this permission, fail
open.

This fixes an issue where connecting to an instance by URL
failed if the user only had the 'iap.tunnelInstances.accessViaIAP'
perission (#365).