### PR TITLE
Do not attempt to load instance data when enclosing project not loaded

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/ProjectModel/TestProjectModelService.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/ProjectModel/TestProjectModelService.cs
@@ -582,6 +582,42 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.ProjectModel
             Assert.IsNotNull(instance);
         }
 
+        [Test]
+        public async Task WhenProjectNotAddedButZoneLocatorValid_ThenGetNodeAsyncReturnsNull()
+        {
+            var serviceRegistry = new ServiceRegistry();
+            serviceRegistry.AddMock<IEventService>();
+            serviceRegistry.AddSingleton(CreateProjectRepositoryMock().Object);
+            serviceRegistry.AddSingleton(CreateComputeEngineAdapterMock(
+                SampleProjectId,
+                SampleWindowsInstanceInZone1).Object);
+            serviceRegistry.AddSingleton(CreateResourceManagerAdapterMock().Object);
+
+            var modelService = new ProjectModelService(serviceRegistry);
+
+            Assert.IsNull(await modelService.GetNodeAsync(
+                new ZoneLocator(SampleProjectId, "zone-1"),
+                CancellationToken.None));
+        }
+
+        [Test]
+        public async Task WhenProjectNotAddedButInstanceLocatorValid_ThenGetNodeAsyncReturnsNull()
+        {
+            var serviceRegistry = new ServiceRegistry();
+            serviceRegistry.AddMock<IEventService>();
+            serviceRegistry.AddSingleton(CreateProjectRepositoryMock().Object);
+            serviceRegistry.AddSingleton(CreateComputeEngineAdapterMock(
+                SampleProjectId,
+                SampleWindowsInstanceInZone1).Object);
+            serviceRegistry.AddSingleton(CreateResourceManagerAdapterMock().Object);
+
+            var modelService = new ProjectModelService(serviceRegistry);
+
+            Assert.IsNull(await modelService.GetNodeAsync(
+                new InstanceLocator(SampleProjectId, "zone-1", SampleWindowsInstanceInZone1.Name),
+                CancellationToken.None));
+        }
+
         //---------------------------------------------------------------------
         // GetActiveNodeAsync.
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Application/Services/ProjectModel/ProjectModelService.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/ProjectModel/ProjectModelService.cs
@@ -356,6 +356,15 @@ namespace Google.Solutions.IapDesktop.Application.Services.ProjectModel
                 }
                 else if (locator is ZoneLocator zoneLocator)
                 {
+                    var project = await GetNodeAsync(
+                            new ProjectLocator(zoneLocator.ProjectId), token)
+                        .ConfigureAwait(false);
+                    if (project == null)
+                    {
+                        // Don't load a zone if the parent project has not been added.
+                        return null;
+                    }
+
                     var zones = await GetZoneNodesAsync(
                             new ProjectLocator(zoneLocator.ProjectId),
                             false,
@@ -365,6 +374,15 @@ namespace Google.Solutions.IapDesktop.Application.Services.ProjectModel
                 }
                 else if (locator is InstanceLocator instanceLocator)
                 {
+                    var project = await GetNodeAsync(
+                            new ProjectLocator(instanceLocator.ProjectId), token)
+                        .ConfigureAwait(false);
+                    if (project == null)
+                    {
+                        // Don't load a instance if the parent project has not been added.
+                        return null;
+                    }
+
                     var zones = await GetZoneNodesAsync(
                             new ProjectLocator(instanceLocator.ProjectId),
                             false,


### PR DESCRIPTION
This fixes an issue where connecting to an instance by URL
failed when the enclosing project had not previously been
loaded.