### PR TITLE
Avoid re-focusing if control already has focus

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/MsRdpClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/MsRdpClient.cs
@@ -42,7 +42,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.RemoteDesktop
             //
             // Cf. https://www.codeproject.com/Tips/109917/Fix-the-focus-issue-on-RDP-Client-from-the-AxInter
             //
-            if (m.Msg == WM_MOUSEACTIVATE)
+            // NB. Only do this when the control does not have focus yet, 
+            // otherwise we're interfering with operations such as dragging 
+            // or resizing windows.
+            //
+            if (!this.ContainsFocus && m.Msg == WM_MOUSEACTIVATE)
             {
                 this.Focus();
             }


### PR DESCRIPTION
Re-focusing interferes with certain operations such
as resizing windows in Remote Desktop