### PR TITLE
Force focus back to RDP control when activated by mouse

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
+++ b/sources/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
@@ -189,6 +189,12 @@
     <Compile Include="Views\Diagnostics\DebugFullScreenPane.Designer.cs">
       <DependentUpon>DebugFullScreenPane.cs</DependentUpon>
     </Compile>
+    <Compile Include="Views\Diagnostics\DebugFocusWindow.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Views\Diagnostics\DebugFocusWindow.Designer.cs">
+      <DependentUpon>DebugFocusWindow.cs</DependentUpon>
+    </Compile>
     <Compile Include="Views\Dialog\ConfirmationDialog.cs" />
     <Compile Include="Views\Diagnostics\DebugDockingWindow.cs">
       <SubType>Form</SubType>
@@ -364,6 +370,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Views\Diagnostics\DebugDockingWindow.resx">
       <DependentUpon>DebugDockingWindow.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Views\Diagnostics\DebugFocusWindow.resx">
+      <DependentUpon>DebugFocusWindow.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Views\Diagnostics\DebugFullScreenPane.resx">
       <DependentUpon>DebugFullScreenPane.cs</DependentUpon>

--- a/sources/Google.Solutions.IapDesktop.Application/Views/Diagnostics/DebugFocusWindow.Designer.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/Diagnostics/DebugFocusWindow.Designer.cs
@@ -1,0 +1,129 @@
+﻿//
+// Copyright 2020 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+namespace Google.Solutions.IapDesktop.Application.Views.Diagnostics
+{
+    partial class DebugFocusWindow
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.components = new System.ComponentModel.Container();
+            this.timer = new System.Windows.Forms.Timer(this.components);
+            this.focusLabel = new System.Windows.Forms.Label();
+            this.focusNameTextBox = new System.Windows.Forms.TextBox();
+            this.focusHandleTextBox = new System.Windows.Forms.TextBox();
+            this.focusTypeTextBox = new System.Windows.Forms.TextBox();
+            this.SuspendLayout();
+            // 
+            // timer
+            // 
+            this.timer.Enabled = true;
+            this.timer.Interval = 500;
+            this.timer.Tick += new System.EventHandler(this.timer_Tick);
+            // 
+            // focusLabel
+            // 
+            this.focusLabel.AutoSize = true;
+            this.focusLabel.Location = new System.Drawing.Point(12, 18);
+            this.focusLabel.Name = "focusLabel";
+            this.focusLabel.Size = new System.Drawing.Size(74, 13);
+            this.focusLabel.TabIndex = 0;
+            this.focusLabel.Text = "Focus control:";
+            // 
+            // focusNameTextBox
+            // 
+            this.focusNameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.focusNameTextBox.Location = new System.Drawing.Point(92, 14);
+            this.focusNameTextBox.Name = "focusNameTextBox";
+            this.focusNameTextBox.ReadOnly = true;
+            this.focusNameTextBox.Size = new System.Drawing.Size(211, 20);
+            this.focusNameTextBox.TabIndex = 1;
+            // 
+            // focusHandleTextBox
+            // 
+            this.focusHandleTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.focusHandleTextBox.Location = new System.Drawing.Point(92, 40);
+            this.focusHandleTextBox.Name = "focusHandleTextBox";
+            this.focusHandleTextBox.ReadOnly = true;
+            this.focusHandleTextBox.Size = new System.Drawing.Size(211, 20);
+            this.focusHandleTextBox.TabIndex = 1;
+            // 
+            // focusTypeTextBox
+            // 
+            this.focusTypeTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.focusTypeTextBox.Location = new System.Drawing.Point(92, 66);
+            this.focusTypeTextBox.Name = "focusTypeTextBox";
+            this.focusTypeTextBox.ReadOnly = true;
+            this.focusTypeTextBox.Size = new System.Drawing.Size(211, 20);
+            this.focusTypeTextBox.TabIndex = 1;
+            // 
+            // DebugFocusWindow
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(334, 450);
+            this.Controls.Add(this.focusTypeTextBox);
+            this.Controls.Add(this.focusHandleTextBox);
+            this.Controls.Add(this.focusNameTextBox);
+            this.Controls.Add(this.focusLabel);
+            this.Name = "DebugFocusWindow";
+            this.Text = "DebugWindowFocus";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Timer timer;
+        private System.Windows.Forms.Label focusLabel;
+        private System.Windows.Forms.TextBox focusNameTextBox;
+        private System.Windows.Forms.TextBox focusHandleTextBox;
+        private System.Windows.Forms.TextBox focusTypeTextBox;
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Application/Views/Diagnostics/DebugFocusWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/Diagnostics/DebugFocusWindow.cs
@@ -1,0 +1,65 @@
+﻿//
+// Copyright 2020 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Diagnostics;
+using Google.Solutions.IapDesktop.Application.ObjectModel;
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using WeifenLuo.WinFormsUI.Docking;
+
+namespace Google.Solutions.IapDesktop.Application.Views.Diagnostics
+{
+    [ComVisible(false)]
+    [SkipCodeCoverage("For debug purposes only")]
+    public partial class DebugFocusWindow : ToolWindow
+    {
+        private readonly IMainForm mainForm;
+
+        public DebugFocusWindow(IServiceProvider serviceProvider)
+            : base(serviceProvider, DockState.Float)
+        {
+            InitializeComponent();
+
+            this.TabText = this.Text;
+            this.mainForm = serviceProvider.GetService<IMainForm>();
+        }
+
+        private static Control FindFocusedControl(Control control)
+        {
+            var container = control as IContainerControl;
+            while (container != null)
+            {
+                control = container.ActiveControl;
+                container = control as IContainerControl;
+            }
+            return control;
+        }
+
+        private void timer_Tick(object sender, EventArgs e)
+        {
+            var control = FindFocusedControl((Control)this.mainForm.Window);
+            this.focusNameTextBox.Text = control?.Name;
+            this.focusHandleTextBox.Text = control?.Handle.ToString();
+            this.focusTypeTextBox.Text = control?.GetType().Name;
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Application/Views/Diagnostics/DebugFocusWindow.resx
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/Diagnostics/DebugFocusWindow.resx
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="timer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+</root>

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Google.Solutions.IapDesktop.Extensions.Shell.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Google.Solutions.IapDesktop.Extensions.Shell.csproj
@@ -157,6 +157,9 @@
       <DependentUpon>TerminalOptionsControl.cs</DependentUpon>
     </Compile>
     <Compile Include="Views\Options\TerminalOptionsViewModel.cs" />
+    <Compile Include="Views\RemoteDesktop\MsRdpClient.cs">
+      <SubType>Component</SubType>
+    </Compile>
     <Compile Include="Views\RemoteDesktop\RemoteDesktopSessionBroker.cs" />
     <Compile Include="Views\RemoteDesktop\RdpClientExtensions.cs" />
     <Compile Include="Views\RemoteDesktop\RdpExceptions.cs" />

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/MsRdpClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/MsRdpClient.cs
@@ -1,0 +1,53 @@
+﻿//
+// Copyright 2021 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.RemoteDesktop
+{
+    internal class MsRdpClient : AxMSTSCLib.AxMsRdpClient9NotSafeForScripting
+    {
+        private const int WM_MOUSEACTIVATE = 0x0021;
+
+        protected override void WndProc(ref Message m)
+        {
+            //
+            // When the RDP control loses focus and you later click into the
+            // control again, the control does not re-gain focus. Fix this
+            // default behavior by forcing the focus back on the control 
+            // whenever we see a WM_MOUSEACTIVATE message.
+            //
+            // Cf. https://www.codeproject.com/Tips/109917/Fix-the-focus-issue-on-RDP-Client-from-the-AxInter
+            //
+            if (m.Msg == WM_MOUSEACTIVATE)
+            {
+                this.Focus();
+            }
+
+            base.WndProc(ref m);
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/RemoteDesktopPane.Designer.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/RemoteDesktopPane.Designer.cs
@@ -53,7 +53,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.RemoteDesktop
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(RemoteDesktopPane));
-            this.rdpClient = new AxMSTSCLib.AxMsRdpClient9NotSafeForScripting();
+            this.rdpClient = new MsRdpClient();
             this.spinner = new System.Windows.Forms.PictureBox();
             this.reconnectToResizeTimer = new System.Windows.Forms.Timer(this.components);
             this.reconnectPanel = new System.Windows.Forms.Panel();
@@ -173,7 +173,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.RemoteDesktop
 
         #endregion
 
-        private AxMSTSCLib.AxMsRdpClient9NotSafeForScripting rdpClient;
+        private MsRdpClient rdpClient;
         private System.Windows.Forms.PictureBox spinner;
         private System.Windows.Forms.Timer reconnectToResizeTimer;
         private System.Windows.Forms.Panel reconnectPanel;

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -265,6 +265,7 @@ namespace Google.Solutions.IapDesktop
             windowAndWorkflowLayer.AddSingleton<DebugDockingWindow>();
             windowAndWorkflowLayer.AddSingleton<DebugProjectExplorerTrackingWindow>();
             windowAndWorkflowLayer.AddSingleton<DebugFullScreenPane>();
+            windowAndWorkflowLayer.AddSingleton<DebugFocusWindow>();
 #endif
             //
             // Extension layer.

--- a/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
+++ b/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
@@ -317,6 +317,10 @@ namespace Google.Solutions.IapDesktop.Windows
                 "Full screen pane",
                 _ => CommandState.Enabled,
                 _ => this.serviceProvider.GetService<DebugFullScreenPane>().ShowWindow()));
+            debugCommand.AddCommand(new Command<IMainForm>(
+                "Track window focus",
+                _ => CommandState.Enabled,
+                _ => this.serviceProvider.GetService<DebugFocusWindow>().ShowWindow()));
 #endif
         }
 


### PR DESCRIPTION
When the RDP control loses focus and you later click into the
control again, the control does not re-gain focus. Fix this
default behavior by forcing the focus back on the control
whenever we see a WM_MOUSEACTIVATE message.

This addresses #490