### PR TITLE
Use ImageAndText display style for Desktop menu

### DIFF
--- a/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
+++ b/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
@@ -373,7 +373,7 @@ namespace Google.Solutions.IapDesktop.Windows
             var commandContainer = new CommandContainer<IMainForm>(
                 this,
                 menu.DropDownItems,
-                ToolStripItemDisplayStyle.Text,
+                ToolStripItemDisplayStyle.ImageAndText,
                 this.serviceProvider)
             {
                 Context = this // There is no real context for this.


### PR DESCRIPTION
This fixes an issue where icons were missing for
certain commands in the Desktop menu.