### PR TITLE
Add patch to fix OSC sequences with empty text parameters

### DIFF
--- a/dependencies/makefile
+++ b/dependencies/makefile
@@ -21,7 +21,7 @@
 CONFIGURATION = Release
 
 # The tag should be increased whenever one of the dependencies is changed
-TAG = 10
+TAG = 11
 
 VTNETCORE_SHA = 9e68f5561dc52edb780615b3fe133289216b3dba
 VTNETCORE_URL = https://github.com/darrenstarr/VtNetCore.git
@@ -60,13 +60,19 @@ $(MAKEDIR)\obj\vtnetcore\VtNetCore\VtNetCore.csproj:
 
 	git clone $(VTNETCORE_URL) $(MAKEDIR)\obj\vtnetcore
 
+	cd $(MAKEDIR)\obj\vtnetcore
+
+	git checkout $(VTNETCORE_SHA)
+	git am $(MAKEDIR)\vtnetcore-patches\0001-Handle-OSC-sequences-with-empty-text-parameters.patch
+
+	cd $(MAKEDIR)
+
 $(MAKEDIR)\obj\vtnetcore\VtNetCore\bin\$(CONFIGURATION)\vtnetcore.$(VTNETCORE_VERSION).nupkg: \
 		$(MAKEDIR)\obj\vtnetcore\VtNetCore\VtNetCore.csproj
 	@echo "========================================================"
 	@echo "=== Building vtnetcore                               ==="
 	@echo "========================================================"
 	cd $(MAKEDIR)\obj\vtnetcore
-	git checkout $(VTNETCORE_SHA)
 
 	nuget restore
 	msbuild \

--- a/dependencies/vtnetcore-patches/0001-Handle-OSC-sequences-with-empty-text-parameters.patch
+++ b/dependencies/vtnetcore-patches/0001-Handle-OSC-sequences-with-empty-text-parameters.patch
@@ -1,0 +1,47 @@
+From d20637fc143d6bdb364fc1cd6ea4cbe76b42d51a Mon Sep 17 00:00:00 2001
+From: Johannes Passing <jpassing@hotmail.com>
+Date: Thu, 4 Mar 2021 16:06:31 +0100
+Subject: [PATCH] Handle OSC sequences with empty text parameters
+
+Previously, the parser only handled sequences with non-empty text
+parameters and failed to handle sequences like `\e]2;\a` or `\e]0;\a`.
+
+This caused some programs to hang because they did not receive
+the expected feedback.
+---
+ VtNetCore.Unit.Tests/libvtermStateTerminalProperties.cs | 6 ++++++
+ VtNetCore/XTermParser/XTermSequenceReader.cs            | 1 +
+ 2 files changed, 7 insertions(+)
+
+diff --git a/VtNetCore.Unit.Tests/libvtermStateTerminalProperties.cs b/VtNetCore.Unit.Tests/libvtermStateTerminalProperties.cs
+index 22f9ef3..67829bb 100644
+--- a/VtNetCore.Unit.Tests/libvtermStateTerminalProperties.cs
++++ b/VtNetCore.Unit.Tests/libvtermStateTerminalProperties.cs
+@@ -125,6 +125,12 @@
+                 windowTitle = args.Text;
+             };
+ 
++            // !Title
++            // PUSH "\e]2;\a"
++            //   settermprop 4 ""
++            Push(d, "".ChangeWindowTitle(""));
++            Assert.Equal("", windowTitle);
++
+             // !Title
+             // PUSH "\e]2;Here is my title\a"
+             //   settermprop 4 "Here is my title"
+diff --git a/VtNetCore/XTermParser/XTermSequenceReader.cs b/VtNetCore/XTermParser/XTermSequenceReader.cs
+index 1df90e6..1e55f21 100644
+--- a/VtNetCore/XTermParser/XTermSequenceReader.cs
++++ b/VtNetCore/XTermParser/XTermSequenceReader.cs
+@@ -169,6 +169,7 @@
+ 
+                         Parameters.Add(currentParameter);
+                         currentParameter = -1;
++                        readingCommand = true;
+                     }
+                     else if (char.IsDigit(next))
+                     {
+-- 
+2.17.1.windows.2
+


### PR DESCRIPTION
- Extend makefile to apply patch pre-build
- Increment tag