### PR TITLE
Run test assemblies in parallel

### DIFF
--- a/sources/makefile
+++ b/sources/makefile
@@ -224,7 +224,7 @@ test: $(NUNIT_ASSEMBLIES)
 		-register:user \
 		-returntargetcode \
 		-target:nunit3-console.exe \
-		"-targetargs:$(NUNIT_ASSEMBLIES) --result=sponge_log.xml;transform=kokoro\nunit-to-sponge.xsl --agents=1" \
+		"-targetargs:$(NUNIT_ASSEMBLIES) --result=sponge_log.xml;transform=kokoro\nunit-to-sponge.xsl" \
 		-filter:"$(NUNIT_COVERAGE_FILTER)" \
 		"-excludebyattribute:*.SkipCodeCoverage*;*CompilerGenerated*" \
 		-output:opencovertests.xml


### PR DESCRIPTION
* Let NUnit use multiple agents (one per assembly)
* Embed assembly name in instance hash so that concurrently
  running assemblies use different instances