### PR TITLE
Use ceiling when calculating caret position

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminal.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminal.cs
@@ -363,8 +363,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
                 graphics, 
                 caretPosition.Column);
 
-            var drawX = (int)(precedingTextDimensions.Width);
-            var drawY = (int)(caretY * precedingTextDimensions.Height);
+            var drawX = (int)Math.Ceiling(precedingTextDimensions.Width);
+            var drawY = (int)Math.Ceiling(caretY * precedingTextDimensions.Height);
 
             GetCaret(graphics).Position = new Point(drawX, drawY);
         }


### PR DESCRIPTION
This fixes an issue where the caret was off by one pixel
and did not properly align with a text selection.