### PR TITLE
Fix UI hang when connection handshake hangs

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshTerminalPane.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshTerminalPane.cs
@@ -110,6 +110,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
                 View = this
             };
 
+            Debug.Assert(this.viewModel.View != null);
+
             this.DockAreas = DockAreas.Document;
 
             this.reconnectPanel.BindReadonlyProperty(
@@ -141,6 +143,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
 
             this.Disposed += (sender, args) =>
             {
+                this.viewModel.ConnectionFailed -= OnErrorReceivedFromServerAsync;
+                this.viewModel.DataReceived -= OnDataReceivedFromServerAsync;
                 this.viewModel.Dispose();
             };
             this.FormClosed += OnFormClosed;
@@ -269,7 +273,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
             ConnectionErrorEventArgs args)
         {
             Debug.Assert(!this.InvokeRequired);
-
             ShowErrorAndClose("SSH connection terminated", args.Error);
         }
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshTerminalPaneViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshTerminalPaneViewModel.cs
@@ -104,15 +104,23 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
             get => this.connectionStatus;
             private set
             {
-                Debug.Assert(this.ViewInvoker != null);
-                Debug.Assert(!this.ViewInvoker.InvokeRequired, "Accessed from UI thread");
-
                 this.connectionStatus = value;
 
-                RaisePropertyChange();
-                RaisePropertyChange((SshTerminalPaneViewModel m) => m.IsSpinnerVisible);
-                RaisePropertyChange((SshTerminalPaneViewModel m) => m.IsTerminalVisible);
-                RaisePropertyChange((SshTerminalPaneViewModel m) => m.IsReconnectPanelVisible);
+                Debug.Assert(this.ViewInvoker != null);
+                if (this.ViewInvoker != null)
+                {
+                    //
+                    // It's (unlikely but( possible that the View has already been torn down.
+                    // In that case, do not deliver events since they are likely to
+                    // cause trouble and touch disposed objects.
+                    //
+                    Debug.Assert(!this.ViewInvoker.InvokeRequired, "Accessed from UI thread");
+
+                    RaisePropertyChange();
+                    RaisePropertyChange((SshTerminalPaneViewModel m) => m.IsSpinnerVisible);
+                    RaisePropertyChange((SshTerminalPaneViewModel m) => m.IsTerminalVisible);
+                    RaisePropertyChange((SshTerminalPaneViewModel m) => m.IsReconnectPanelVisible);
+                }
             }
         }
 
@@ -148,6 +156,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
 
         public async Task ConnectAsync(TerminalSize initialSize)
         {
+            Debug.Assert(this.View != null);
+            Debug.Assert(this.ViewInvoker != null);
+
             void OnErrorReceivedFromServerAsync(Exception exception)
             {
                 // NB. Callback runs on SSH thread, not on UI thread.

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshTerminalPaneViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshTerminalPaneViewModel.cs
@@ -239,7 +239,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
                         OnDataReceivedFromServerAsync,
                         OnErrorReceivedFromServerAsync)
                     {
-                        Banner = SshSession.BannerPrefix + Globals.UserAgent
+                        Banner = SshSession.BannerPrefix + Globals.UserAgent,
+
+                        //
+                        // NB. Do not join worker thread as this could block the
+                        // UI thread.
+                        //
+                        JoinWorkerThreadOnDispose = false
                     };
 
                     await ConnectAndTranslateErrorsAsync().ConfigureAwait(true);

--- a/sources/Google.Solutions.Ssh.Test/Google.Solutions.Ssh.Test.csproj
+++ b/sources/Google.Solutions.Ssh.Test/Google.Solutions.Ssh.Test.csproj
@@ -113,9 +113,9 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\libssh2.1.9.0.10\build\libssh2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libssh2.1.9.0.10\build\libssh2.targets'))" />
     <Error Condition="!Exists('..\packages\NUnit.3.13.1\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.1\build\NUnit.props'))" />
     <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.17.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\libssh2.1.9.0.10\build\libssh2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libssh2.1.9.0.10\build\libssh2.targets'))" />
   </Target>
   <Import Project="..\packages\libssh2.1.9.0.10\build\libssh2.targets" Condition="Exists('..\packages\libssh2.1.9.0.10\build\libssh2.targets')" />
 </Project>

--- a/sources/Google.Solutions.Ssh/Google.Solutions.Ssh.csproj
+++ b/sources/Google.Solutions.Ssh/Google.Solutions.Ssh.csproj
@@ -86,7 +86,6 @@
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\packages\libssh2.1.9.0\build\libssh2.targets" Condition="Exists('..\packages\libssh2.1.9.0\build\libssh2.targets')" />
   <Import Project="..\packages\libssh2.1.9.0.10\build\libssh2.targets" Condition="Exists('..\packages\libssh2.1.9.0.10\build\libssh2.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/sources/Google.Solutions.Ssh/SshWorkerThread.cs
+++ b/sources/Google.Solutions.Ssh/SshWorkerThread.cs
@@ -58,6 +58,8 @@ namespace Google.Solutions.Ssh
         /// </summary>
         public TimeSpan BlockingTimeout { get; set; } = TimeSpan.FromSeconds(15);
 
+        public bool JoinWorkerThreadOnDispose { get; set; } = true;
+
         public string Banner { get; set; }
 
         //---------------------------------------------------------------------
@@ -408,10 +410,10 @@ namespace Google.Solutions.Ssh
             // Stop worker thread.
             this.workerCancellationSource.Cancel();
             
-            //
-            // NB. Do not join the thread as this could block the current
-            // thread (which is likely the UI thread.
-            //
+            if (this.JoinWorkerThreadOnDispose)
+            {
+                this.workerThread.Join();
+            }
 
             if (!this.disposed && disposing)
             {

--- a/sources/Google.Solutions.Ssh/SshWorkerThread.cs
+++ b/sources/Google.Solutions.Ssh/SshWorkerThread.cs
@@ -53,6 +53,11 @@ namespace Google.Solutions.Ssh
 
         public TimeSpan SocketWaitInterval { get; set; } = TimeSpan.FromSeconds(2);
 
+        /// <summary>
+        /// Timeout for blocking operations (used during connection phase).
+        /// </summary>
+        public TimeSpan BlockingTimeout { get; set; } = TimeSpan.FromSeconds(15);
+
         public string Banner { get; set; }
 
         //---------------------------------------------------------------------
@@ -198,6 +203,8 @@ namespace Google.Solutions.Ssh
                         {
                             session.SetLocalBanner(this.Banner);
                         }
+
+                        session.Timeout = this.BlockingTimeout;
 
                         //
                         // Open connection and perform handshake using blocking I/O.
@@ -400,7 +407,11 @@ namespace Google.Solutions.Ssh
         {
             // Stop worker thread.
             this.workerCancellationSource.Cancel();
-            this.workerThread.Join();
+            
+            //
+            // NB. Do not join the thread as this could block the current
+            // thread (which is likely the UI thread.
+            //
 
             if (!this.disposed && disposing)
             {


### PR DESCRIPTION
Instead of blocking the UI until the SSH worker
thread is done, tear down UI and stop passing
events to the (disposed) UI.