### PR TITLE
Do not free channel if session has been freed already

### DIFF
--- a/sources/Google.Solutions.Ssh/Native/SshAuthenticatedSession.cs
+++ b/sources/Google.Solutions.Ssh/Native/SshAuthenticatedSession.cs
@@ -86,6 +86,8 @@ namespace Google.Solutions.Ssh.Native
                     throw this.session.CreateException(result);
                 }
 
+                channelHandle.SessionHandle = this.session.Handle;
+
                 //
                 // Configure how extended data (stderr, in particular) should
                 // be handled.


### PR DESCRIPTION
During finalization, it's possible that a channel handle is freed
after the associated session has been freed already. Detect
this situation and prevent the free'ing of the channel handle
as it would cause an access violation.