### PR TITLE
b/184619387 Ignore Shift+Esc shortcut in documentate

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Views/ToolWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/ToolWindow.cs
@@ -215,7 +215,7 @@ namespace Google.Solutions.IapDesktop.Application.Views
 
         private void ToolWindow_KeyUp(object sender, KeyEventArgs e)
         {
-            if (e.Shift && e.KeyCode == Keys.Escape)
+            if (this.DockState != DockState.Document && e.Shift && e.KeyCode == Keys.Escape)
             {
                 CloseSafely();
             }


### PR DESCRIPTION
Only consider Shift+Esc as shortcut if window
is floating or docked. This fixes an issue where
Shift+Esc closes a terminal window even if it was
supposed to be a keytroke to be sent to the server.