### PR TITLE
b/185888130 Set window title before loading model

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Os/Views/PackageInventory/PackageInventoryViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Os/Views/PackageInventory/PackageInventoryViewModel.cs
@@ -51,6 +51,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Views.PackageInventory
         private string windowTitle = "";
         private bool isInformationBarVisible = true;
 
+        private string WindowTitlePrefix =>
+                this.inventoryType == PackageInventoryType.AvailablePackages
+                    ? "Available updates"
+                    : "Installed packages";
+
         public string InformationText => "OS inventory data not available";
 
         public PackageInventoryViewModel(
@@ -197,6 +202,12 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Views.PackageInventory
                 {
                     this.IsLoading = true;
 
+                    //
+                    // Reset window title, otherwise the default or previous title
+                    // stays while data is loading.
+                    //
+                    this.WindowTitle = this.WindowTitlePrefix;
+
                     var jobService = this.serviceProvider.GetService<IJobService>();
 
                     // Load data using a job so that the task is retried in case
@@ -230,23 +241,18 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Views.PackageInventory
             this.AllPackages.Clear();
             this.FilteredPackages.Clear();
 
-            var windowTitlePrefix =
-                this.inventoryType == PackageInventoryType.AvailablePackages
-                    ? "Available updates"
-                    : "Installed packages";
-
             if (this.Model == null)
             {
                 // Unsupported node.
                 this.IsPackageListEnabled = false;
                 this.IsInformationBarVisible = false;
-                this.WindowTitle = windowTitlePrefix;
+                this.WindowTitle = this.WindowTitlePrefix;
             }
             else
             {
                 this.IsPackageListEnabled = true;
                 this.IsInformationBarVisible = !this.Model.IsInventoryDataAvailable;
-                this.WindowTitle = windowTitlePrefix + $": {this.Model.DisplayName}";
+                this.WindowTitle = this.WindowTitlePrefix + $": {this.Model.DisplayName}";
                 this.AllPackages.AddRange(this.Model.Packages);
             }
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Os/Views/PackageInventory/PackageInventoryViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Os/Views/PackageInventory/PackageInventoryViewModel.cs
@@ -48,7 +48,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Views.PackageInventory
         private string filter;
         private bool isLoading;
         private bool isPackageListEnabled = false;
-        private string windowTitle = "";
+        private string windowTitle;
         private bool isInformationBarVisible = true;
 
         private string WindowTitlePrefix =>
@@ -65,6 +65,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Views.PackageInventory
         {
             this.serviceProvider = serviceProvider;
             this.inventoryType = inventoryType;
+        }
+
+        public void ResetWindowTitle()
+        {
+            this.WindowTitle = WindowTitlePrefix;
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Extensions.Os/Views/PackageInventory/PackageInventoryWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Os/Views/PackageInventory/PackageInventoryWindow.cs
@@ -50,7 +50,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Views.PackageInventory
                 serviceProvider,
                 inventoryType);
 
-
             this.infoLabel.BindProperty(
                 c => c.Text,
                 this.viewModel,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Os/Views/PackageInventory/PackageInventoryWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Os/Views/PackageInventory/PackageInventoryWindow.cs
@@ -72,6 +72,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Views.PackageInventory
                     this.TabText = title;
                     this.Text = title;
                 }));
+            this.viewModel.ResetWindowTitle();  // Fire event to set initial window title.
 
             // Bind list.
             this.packageList.BindProperty(
@@ -92,7 +93,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Views.PackageInventory
                 this.viewModel,
                 m => m.IsLoading,
                 this.components);
-
 
             var openUrl = new ToolStripMenuItem(
                 "&Additional information...",


### PR DESCRIPTION
This fixes an issue where the window shows the default "PackageInventoryWindow"
title when the initial load is slow.