### PR TITLE
Add newlines to 2SV description text

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshAuthenticationPromptViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshAuthenticationPromptViewModel.cs
@@ -48,7 +48,16 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
                 () => viewModel.Description = "test",
                 v => v.Description);
         }
-        
+
+        [Test]
+        public void WhenDescriptionSetToMultipleSentences_ThenLineBreaksAreAdded()
+        {
+            var viewModel = new SshAuthenticationPromptViewModel();
+            viewModel.Description = "first. second. third.";
+
+            Assert.AreEqual("first.\nsecond.\nthird.", viewModel.Description);
+        }
+
         [Test]
         public void WhenInputSet_ThenNotificationIsRaised()
         {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshAuthenticationPromptViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshAuthenticationPromptViewModel.cs
@@ -51,7 +51,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
 
         public string Description
         {
-            get => this.description;
+            // Insert line breaks so that the lines don't get overly long.
+            get => this.description.Replace(". ", ".\n");
             set
             {
                 this.description = value;


### PR DESCRIPTION
This is to prevent the description text from extending
beyond window bounds.