### PR TITLE
Add vtnetcore patch for detecting key modifiers

### DIFF
--- a/dependencies/makefile
+++ b/dependencies/makefile
@@ -21,7 +21,7 @@
 CONFIGURATION = Release
 
 # The tag should be increased whenever one of the dependencies is changed
-TAG = 15
+TAG = 16
 
 VTNETCORE_TAG = 9e68f5561dc52edb780615b3fe133289216b3dba
 VTNETCORE_URL = https://github.com/darrenstarr/VtNetCore.git
@@ -74,6 +74,7 @@ $(MAKEDIR)\obj\vtnetcore\VtNetCore\VtNetCore.csproj:
 	git am $(MAKEDIR)\vtnetcore-patches\0002-Fix-escape-sequences-for-bracketed-text-mode.patch
 	git am $(MAKEDIR)\vtnetcore-patches\0003-Translate-Enter-to-CR-instead-of-LF.patch
 	git am $(MAKEDIR)\vtnetcore-patches\0004-Add-keyboard-translation-for-Ctrl-Space.patch
+	git am $(MAKEDIR)\vtnetcore-patches\0005-Detect-key-modifier-options-XTMODKEYS.patch
 
 	cd $(MAKEDIR)
 

--- a/dependencies/vtnetcore-patches/0005-Detect-key-modifier-options-XTMODKEYS.patch
+++ b/dependencies/vtnetcore-patches/0005-Detect-key-modifier-options-XTMODKEYS.patch
@@ -1,0 +1,257 @@
+From bd0e92776af023e7a7c8a32cbe6800bd1319f05b Mon Sep 17 00:00:00 2001
+From: IAP Desktop Build <iap-desktop+build@google.com>
+Date: Fri, 21 May 2021 13:24:51 +0200
+Subject: [PATCH 5/5] Detect key modifier options (XTMODKEYS)
+
+* Add sequence handler for:
+  - modifyKeyboard
+  - modifyCursorKeys
+  - modifyFunctionKeys
+  - modifyOtherKeys
+* Extend VirtualTerminalController to track mode
+
+The KeyPress logic is unchanged, i.e. the key modifier options are
+only detected, but not applied.
+---
+ VtNetCore.Unit.Tests/modifyKeys.cs            | 71 +++++++++++++++++++
+ .../IVirtualTerminalController.cs             | 43 +++++++++++
+ .../VirtualTerminalController.cs              | 45 ++++++++++++
+ .../XTermParser/XTermSequenceHandlers.cs      | 29 ++++++++
+ 4 files changed, 188 insertions(+)
+ create mode 100644 VtNetCore.Unit.Tests/modifyKeys.cs
+
+diff --git a/VtNetCore.Unit.Tests/modifyKeys.cs b/VtNetCore.Unit.Tests/modifyKeys.cs
+new file mode 100644
+index 0000000..67c7dbb
+--- /dev/null
++++ b/VtNetCore.Unit.Tests/modifyKeys.cs
+@@ -0,0 +1,71 @@
++﻿using System.Text;
++using VtNetCore.VirtualTerminal;
++using VtNetCore.XTermParser;
++using Xunit;
++
++namespace VtNetCoreUnitTests
++{
++    public class ModifyKeys
++    {
++        private void Push(DataConsumer d, string s)
++        {
++            d.Push(Encoding.UTF8.GetBytes(s));
++        }
++
++        [Fact]
++        public void SetModifyKeyboard()
++        {
++            var t = new VirtualTerminalController();
++            t.Debugging = true;
++            var d = new DataConsumer(t);
++
++            Push(d, "".CSI() + ">0;8m");
++
++            Assert.Equal(
++                ModifyKeyboardMode.AllowModifySpecialKeys,
++                t.ModifyKeyboard);
++        }
++
++        [Fact]
++        public void SetModifyCursorKeys()
++        {
++            var t = new VirtualTerminalController();
++            t.Debugging = true;
++            var d = new DataConsumer(t);
++
++            Push(d, "".CSI() + ">1;3m");
++
++            Assert.Equal(
++                ModifyCursorKeysMode.MarkAsPrivate,
++                t.ModifyCursorKeys);
++        }
++
++        [Fact]
++        public void SetModifyFunctionKeys()
++        {
++            var t = new VirtualTerminalController();
++            t.Debugging = true;
++            var d = new DataConsumer(t);
++
++            Push(d, "".CSI() + ">2;1m");
++
++            Assert.Equal(
++                ModifyFunctionKeysMode.PrefixWithCsi,
++                t.ModifyFunctionKeys);
++        }
++
++        [Fact]
++        public void SetModifyOtherKeys()
++        {
++            var t = new VirtualTerminalController();
++            t.Debugging = true;
++            var d = new DataConsumer(t);
++
++            Push(d, "".CSI() + ">4;1m");
++
++            Assert.Equal(
++                ModifyOtherKeysMode.EnabledWithExceptions,
++                t.ModifyOtherKeys);
++        }
++    }
++}
+diff --git a/VtNetCore/VirtualTerminal/IVirtualTerminalController.cs b/VtNetCore/VirtualTerminal/IVirtualTerminalController.cs
+index a452f42..356c98c 100644
+--- a/VtNetCore/VirtualTerminal/IVirtualTerminalController.cs
++++ b/VtNetCore/VirtualTerminal/IVirtualTerminalController.cs
+@@ -157,5 +157,48 @@
+         void XTermReport(XTermReportType reportType);
+         void XTermResizeTextArea(int columns, int rows);
+         void XTermResizeWindow(int width, int height);
++
++        ModifyKeyboardMode ModifyKeyboard { get; set; }
++        ModifyCursorKeysMode ModifyCursorKeys { get; set; }
++        ModifyFunctionKeysMode ModifyFunctionKeys { get; set; }
++        ModifyOtherKeysMode ModifyOtherKeys { get; set; }
++    }
++
++    public enum ModifyCursorKeysMode
++    {
++        Disabled = -1,
++        OldBehavior = 0,
++        PrefixWithCsi = 1,
++        ForceAsSecondParameter = 2,
++        MarkAsPrivate,
++        _Default = ForceAsSecondParameter
++    }
++
++    public enum ModifyFunctionKeysMode
++    {
++        PermitShiftAndControlModifiers = -1,
++        OldBehavior = 0,
++        PrefixWithCsi = 1,
++        ForceAsSecondParameter = 2,
++        MarkAsPrivate,
++        _Default = ForceAsSecondParameter
++    }
++
++    public enum ModifyKeyboardMode
++    {
++        OldBehavior = 0,
++        AllowModifyNumericKeypad = 1,
++        AllowModifyEditingKeypad = 2,
++        AllowModifyFunctionKeys = 4,
++        AllowModifySpecialKeys = 8,
++        _Default = OldBehavior
++    }
++
++    public enum ModifyOtherKeysMode
++    {
++        Disabled = 0,
++        EnabledWithExceptions = 1,
++        Enabled = 2,
++        _Default = Disabled
+     }
+ }
+diff --git a/VtNetCore/VirtualTerminal/VirtualTerminalController.cs b/VtNetCore/VirtualTerminal/VirtualTerminalController.cs
+index 248c2a0..583f562 100644
+--- a/VtNetCore/VirtualTerminal/VirtualTerminalController.cs
++++ b/VtNetCore/VirtualTerminal/VirtualTerminalController.cs
+@@ -19,6 +19,11 @@
+         private int alternativeBufferTopRow = 0;
+         private int normalBufferTopRow = 0;
+ 
++        private ModifyKeyboardMode modifyKeyboard = ModifyKeyboardMode._Default;
++        private ModifyCursorKeysMode modifyCursorKeys = ModifyCursorKeysMode._Default;
++        private ModifyFunctionKeysMode modifyFunctionKeys = ModifyFunctionKeysMode._Default;
++        private ModifyOtherKeysMode modifyOtherKeys = ModifyOtherKeysMode._Default;
++
+         /// <summary>
+         /// Configures the maximum number of lines stored in the history
+         /// </summary>
+@@ -3496,5 +3501,45 @@
+ 
+             SendData?.Invoke(this, new SendDataEventArgs { Data = Encoding.UTF8.GetBytes(report) });
+         }
++
++        public ModifyKeyboardMode ModifyKeyboard
++        {
++            get => this.modifyKeyboard;
++            set
++            {
++                LogController($"Set ModifyKeyboard mode set to {value}");
++                this.modifyKeyboard = value;
++            }
++        }
++
++        public ModifyCursorKeysMode ModifyCursorKeys
++        {
++            get => this.modifyCursorKeys;
++            set
++            {
++                LogController($"Set ModifyCursorKeys mode set to {value}");
++                this.modifyCursorKeys = value;
++            }
++        }
++
++        public ModifyFunctionKeysMode ModifyFunctionKeys
++        {
++            get => this.modifyFunctionKeys;
++            set
++            {
++                LogController($"Set ModifyFunctionKeys mode set to {value}");
++                this.modifyFunctionKeys = value;
++            }
++        }
++
++        public ModifyOtherKeysMode ModifyOtherKeys
++        {
++            get => this.modifyOtherKeys;
++            set
++            {
++                LogController($"Set ModifyOtherKeys mode set to {value}");
++                this.modifyOtherKeys = value;
++            }
++        }
+     }
+ }
+diff --git a/VtNetCore/XTermParser/XTermSequenceHandlers.cs b/VtNetCore/XTermParser/XTermSequenceHandlers.cs
+index 3c804c0..c368ec0 100644
+--- a/VtNetCore/XTermParser/XTermSequenceHandlers.cs
++++ b/VtNetCore/XTermParser/XTermSequenceHandlers.cs
+@@ -738,6 +738,35 @@
+                 }
+             },
+             new SequenceHandler
++            {
++                Description = "Set/reset key modifier options (XTMODKEYS).",
++                SequenceType = SequenceHandler.ESequenceType.CSI,
++                CsiCommand = "m",
++                Send = true,
++                ExactParameterCount = 2,
++                Handler = (sequence, controller) =>
++                {
++                    switch (sequence.Parameters[0])
++                    {
++                        case 0:
++                            controller.ModifyKeyboard = (ModifyKeyboardMode)sequence.Parameters[1];
++                            break;
++
++                        case 1:
++                            controller.ModifyCursorKeys = (ModifyCursorKeysMode)sequence.Parameters[1];
++                            break;
++
++                        case 2:
++                            controller.ModifyFunctionKeys = (ModifyFunctionKeysMode)sequence.Parameters[1];
++                            break;
++
++                        case 4:
++                            controller.ModifyOtherKeys = (ModifyOtherKeysMode)sequence.Parameters[1];
++                            break;
++                    }
++                }
++            },
++            new SequenceHandler
+             {
+                 Description = "Device Status Report (DSR). - Status Report.",
+                 SequenceType = SequenceHandler.ESequenceType.CSI,
+-- 
+2.17.1.windows.2
+


### PR DESCRIPTION
Patch vtnetcore:

* Add sequence handler for:
  - modifyKeyboard
  - modifyCursorKeys
  - modifyFunctionKeys
  - modifyOtherKeys
* Extend VirtualTerminalController to track mode

The KeyPress logic is unchanged, i.e. the key modifier options are
only detected, but not applied.