### PR TITLE
Download MSI, even if it's not the first asset

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Services/UpdateService.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/UpdateService.cs
@@ -100,7 +100,10 @@ namespace Google.Solutions.IapDesktop.Application.Services
                     {
                         if (selectedOption == 0 && latestRelease.Assets.Any())
                         {
-                            launchBrowser.StartInfo.FileName = latestRelease.Assets.First().DownloadUrl;
+                            launchBrowser.StartInfo.FileName = latestRelease
+                                .Assets
+                                .First(u => u.DownloadUrl.EndsWith(".msi", StringComparison.OrdinalIgnoreCase))
+                                .DownloadUrl;
                         }
                         else
                         {


### PR DESCRIPTION
Ensure that we always download the MSI file, even if there is another
package that's listed first (the API seems to be listing alphabetically).