### PR TITLE
b/189199398 Use custom key translation table

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminalKeyHandler.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminalKeyHandler.cs
@@ -73,9 +73,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[11~", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F1 | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[11~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F1 | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[11~", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -93,9 +93,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[12~", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F2 | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[12~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F2 | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[12~", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -113,9 +113,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[13~", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F3 | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[13~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F3 | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[13~", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -133,9 +133,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[14~", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F4 | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[14~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F4 | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[14~", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -153,9 +153,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[15~", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F5 | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[15~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F5 | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[15~", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -173,9 +173,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[17~", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F6 | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[17~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F6 | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[17~", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -193,9 +193,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[18~", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F7 | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[18~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F7 | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[18~", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -213,9 +213,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[19~", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F8 | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[19~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F8 | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[19~", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -233,9 +233,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[20~", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F9 | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[20~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F9 | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[20~", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -253,9 +253,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[21~", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F10 | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[21~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F10 | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[21~", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -273,9 +273,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[23~", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F11 | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[23~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F11 | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[23~", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -293,9 +293,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[24~", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F12 | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[24~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F12 | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[24~", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         //---------------------------------------------------------------------
@@ -317,9 +317,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}OA", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Up | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[A", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Up | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[A", this.sendData.ToString());
+            this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Up));
@@ -342,9 +342,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}OB", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Down | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[B", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Down | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[B", this.sendData.ToString());
+            this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Down));
@@ -367,9 +367,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}OC", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Right | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[C", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Right | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[C", this.sendData.ToString());
+            this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Right));
@@ -392,9 +392,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}OD", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Left | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}[D", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Left | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[D", this.sendData.ToString());
+            this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Left));
@@ -416,9 +416,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.Home | Keys.Control));
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home | Keys.Alt));
-            //Assert.AreEqual($"{Esc}[1~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[1~", this.sendData.ToString());
+            this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home));
@@ -440,9 +440,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.End | Keys.Control));
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.End | Keys.Alt));
-            //Assert.AreEqual($"{Esc}[4~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.End | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[4~", this.sendData.ToString());
+            this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.End));
@@ -463,9 +463,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.Insert | Keys.Control));
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Insert | Keys.Alt));
-            //Assert.AreEqual($"{Esc}[2~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Insert | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[2~", this.sendData.ToString());
+            this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Insert));
@@ -487,9 +487,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.Delete | Keys.Control));
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Delete | Keys.Alt));
-            //Assert.AreEqual($"{Esc}[3~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Delete | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[3~", this.sendData.ToString());
+            this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Delete));
@@ -511,9 +511,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.PageUp | Keys.Control));
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageUp | Keys.Alt));
-            //Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageUp | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[5~", this.sendData.ToString());
+            this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageUp));
@@ -535,9 +535,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.Prior | Keys.Control));
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Prior | Keys.Alt));
-            //Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Prior | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[5~", this.sendData.ToString());
+            this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Prior));
@@ -559,9 +559,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.PageDown | Keys.Control));
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageDown | Keys.Alt));
-            //Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageDown | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[6~", this.sendData.ToString());
+            this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageDown));
@@ -583,9 +583,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.Next | Keys.Control));
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Next | Keys.Alt));
-            //Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Next | Keys.Alt));
+            Assert.AreEqual($"{Esc}{Esc}[6~", this.sendData.ToString());
+            this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Next));
@@ -612,7 +612,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual("\u007f", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsFalse(this.keyHandler.KeyDown(Keys.Back | Keys.Alt));
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Back | Keys.Alt));
         }
 
 
@@ -629,18 +629,12 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
 
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.Tab | Keys.Control));
 
-            //Assert.IsFalse(this.keyHandler.KeyDown(Keys.Tab | Keys.Alt));
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Tab | Keys.Alt));
         }
 
         [Test]
         public void Return()
         {
-            //
-            // NB. This test requires a patched version of vtnetcore. If it fails,
-            // you're probably using an unpatched version.
-            //
-
-
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Return));
             Assert.AreEqual("\r", this.sendData.ToString());
             this.sendData.Clear();
@@ -653,20 +647,14 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual("\r", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Return | Keys.Alt));
-            //Assert.AreEqual("\r", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Return | Keys.Alt));
+            Assert.AreEqual($"{Esc}\r", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
         public void Enter()
         {
-            //
-            // NB. This test requires a patched version of vtnetcore. If it fails,
-            // you're probably using an unpatched version.
-            //
-
-
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Enter));
             Assert.AreEqual("\r", this.sendData.ToString());
             this.sendData.Clear();
@@ -679,9 +667,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual("\r", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Enter | Keys.Alt));
-            //Assert.AreEqual("\r", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Enter | Keys.Alt));
+            Assert.AreEqual($"{Esc}\r", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -699,9 +687,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}{Esc}", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Escape | Keys.Alt));
-            //Assert.AreEqual($"{Esc}{Esc}", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Escape | Keys.Alt));
         }
 
         [Test]
@@ -715,9 +701,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"\u0000", this.sendData.ToString());
             this.sendData.Clear();
 
-            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Space | Keys.Alt));
-            //Assert.AreEqual($"{Esc} ", this.sendData.ToString());
-            //this.sendData.Clear();
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Space | Keys.Alt));
+            Assert.AreEqual($"{Esc} ", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminalKeyHandler.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminalKeyHandler.cs
@@ -55,21 +55,582 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         }
 
         //---------------------------------------------------------------------
-        // Modifiers.
+        // Function keys.
         //---------------------------------------------------------------------
 
         [Test]
-        public void CtrlSpace()
+        public void F1()
         {
-            Assert.IsTrue(this.keyHandler.KeyDown(
-                Keys.Control | Keys.Space));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F1));
+            Assert.AreEqual($"{Esc}[11~", this.sendData.ToString());
+            this.sendData.Clear();
 
-            Assert.AreEqual("\u0000", this.sendData.ToString());
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F1 | Keys.Shift));
+            Assert.AreEqual($"{Esc}[23~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F1 | Keys.Control));
+            Assert.AreEqual($"{Esc}[11~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F1 | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[11~", this.sendData.ToString());
+            //this.sendData.Clear();
+        }
+
+        [Test]
+        public void F2()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F2));
+            Assert.AreEqual($"{Esc}[12~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F2 | Keys.Shift));
+            Assert.AreEqual($"{Esc}[24~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F2 | Keys.Control));
+            Assert.AreEqual($"{Esc}[12~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F2 | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[12~", this.sendData.ToString());
+            //this.sendData.Clear();
+        }
+
+        [Test]
+        public void F3()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F3));
+            Assert.AreEqual($"{Esc}[13~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F3 | Keys.Shift));
+            Assert.AreEqual($"{Esc}[25~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F3 | Keys.Control));
+            Assert.AreEqual($"{Esc}[13~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F3 | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[13~", this.sendData.ToString());
+            //this.sendData.Clear();
+        }
+
+        [Test]
+        public void F4()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F4));
+            Assert.AreEqual($"{Esc}[14~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F4 | Keys.Shift));
+            Assert.AreEqual($"{Esc}[26~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F4 | Keys.Control));
+            Assert.AreEqual($"{Esc}[14~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F4 | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[14~", this.sendData.ToString());
+            //this.sendData.Clear();
+        }
+
+        [Test]
+        public void F5()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F5));
+            Assert.AreEqual($"{Esc}[15~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F5 | Keys.Shift));
+            Assert.AreEqual($"{Esc}[28~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F5 | Keys.Control));
+            Assert.AreEqual($"{Esc}[15~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F5 | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[15~", this.sendData.ToString());
+            //this.sendData.Clear();
+        }
+
+        [Test]
+        public void F6()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F6));
+            Assert.AreEqual($"{Esc}[17~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F6 | Keys.Shift));
+            Assert.AreEqual($"{Esc}[29~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F6 | Keys.Control));
+            Assert.AreEqual($"{Esc}[17~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F6 | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[17~", this.sendData.ToString());
+            //this.sendData.Clear();
+        }
+
+        [Test]
+        public void F7()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F7));
+            Assert.AreEqual($"{Esc}[18~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F7 | Keys.Shift));
+            Assert.AreEqual($"{Esc}[31~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F7 | Keys.Control));
+            Assert.AreEqual($"{Esc}[18~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F7 | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[18~", this.sendData.ToString());
+            //this.sendData.Clear();
+        }
+
+        [Test]
+        public void F8()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F8));
+            Assert.AreEqual($"{Esc}[19~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F8 | Keys.Shift));
+            Assert.AreEqual($"{Esc}[32~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F8 | Keys.Control));
+            Assert.AreEqual($"{Esc}[19~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F8 | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[19~", this.sendData.ToString());
+            //this.sendData.Clear();
+        }
+
+        [Test]
+        public void F9()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F9));
+            Assert.AreEqual($"{Esc}[20~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F9 | Keys.Shift));
+            Assert.AreEqual($"{Esc}[33~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F9 | Keys.Control));
+            Assert.AreEqual($"{Esc}[20~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F9 | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[20~", this.sendData.ToString());
+            //this.sendData.Clear();
+        }
+
+        [Test]
+        public void F10()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F10));
+            Assert.AreEqual($"{Esc}[21~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F10 | Keys.Shift));
+            Assert.AreEqual($"{Esc}[24~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F10 | Keys.Control));
+            Assert.AreEqual($"{Esc}[21~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F10 | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[21~", this.sendData.ToString());
+            //this.sendData.Clear();
+        }
+
+        [Test]
+        public void F11()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F11));
+            Assert.AreEqual($"{Esc}[23~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F11 | Keys.Shift));
+            Assert.AreEqual($"{Esc}[23~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F11 | Keys.Control));
+            Assert.AreEqual($"{Esc}[23~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F11 | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[23~", this.sendData.ToString());
+            //this.sendData.Clear();
+        }
+
+        [Test]
+        public void F12()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F12));
+            Assert.AreEqual($"{Esc}[24~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F12 | Keys.Shift));
+            Assert.AreEqual($"{Esc}[24~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.F12 | Keys.Control));
+            Assert.AreEqual($"{Esc}[24~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.F12 | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[24~", this.sendData.ToString());
+            //this.sendData.Clear();
         }
 
         //---------------------------------------------------------------------
-        // Special keys.
+        // Arrow keys.
         //---------------------------------------------------------------------
+
+        [Test]
+        public void Up()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Up));
+            Assert.AreEqual($"{Esc}[A", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Up | Keys.Shift));
+            Assert.AreEqual($"{Esc}OA", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Up | Keys.Control));
+            Assert.AreEqual($"{Esc}OA", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Up | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[A", this.sendData.ToString());
+            //this.sendData.Clear();
+
+            this.controller.EnableApplicationCursorKeys(true);
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Up));
+            Assert.AreEqual($"{Esc}OA", this.sendData.ToString());
+            this.sendData.Clear();
+        }
+
+        [Test]
+        public void Down()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Down));
+            Assert.AreEqual($"{Esc}[B", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Down | Keys.Shift));
+            Assert.AreEqual($"{Esc}OB", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Down | Keys.Control));
+            Assert.AreEqual($"{Esc}OB", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Down | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[B", this.sendData.ToString());
+            //this.sendData.Clear();
+
+            this.controller.EnableApplicationCursorKeys(true);
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Down));
+            Assert.AreEqual($"{Esc}OB", this.sendData.ToString());
+            this.sendData.Clear();
+        }
+
+        [Test]
+        public void Right()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Right));
+            Assert.AreEqual($"{Esc}[C", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Right | Keys.Shift));
+            Assert.AreEqual($"{Esc}OC", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Right | Keys.Control));
+            Assert.AreEqual($"{Esc}OC", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Right | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[C", this.sendData.ToString());
+            //this.sendData.Clear();
+
+            this.controller.EnableApplicationCursorKeys(true);
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Right));
+            Assert.AreEqual($"{Esc}OC", this.sendData.ToString());
+            this.sendData.Clear();
+        }
+
+        [Test]
+        public void Left()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Left));
+            Assert.AreEqual($"{Esc}[D", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Left | Keys.Shift));
+            Assert.AreEqual($"{Esc}OD", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Left | Keys.Control));
+            Assert.AreEqual($"{Esc}OD", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Left | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}[D", this.sendData.ToString());
+            //this.sendData.Clear();
+
+            this.controller.EnableApplicationCursorKeys(true);
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Left));
+            Assert.AreEqual($"{Esc}OD", this.sendData.ToString());
+            this.sendData.Clear();
+        }
+
+        [Test]
+        public void Home()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home));
+            Assert.AreEqual($"{Esc}[1~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home | Keys.Shift));
+            Assert.AreEqual($"{Esc}[1~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Home | Keys.Control));
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home | Keys.Alt));
+            //Assert.AreEqual($"{Esc}[1~", this.sendData.ToString());
+            //this.sendData.Clear();
+
+            this.controller.EnableApplicationCursorKeys(true);
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home));
+            Assert.AreEqual($"{Esc}[1~", this.sendData.ToString());
+            this.sendData.Clear();
+        }
+
+        [Test]
+        public void End()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.End));
+            Assert.AreEqual($"{Esc}[4~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.End | Keys.Shift));
+            Assert.AreEqual($"{Esc}[4~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.End | Keys.Control));
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.End | Keys.Alt));
+            //Assert.AreEqual($"{Esc}[4~", this.sendData.ToString());
+            //this.sendData.Clear();
+
+            this.controller.EnableApplicationCursorKeys(true);
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.End));
+            Assert.AreEqual($"{Esc}[4~", this.sendData.ToString());
+            this.sendData.Clear();
+        }
+
+        [Test]
+        public void Insert()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Insert));
+            Assert.AreEqual($"{Esc}[2~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Insert | Keys.Shift));
+            this.sendData.Clear();
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Insert | Keys.Control));
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Insert | Keys.Alt));
+            //Assert.AreEqual($"{Esc}[2~", this.sendData.ToString());
+            //this.sendData.Clear();
+
+            this.controller.EnableApplicationCursorKeys(true);
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Insert));
+            Assert.AreEqual($"{Esc}[2~", this.sendData.ToString());
+            this.sendData.Clear();
+        }
+
+        [Test]
+        public void Delete()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Delete));
+            Assert.AreEqual($"{Esc}[3~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Delete | Keys.Shift));
+            Assert.AreEqual($"{Esc}[3~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Delete | Keys.Control));
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Delete | Keys.Alt));
+            //Assert.AreEqual($"{Esc}[3~", this.sendData.ToString());
+            //this.sendData.Clear();
+
+            this.controller.EnableApplicationCursorKeys(true);
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Delete));
+            Assert.AreEqual($"{Esc}[3~", this.sendData.ToString());
+            this.sendData.Clear();
+        }
+
+        [Test]
+        public void PageUp()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageUp));
+            Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageUp | Keys.Shift));
+            Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.PageUp | Keys.Control));
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageUp | Keys.Alt));
+            //Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
+            //this.sendData.Clear();
+
+            this.controller.EnableApplicationCursorKeys(true);
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageUp));
+            Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
+            this.sendData.Clear();
+        }
+
+        [Test]
+        public void Prior()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Prior));
+            Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Prior | Keys.Shift));
+            Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Prior | Keys.Control));
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Prior | Keys.Alt));
+            //Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
+            //this.sendData.Clear();
+
+            this.controller.EnableApplicationCursorKeys(true);
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Prior));
+            Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
+            this.sendData.Clear();
+        }
+
+        [Test]
+        public void PageDown()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageDown));
+            Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageDown | Keys.Shift));
+            Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.PageDown | Keys.Control));
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageDown | Keys.Alt));
+            //Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
+            //this.sendData.Clear();
+
+            this.controller.EnableApplicationCursorKeys(true);
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageDown));
+            Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
+            this.sendData.Clear();
+        }
+
+        [Test]
+        public void Next()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Next));
+            Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Next | Keys.Shift));
+            Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Next | Keys.Control));
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Next | Keys.Alt));
+            //Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
+            //this.sendData.Clear();
+
+            this.controller.EnableApplicationCursorKeys(true);
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Next));
+            Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
+            this.sendData.Clear();
+        }
+
+        //---------------------------------------------------------------------
+        // Main keyboard keys.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void Back()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Back));
+            Assert.AreEqual("\u007f", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Back | Keys.Shift));
+            Assert.AreEqual($"\b", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Back | Keys.Control));
+            Assert.AreEqual("\u007f", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsFalse(this.keyHandler.KeyDown(Keys.Back | Keys.Alt));
+        }
+
+
+        [Test]
+        public void Tab()
+        {
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Tab));
+            Assert.AreEqual("\t", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Tab | Keys.Shift));
+            Assert.AreEqual($"{Esc}[Z", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Tab | Keys.Control));
+
+            //Assert.IsFalse(this.keyHandler.KeyDown(Keys.Tab | Keys.Alt));
+        }
 
         [Test]
         public void Return()
@@ -79,93 +640,102 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             // you're probably using an unpatched version.
             //
 
+
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Return));
-            Assert.IsTrue(this.keyHandler.KeyPressed('a'));
+            Assert.AreEqual("\r", this.sendData.ToString());
+            this.sendData.Clear();
+
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Return | Keys.Shift));
-            Assert.IsTrue(this.keyHandler.KeyPressed('b'));
+            Assert.AreEqual("\r", this.sendData.ToString());
+            this.sendData.Clear();
+
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Return | Keys.Control));
+            Assert.AreEqual("\r", this.sendData.ToString());
+            this.sendData.Clear();
 
-            Assert.AreEqual("\ra\rb\r", this.sendData.ToString());
-        }
-
-
-        //---------------------------------------------------------------------
-        // Cursor.
-        //---------------------------------------------------------------------
-
-        [Test]
-        public void UpArrow()
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Up));
-            Assert.AreEqual($"{Esc}[A", this.sendData.ToString());
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Return | Keys.Alt));
+            //Assert.AreEqual("\r", this.sendData.ToString());
+            //this.sendData.Clear();
         }
 
         [Test]
-        public void DownArrow()
+        public void Enter()
         {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Down));
-            Assert.AreEqual($"{Esc}[B", this.sendData.ToString());
+            //
+            // NB. This test requires a patched version of vtnetcore. If it fails,
+            // you're probably using an unpatched version.
+            //
+
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Enter));
+            Assert.AreEqual("\r", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Enter | Keys.Shift));
+            Assert.AreEqual("\r", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Enter | Keys.Control));
+            Assert.AreEqual("\r", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Enter | Keys.Alt));
+            //Assert.AreEqual("\r", this.sendData.ToString());
+            //this.sendData.Clear();
         }
 
         [Test]
-        public void RightArrow()
+        public void Escape()
         {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Right));
-            Assert.AreEqual($"{Esc}[C", this.sendData.ToString());
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Escape));
+            Assert.AreEqual($"{Esc}{Esc}", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Escape | Keys.Shift));
+            Assert.AreEqual($"{Esc}{Esc}", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Escape | Keys.Control));
+            Assert.AreEqual($"{Esc}{Esc}", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Escape | Keys.Alt));
+            //Assert.AreEqual($"{Esc}{Esc}", this.sendData.ToString());
+            //this.sendData.Clear();
         }
 
         [Test]
-        public void LeftArrow()
+        public void Space()
         {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Left));
-            Assert.AreEqual($"{Esc}[D", this.sendData.ToString());
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Space));
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Space | Keys.Shift));
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Space | Keys.Control));
+            Assert.AreEqual($"\u0000", this.sendData.ToString());
+            this.sendData.Clear();
+
+            //Assert.IsTrue(this.keyHandler.KeyDown(Keys.Space | Keys.Alt));
+            //Assert.AreEqual($"{Esc} ", this.sendData.ToString());
+            //this.sendData.Clear();
         }
 
         [Test]
-        public void Home()
+        public void Letter(
+            [Range(0, 25)] int offset)
         {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home));
-            Assert.AreEqual($"{Esc}[1~", this.sendData.ToString());
-        }
+            var key = (Keys)(Keys.A + offset);
+            Assert.IsFalse(this.keyHandler.KeyDown(key));
 
-        [Test]
-        public void End()
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.End));
-            Assert.AreEqual($"{Esc}[4~", this.sendData.ToString());
-        }
+            Assert.IsFalse(this.keyHandler.KeyDown(key | Keys.Shift));
 
-        //---------------------------------------------------------------------
-        // Modifiers.
-        //---------------------------------------------------------------------
+            Assert.IsTrue(this.keyHandler.KeyDown(key | Keys.Control));
+            Assert.AreEqual(((char)(offset + 1)).ToString(), this.sendData.ToString());
+            this.sendData.Clear();
 
-        [Test]
-        public void WhenTypingCtrlChar_ThenKeystrokeIsSent()
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Control | Keys.A));
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Control | Keys.Z));
-
-            Assert.AreEqual("\u0001\u001a", this.sendData.ToString());
-        }
-
-        [Test]
-        public void WhenTypingAltChar_ThenKeystrokeIsSent()
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Alt | Keys.A));
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Alt | Keys.Z));
-
-            Assert.AreEqual("\u001ba\u001bz", this.sendData.ToString());
-        }
-
-        //---------------------------------------------------------------------
-        // Numpad & Function Keys.
-        //---------------------------------------------------------------------
-
-        [Test]
-        public void Backspace()
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Back));
-            Assert.AreEqual("\u007f", this.sendData.ToString());
+            Assert.IsTrue(this.keyHandler.KeyDown(key | Keys.Alt));
+            Assert.AreEqual($"{Esc}" + (char)('a' + offset), this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -174,82 +744,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         {
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Pause));
             Assert.AreEqual("\u001a", this.sendData.ToString());
-        }
-
-        [Test]
-        public void Escape()
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Escape));
-            Assert.AreEqual(Esc + Esc, this.sendData.ToString());
-        }
-
-        [Test]
-        public void Insert()
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Insert));
-            Assert.AreEqual($"{Esc}[2~", this.sendData.ToString());
-        }
-
-        [Test]
-        public void Delete()
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Delete));
-            Assert.AreEqual($"{Esc}[3~", this.sendData.ToString());
-        }
-
-        [Test]
-        public void PageUp()
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageUp));
-            Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
-        }
-
-        [Test]
-        public void Prior()
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Prior));
-            Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
-        }
-
-        [Test]
-        public void PageDown()
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageDown));
-            Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
-        }
-
-        [Test]
-        public void Next()
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Next));
-            Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
-        }
-
-        [Test]
-        public void FunctionKeyInLowerRange(
-            [Range(1, 5)] int functionKey
-            )
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown((Keys)(Keys.F1 + functionKey - 1)));
-            Assert.AreEqual($"{Esc}[{10 + functionKey}~", this.sendData.ToString());
-        }
-
-        [Test]
-        public void FunctionKeyInMiddleRange(
-            [Range(6, 10)] int functionKey
-            )
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown((Keys)(Keys.F1 + functionKey - 1)));
-            Assert.AreEqual($"{Esc}[{11 + functionKey}~", this.sendData.ToString());
-        }
-
-        [Test]
-        public void FunctionKeyInUpperRange(
-            [Range(11, 12)] int functionKey
-            )
-        {
-            Assert.IsTrue(this.keyHandler.KeyDown((Keys)(Keys.F1 + functionKey - 1)));
-            Assert.AreEqual($"{Esc}[{12 + functionKey}~", this.sendData.ToString());
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyHandler.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyHandler.cs
@@ -38,22 +38,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
     {
         private readonly VirtualTerminalController controller;
 
-        private static string NameFromKey(Keys key)
-        {
-            // Return name that is compatible with vtnetcore's KeyboardTranslation
-            switch (key)
-            {
-                case Keys.Next: // Alias for PageDown
-                    return "PageDown";
-
-                case Keys.Prior:   // Alias for PageUp
-                    return "PageUp";
-
-                default:
-                    return key.ToString();
-            }
-        }
-
         private void Send(string data)
         {
             this.controller.SendData?.Invoke(
@@ -77,14 +61,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
         //
         //---------------------------------------------------------------------
 
-        private bool IsKeySequence(Keys keyCode, bool control, bool shift)
-        {
-            return this.controller.GetKeySequence(
-                NameFromKey(keyCode), 
-                control, 
-                shift) != null;
-        }
-
         public bool KeyDown(Keys keyData)
         {
             return KeyDown(
@@ -98,52 +74,21 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
         {
             Debug.Assert((keyCode & Keys.KeyCode) == keyCode, "No modifiers");
 
-            if (!alt && IsKeySequence(keyCode, control, shift))
+            var translation = VirtualTerminalKeyTranslation.ForKey(
+                keyCode, 
+                alt, 
+                control, 
+                shift,
+                this.controller.CursorState.ApplicationCursorKeysMode);
+
+            if (translation != null)
             {
                 //
-                // This is a key sequence that needs to be
-                // translated to some VT sequence.
+                // This key translated into some escape sequence. Send
+                // translated sequence and stop processing the key.
                 //
-                // NB. If Alt is pressed, it cannot be a key sequence. 
-                // Otherwise, it might.
-                //
-                return this.controller.KeyPressed(
-                    NameFromKey(keyCode),
-                    control,
-                    shift);
-            }
-            else if (alt && control)
-            {
-                //
-                // AltGr - let KeyPress handle the composition.
-                //
-                return false;
-            }
-            else if (alt)
-            {
-                //
-                // Somewhat non-standard, emulate the behavior
-                // of other terminals and escape the character.
-                //
-                // This enables applications like midnight 
-                // commander which rely on Alt+<char> keyboard
-                // shortcuts.
-                //
-                var ch = KeyUtil.CharFromKeyCode(keyCode);
-                if (ch.Length > 0)
-                {
-                    Send("\u001b" + ch);
-                    return true;
-                }
-                else
-                {
-                    //
-                    // This is a stray Alt press, could be part
-                    // of an Alt+Tab action. Do not handle this
-                    // as it might screw up subsequent input.
-                    //
-                    return false;
-                }
+                Send(translation);
+                return true;
             }
             else
             {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyHandler.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyHandler.cs
@@ -74,6 +74,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
         {
             Debug.Assert((keyCode & Keys.KeyCode) == keyCode, "No modifiers");
 
+            //
+            // Instead of passing the key to vtnetcore to translate, use
+            // our own translation logic (which is more complete than
+            // vtnetcore's).
+            //
             var translation = VirtualTerminalKeyTranslation.ForKey(
                 keyCode, 
                 alt, 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyTranslation.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyTranslation.cs
@@ -66,6 +66,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
             }
         }
 
+        private static string Esc = "\u001b";
+        private static string Ss3 = Esc + "O";
+
         /// <summary>
         /// Standard Xterm key translations.
         /// </summary>
@@ -75,67 +78,67 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
                 //
                 // Function keys.
                 //
-                { Keys.F1,       new StandardMapping { Normal = "\u001b[11~", Shift = "\u001b[23~", Control = "\u001b[11~", Alt = "\u001b\u001b[11~" } },
-                { Keys.F2,       new StandardMapping { Normal = "\u001b[12~", Shift = "\u001b[24~", Control = "\u001b[12~", Alt = "\u001b\u001b[12~" } },
-                { Keys.F3,       new StandardMapping { Normal = "\u001b[13~", Shift = "\u001b[25~", Control = "\u001b[13~", Alt = "\u001b\u001b[13~" } },
-                { Keys.F4,       new StandardMapping { Normal = "\u001b[14~", Shift = "\u001b[26~", Control = "\u001b[14~", Alt = "\u001b\u001b[14~" } },
-                { Keys.F5,       new StandardMapping { Normal = "\u001b[15~", Shift = "\u001b[28~", Control = "\u001b[15~", Alt = "\u001b\u001b[15~" } },
-                { Keys.F6,       new StandardMapping { Normal = "\u001b[17~", Shift = "\u001b[29~", Control = "\u001b[17~", Alt = "\u001b\u001b[17~" } },
-                { Keys.F7,       new StandardMapping { Normal = "\u001b[18~", Shift = "\u001b[31~", Control = "\u001b[18~", Alt = "\u001b\u001b[18~" } },
-                { Keys.F8,       new StandardMapping { Normal = "\u001b[19~", Shift = "\u001b[32~", Control = "\u001b[19~", Alt = "\u001b\u001b[19~" } },
-                { Keys.F9,       new StandardMapping { Normal = "\u001b[20~", Shift = "\u001b[33~", Control = "\u001b[20~", Alt = "\u001b\u001b[20~" } },
-                { Keys.F10,      new StandardMapping { Normal = "\u001b[21~", Shift = "\u001b[24~", Control = "\u001b[21~", Alt = "\u001b\u001b[21~" } },
-                { Keys.F11,      new StandardMapping { Normal = "\u001b[23~", Shift = "\u001b[23~", Control = "\u001b[23~", Alt = "\u001b\u001b[23~" } },
-                { Keys.F12,      new StandardMapping { Normal = "\u001b[24~", Shift = "\u001b[24~", Control = "\u001b[24~", Alt = "\u001b\u001b[24~" } },
+                { Keys.F1,       new StandardMapping { Normal = Esc + "[11~", Shift = Esc + "[23~", Control = Esc + "[11~", Alt = Esc + Esc + "[11~" } },
+                { Keys.F2,       new StandardMapping { Normal = Esc + "[12~", Shift = Esc + "[24~", Control = Esc + "[12~", Alt = Esc + Esc + "[12~" } },
+                { Keys.F3,       new StandardMapping { Normal = Esc + "[13~", Shift = Esc + "[25~", Control = Esc + "[13~", Alt = Esc + Esc + "[13~" } },
+                { Keys.F4,       new StandardMapping { Normal = Esc + "[14~", Shift = Esc + "[26~", Control = Esc + "[14~", Alt = Esc + Esc + "[14~" } },
+                { Keys.F5,       new StandardMapping { Normal = Esc + "[15~", Shift = Esc + "[28~", Control = Esc + "[15~", Alt = Esc + Esc + "[15~" } },
+                { Keys.F6,       new StandardMapping { Normal = Esc + "[17~", Shift = Esc + "[29~", Control = Esc + "[17~", Alt = Esc + Esc + "[17~" } },
+                { Keys.F7,       new StandardMapping { Normal = Esc + "[18~", Shift = Esc + "[31~", Control = Esc + "[18~", Alt = Esc + Esc + "[18~" } },
+                { Keys.F8,       new StandardMapping { Normal = Esc + "[19~", Shift = Esc + "[32~", Control = Esc + "[19~", Alt = Esc + Esc + "[19~" } },
+                { Keys.F9,       new StandardMapping { Normal = Esc + "[20~", Shift = Esc + "[33~", Control = Esc + "[20~", Alt = Esc + Esc + "[20~" } },
+                { Keys.F10,      new StandardMapping { Normal = Esc + "[21~", Shift = Esc + "[24~", Control = Esc + "[21~", Alt = Esc + Esc + "[21~" } },
+                { Keys.F11,      new StandardMapping { Normal = Esc + "[23~", Shift = Esc + "[23~", Control = Esc + "[23~", Alt = Esc + Esc + "[23~" } },
+                { Keys.F12,      new StandardMapping { Normal = Esc + "[24~", Shift = Esc + "[24~", Control = Esc + "[24~", Alt = Esc + Esc + "[24~" } },
 
                 //
                 // Arrow keys.
                 //
-                { Keys.Up,       new StandardMapping { Normal = "\u001b[A",   Shift = "\u001bOA", Control = "\u001bOA",     Alt = "\u001b\u001b[A" } },
-                { Keys.Down,     new StandardMapping { Normal = "\u001b[B",   Shift = "\u001bOB", Control = "\u001bOB",     Alt = "\u001b\u001b[B" } },
-                { Keys.Right,    new StandardMapping { Normal = "\u001b[C",   Shift = "\u001bOC", Control = "\u001bOC",     Alt = "\u001b\u001b[C" } },
-                { Keys.Left,     new StandardMapping { Normal = "\u001b[D",   Shift = "\u001bOD", Control = "\u001bOD",     Alt = "\u001b\u001b[D" } },
-                { Keys.Home,     new StandardMapping { Normal = "\u001b[1~",  Shift = "\u001b[1~",                          Alt = "\u001b\u001b[1~" } },
-                { Keys.Insert,   new StandardMapping { Normal = "\u001b[2~",                                                Alt = "\u001b\u001b[2~" } },
-                { Keys.Delete,   new StandardMapping { Normal = "\u001b[3~",  Shift = "\u001b[3~",                          Alt = "\u001b\u001b[3~" } },
-                { Keys.End,      new StandardMapping { Normal = "\u001b[4~",  Shift = "\u001b[4~",                          Alt = "\u001b\u001b[4~" } },
-                { Keys.PageUp,   new StandardMapping { Normal = "\u001b[5~",  Shift = "\u001b[5~",                          Alt = "\u001b\u001b[5~" } },
-                { Keys.PageDown, new StandardMapping { Normal = "\u001b[6~",  Shift = "\u001b[6~",                          Alt = "\u001b\u001b[6~" } },
+                { Keys.Up,       new StandardMapping { Normal = Esc + "[A",   Shift = Esc + "OA", Control = Esc + "OA",     Alt = Esc + Esc + "[A" } },
+                { Keys.Down,     new StandardMapping { Normal = Esc + "[B",   Shift = Esc + "OB", Control = Esc + "OB",     Alt = Esc + Esc + "[B" } },
+                { Keys.Right,    new StandardMapping { Normal = Esc + "[C",   Shift = Esc + "OC", Control = Esc + "OC",     Alt = Esc + Esc + "[C" } },
+                { Keys.Left,     new StandardMapping { Normal = Esc + "[D",   Shift = Esc + "OD", Control = Esc + "OD",     Alt = Esc + Esc + "[D" } },
+                { Keys.Home,     new StandardMapping { Normal = Esc + "[1~",  Shift = Esc + "[1~",                          Alt = Esc + Esc + "[1~" } },
+                { Keys.Insert,   new StandardMapping { Normal = Esc + "[2~",                                                Alt = Esc + Esc + "[2~" } },
+                { Keys.Delete,   new StandardMapping { Normal = Esc + "[3~",  Shift = Esc + "[3~",                          Alt = Esc + Esc + "[3~" } },
+                { Keys.End,      new StandardMapping { Normal = Esc + "[4~",  Shift = Esc + "[4~",                          Alt = Esc + Esc + "[4~" } },
+                { Keys.PageUp,   new StandardMapping { Normal = Esc + "[5~",  Shift = Esc + "[5~",                          Alt = Esc + Esc + "[5~" } },
+                { Keys.PageDown, new StandardMapping { Normal = Esc + "[6~",  Shift = Esc + "[6~",                          Alt = Esc + Esc + "[6~" } },
 
                 //
                 // Main keyboard.
                 //
                 { Keys.Back,    new StandardMapping { Normal = "\u007F",      Shift = "\b",           Control = "\u007F" } },
-                { Keys.Tab,     new StandardMapping { Normal = "\t",          Shift = "\u001b[Z",     } },
-                { Keys.Return,  new StandardMapping { Normal = "\r",          Shift = "\r",           Control = "\r",       Alt = "\u001b\r" } },
-                { Keys.Escape,  new StandardMapping { Normal = "\u001b\u001b",Shift = "\u001b\u001b", Control = "\u001b\u001b" } },
-                { Keys.Space,   new StandardMapping { Control = "\u0000",                                                   Alt = "\u001b " } },
-                { Keys.A,       new StandardMapping { Control = "\u0001",     Alt = "\u001ba" } },
-                { Keys.B,       new StandardMapping { Control = "\u0002",     Alt = "\u001bb" } },
-                { Keys.C,       new StandardMapping { Control = "\u0003",     Alt = "\u001bc" } },
-                { Keys.D,       new StandardMapping { Control = "\u0004",     Alt = "\u001bd" } },
-                { Keys.E,       new StandardMapping { Control = "\u0005",     Alt = "\u001be" } },
-                { Keys.F,       new StandardMapping { Control = "\u0006",     Alt = "\u001bf" } },
-                { Keys.G,       new StandardMapping { Control = "\u0007",     Alt = "\u001bg" } },
-                { Keys.H,       new StandardMapping { Control = "\u0008",     Alt = "\u001bh" } },
-                { Keys.I,       new StandardMapping { Control = "\u0009",     Alt = "\u001bi" } },
-                { Keys.J,       new StandardMapping { Control = "\u000a",     Alt = "\u001bj" } },
-                { Keys.K,       new StandardMapping { Control = "\u000b",     Alt = "\u001bk" } },
-                { Keys.L,       new StandardMapping { Control = "\u000c",     Alt = "\u001bl" } },
-                { Keys.M,       new StandardMapping { Control = "\u000d",     Alt = "\u001bm" } },
-                { Keys.N,       new StandardMapping { Control = "\u000e",     Alt = "\u001bn" } },
-                { Keys.O,       new StandardMapping { Control = "\u000f",     Alt = "\u001bo" } },
-                { Keys.P,       new StandardMapping { Control = "\u0010",     Alt = "\u001bp" } },
-                { Keys.Q,       new StandardMapping { Control = "\u0011",     Alt = "\u001bq" } },
-                { Keys.R,       new StandardMapping { Control = "\u0012",     Alt = "\u001br" } },
-                { Keys.S,       new StandardMapping { Control = "\u0013",     Alt = "\u001bs" } },
-                { Keys.T,       new StandardMapping { Control = "\u0014",     Alt = "\u001bt" } },
-                { Keys.U,       new StandardMapping { Control = "\u0015",     Alt = "\u001bu" } },
-                { Keys.V,       new StandardMapping { Control = "\u0016",     Alt = "\u001bv" } },
-                { Keys.W,       new StandardMapping { Control = "\u0017",     Alt = "\u001bw" } },
-                { Keys.X,       new StandardMapping { Control = "\u0018",     Alt = "\u001bx" } },
-                { Keys.Y,       new StandardMapping { Control = "\u0019",     Alt = "\u001by" } },
-                { Keys.Z,       new StandardMapping { Control = "\u001a",     Alt = "\u001bz" } },
+                { Keys.Tab,     new StandardMapping { Normal = "\t",          Shift = Esc + "[Z",     } },
+                { Keys.Return,  new StandardMapping { Normal = "\r",          Shift = "\r",           Control = "\r",       Alt = Esc + "\r" } },
+                { Keys.Escape,  new StandardMapping { Normal = Esc + Esc,     Shift = Esc + Esc,      Control = Esc + Esc } },
+                { Keys.Space,   new StandardMapping { Control = "\u0000",                                                   Alt = Esc + " " } },
+                { Keys.A,       new StandardMapping { Control = "\u0001",     Alt = Esc + "a" } },
+                { Keys.B,       new StandardMapping { Control = "\u0002",     Alt = Esc + "b" } },
+                { Keys.C,       new StandardMapping { Control = "\u0003",     Alt = Esc + "c" } },
+                { Keys.D,       new StandardMapping { Control = "\u0004",     Alt = Esc + "d" } },
+                { Keys.E,       new StandardMapping { Control = "\u0005",     Alt = Esc + "e" } },
+                { Keys.F,       new StandardMapping { Control = "\u0006",     Alt = Esc + "f" } },
+                { Keys.G,       new StandardMapping { Control = "\u0007",     Alt = Esc + "g" } },
+                { Keys.H,       new StandardMapping { Control = "\u0008",     Alt = Esc + "h" } },
+                { Keys.I,       new StandardMapping { Control = "\u0009",     Alt = Esc + "i" } },
+                { Keys.J,       new StandardMapping { Control = "\u000a",     Alt = Esc + "j" } },
+                { Keys.K,       new StandardMapping { Control = "\u000b",     Alt = Esc + "k" } },
+                { Keys.L,       new StandardMapping { Control = "\u000c",     Alt = Esc + "l" } },
+                { Keys.M,       new StandardMapping { Control = "\u000d",     Alt = Esc + "m" } },
+                { Keys.N,       new StandardMapping { Control = "\u000e",     Alt = Esc + "n" } },
+                { Keys.O,       new StandardMapping { Control = "\u000f",     Alt = Esc + "o" } },
+                { Keys.P,       new StandardMapping { Control = "\u0010",     Alt = Esc + "p" } },
+                { Keys.Q,       new StandardMapping { Control = "\u0011",     Alt = Esc + "q" } },
+                { Keys.R,       new StandardMapping { Control = "\u0012",     Alt = Esc + "r" } },
+                { Keys.S,       new StandardMapping { Control = "\u0013",     Alt = Esc + "s" } },
+                { Keys.T,       new StandardMapping { Control = "\u0014",     Alt = Esc + "t" } },
+                { Keys.U,       new StandardMapping { Control = "\u0015",     Alt = Esc + "u" } },
+                { Keys.V,       new StandardMapping { Control = "\u0016",     Alt = Esc + "v" } },
+                { Keys.W,       new StandardMapping { Control = "\u0017",     Alt = Esc + "w" } },
+                { Keys.X,       new StandardMapping { Control = "\u0018",     Alt = Esc + "x" } },
+                { Keys.Y,       new StandardMapping { Control = "\u0019",     Alt = Esc + "y" } },
+                { Keys.Z,       new StandardMapping { Control = "\u001a",     Alt = Esc + "z" } },
             };
 
         /// <summary>
@@ -144,10 +147,16 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
         private static readonly Dictionary<Keys, StandardMapping> ApplicationCursorKeysModeTranslations
             = new Dictionary<Keys, StandardMapping>
             {
-                { Keys.Up,       new StandardMapping { Normal = "\u001bOA" } },
-                { Keys.Down,     new StandardMapping { Normal = "\u001bOB" } },
-                { Keys.Right,    new StandardMapping { Normal = "\u001bOC" } },
-                { Keys.Left,     new StandardMapping { Normal = "\u001bOD" } },
+                //
+                // NB. To manually enter this mode, run
+                //     echo -e "\e[?1h"
+                // To disable:
+                //     echo -e "\e[?1l"
+                //
+                { Keys.Up,       new StandardMapping { Normal = Ss3 + "A" } },
+                { Keys.Down,     new StandardMapping { Normal = Ss3 + "B" } },
+                { Keys.Right,    new StandardMapping { Normal = Ss3 + "C" } },
+                { Keys.Left,     new StandardMapping { Normal = Ss3 + "D" } },
             };
 
         public static string ForKey(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyTranslation.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyTranslation.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using VtNetCore.VirtualTerminal;
+
+namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
+{
+    internal static class VirtualTerminalKeyTranslation
+    {
+        /// <summary>
+        /// Mapping that uses 0..1 modifiers.
+        /// </summary>
+        private class StandardMapping
+        {
+            public string Normal { get; set; }
+
+            public string Shift { get; set; }
+
+            public string Control { get; set; }
+
+            public string Alt { get; set; }
+
+            public virtual string Apply(bool alt, bool control, bool shift)
+            {
+                // TODO: Fallthru?
+                if (shift)
+                {
+                    return this.Shift;
+                }
+                else if (control)
+                {
+                    return this.Control;
+                }
+                else if (alt)
+                {
+                    return this.Alt;
+                }
+                else
+                {
+                    return this.Normal;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Standard Xterm key translations.
+        /// </summary>
+        private static readonly Dictionary<Keys, StandardMapping> StandardTranslations =
+            new Dictionary<Keys, StandardMapping>
+            {
+                //
+                // Function keys.
+                //
+                { Keys.F1,       new StandardMapping { Normal = "\u001b[11~", Shift = "\u001b[23~", Control = "\u001b[11~" } },
+                { Keys.F2,       new StandardMapping { Normal = "\u001b[12~", Shift = "\u001b[24~", Control = "\u001b[12~" } },
+                { Keys.F3,       new StandardMapping { Normal = "\u001b[13~", Shift = "\u001b[25~", Control = "\u001b[13~" } },
+                { Keys.F4,       new StandardMapping { Normal = "\u001b[14~", Shift = "\u001b[26~", Control = "\u001b[14~" } },
+                { Keys.F5,       new StandardMapping { Normal = "\u001b[15~", Shift = "\u001b[28~", Control = "\u001b[15~" } },
+                { Keys.F6,       new StandardMapping { Normal = "\u001b[17~", Shift = "\u001b[29~", Control = "\u001b[17~" } },
+                { Keys.F7,       new StandardMapping { Normal = "\u001b[18~", Shift = "\u001b[31~", Control = "\u001b[18~" } },
+                { Keys.F8,       new StandardMapping { Normal = "\u001b[19~", Shift = "\u001b[32~", Control = "\u001b[19~" } },
+                { Keys.F9,       new StandardMapping { Normal = "\u001b[20~", Shift = "\u001b[33~", Control = "\u001b[20~" } },
+                { Keys.F10,      new StandardMapping { Normal = "\u001b[21~", Shift = "\u001b[24~", Control = "\u001b[21~" } },
+                { Keys.F11,      new StandardMapping { Normal = "\u001b[23~", Shift = "\u001b[23~", Control = "\u001b[23~" } },
+                { Keys.F12,      new StandardMapping { Normal = "\u001b[24~", Shift = "\u001b[24~", Control = "\u001b[24~" } },
+
+                //
+                // Arrow keys.
+                //
+                { Keys.Up,       new StandardMapping { Normal = "\u001b[A",   Shift = "\u001bOA", Control = "\u001bOA" } },
+                { Keys.Down,     new StandardMapping { Normal = "\u001b[B",   Shift = "\u001bOB", Control = "\u001bOB" } },
+                { Keys.Right,    new StandardMapping { Normal = "\u001b[C",   Shift = "\u001bOC", Control = "\u001bOC" } },
+                { Keys.Left,     new StandardMapping { Normal = "\u001b[D",   Shift = "\u001bOD", Control = "\u001bOD" } },
+                { Keys.Home,     new StandardMapping { Normal = "\u001b[1~",  Shift = "\u001b[1~" } },
+                { Keys.Insert,   new StandardMapping { Normal = "\u001b[2~" } },
+                { Keys.Delete,   new StandardMapping { Normal = "\u001b[3~",  Shift = "\u001b[3~" } },
+                { Keys.End,      new StandardMapping { Normal = "\u001b[4~",  Shift = "\u001b[4~" } },
+                { Keys.PageUp,   new StandardMapping { Normal = "\u001b[5~",  Shift = "\u001b[5~" } },
+                { Keys.PageDown, new StandardMapping { Normal = "\u001b[6~",  Shift = "\u001b[6~" } },
+
+                //
+                // Main keyboard.
+                //
+                { Keys.Back,    new StandardMapping { Normal = "\u007F",      Shift = "\b",        Control = "\u007F" } },
+                { Keys.Tab,     new StandardMapping { Normal = "\t",          Shift = "\u001b[Z" } },
+                { Keys.Return,  new StandardMapping { Normal = "\r",          Shift = "\r",        Control = "\r" } },
+                { Keys.Escape,  new StandardMapping { Normal = "\u001b\u001b",Shift = "\u001b\u001b", Control = "\u001b\u001b" } },
+                { Keys.Space,   new StandardMapping { Control = "\u0000" } },
+                { Keys.A,       new StandardMapping { Control = "\u0001",     Alt = "\u001ba" } },
+                { Keys.B,       new StandardMapping { Control = "\u0002",     Alt = "\u001bb" } },
+                { Keys.C,       new StandardMapping { Control = "\u0003",     Alt = "\u001bc" } },
+                { Keys.D,       new StandardMapping { Control = "\u0004",     Alt = "\u001bd" } },
+                { Keys.E,       new StandardMapping { Control = "\u0005",     Alt = "\u001be" } },
+                { Keys.F,       new StandardMapping { Control = "\u0006",     Alt = "\u001bf" } },
+                { Keys.G,       new StandardMapping { Control = "\u0007",     Alt = "\u001bg" } },
+                { Keys.H,       new StandardMapping { Control = "\u0008",     Alt = "\u001bh" } },
+                { Keys.I,       new StandardMapping { Control = "\u0009",     Alt = "\u001bi" } },
+                { Keys.J,       new StandardMapping { Control = "\u000a",     Alt = "\u001bj" } },
+                { Keys.K,       new StandardMapping { Control = "\u000b",     Alt = "\u001bk" } },
+                { Keys.L,       new StandardMapping { Control = "\u000c",     Alt = "\u001bl" } },
+                { Keys.M,       new StandardMapping { Control = "\u000d",     Alt = "\u001bm" } },
+                { Keys.N,       new StandardMapping { Control = "\u000e",     Alt = "\u001bn" } },
+                { Keys.O,       new StandardMapping { Control = "\u000f",     Alt = "\u001bo" } },
+                { Keys.P,       new StandardMapping { Control = "\u0010",     Alt = "\u001bp" } },
+                { Keys.Q,       new StandardMapping { Control = "\u0011",     Alt = "\u001bq" } },
+                { Keys.R,       new StandardMapping { Control = "\u0012",     Alt = "\u001br" } },
+                { Keys.S,       new StandardMapping { Control = "\u0013",     Alt = "\u001bs" } },
+                { Keys.T,       new StandardMapping { Control = "\u0014",     Alt = "\u001bt" } },
+                { Keys.U,       new StandardMapping { Control = "\u0015",     Alt = "\u001bu" } },
+                { Keys.V,       new StandardMapping { Control = "\u0016",     Alt = "\u001bv" } },
+                { Keys.W,       new StandardMapping { Control = "\u0017",     Alt = "\u001bw" } },
+                { Keys.X,       new StandardMapping { Control = "\u0018",     Alt = "\u001bx" } },
+                { Keys.Y,       new StandardMapping { Control = "\u0019",     Alt = "\u001by" } },
+                { Keys.Z,       new StandardMapping { Control = "\u001a",     Alt = "\u001bz" } },
+            };
+
+        /// <summary>
+        /// Extra translations to apply in application cursor keys mode.
+        /// </summary>
+        private static readonly Dictionary<Keys, StandardMapping> ApplicationCursorKeysModeTranslations
+            = new Dictionary<Keys, StandardMapping>
+            {
+                { Keys.Up,       new StandardMapping { Normal = "\u001bOA" } },
+                { Keys.Down,     new StandardMapping { Normal = "\u001bOB" } },
+                { Keys.Right,    new StandardMapping { Normal = "\u001bOC" } },
+                { Keys.Left,     new StandardMapping { Normal = "\u001bOD" } },
+            };
+
+        public static string ForKey(
+            Keys keyCode,
+            bool alt,
+            bool control,
+            bool shift,
+            bool applicationCursorKeysMode)
+        {
+            Debug.Assert((keyCode & Keys.KeyCode) == keyCode, "No modifiers");
+
+            if (alt && control)
+            {
+                //
+                // AltGr - that's probably a composition.
+                //
+                return null;
+            }
+            if (applicationCursorKeysMode &&
+                ApplicationCursorKeysModeTranslations.TryGetValue(keyCode, out var appMapping) &&
+                appMapping.Apply(alt, control, shift) is string appSequence)
+            {
+                return appSequence;
+            }
+            else if (
+                StandardTranslations.TryGetValue(keyCode, out var stdMapping) &&
+                stdMapping.Apply(alt, control, shift) is string stdSequence)
+            {
+                return stdSequence;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyTranslation.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyTranslation.cs
@@ -1,4 +1,25 @@
-﻿using System;
+﻿//
+// Copyright 2021 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyTranslation.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyTranslation.cs
@@ -26,7 +26,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
 
             public virtual string Apply(bool alt, bool control, bool shift)
             {
-                // TODO: Fallthru?
                 if (shift)
                 {
                     return this.Shift;
@@ -55,41 +54,41 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
                 //
                 // Function keys.
                 //
-                { Keys.F1,       new StandardMapping { Normal = "\u001b[11~", Shift = "\u001b[23~", Control = "\u001b[11~" } },
-                { Keys.F2,       new StandardMapping { Normal = "\u001b[12~", Shift = "\u001b[24~", Control = "\u001b[12~" } },
-                { Keys.F3,       new StandardMapping { Normal = "\u001b[13~", Shift = "\u001b[25~", Control = "\u001b[13~" } },
-                { Keys.F4,       new StandardMapping { Normal = "\u001b[14~", Shift = "\u001b[26~", Control = "\u001b[14~" } },
-                { Keys.F5,       new StandardMapping { Normal = "\u001b[15~", Shift = "\u001b[28~", Control = "\u001b[15~" } },
-                { Keys.F6,       new StandardMapping { Normal = "\u001b[17~", Shift = "\u001b[29~", Control = "\u001b[17~" } },
-                { Keys.F7,       new StandardMapping { Normal = "\u001b[18~", Shift = "\u001b[31~", Control = "\u001b[18~" } },
-                { Keys.F8,       new StandardMapping { Normal = "\u001b[19~", Shift = "\u001b[32~", Control = "\u001b[19~" } },
-                { Keys.F9,       new StandardMapping { Normal = "\u001b[20~", Shift = "\u001b[33~", Control = "\u001b[20~" } },
-                { Keys.F10,      new StandardMapping { Normal = "\u001b[21~", Shift = "\u001b[24~", Control = "\u001b[21~" } },
-                { Keys.F11,      new StandardMapping { Normal = "\u001b[23~", Shift = "\u001b[23~", Control = "\u001b[23~" } },
-                { Keys.F12,      new StandardMapping { Normal = "\u001b[24~", Shift = "\u001b[24~", Control = "\u001b[24~" } },
+                { Keys.F1,       new StandardMapping { Normal = "\u001b[11~", Shift = "\u001b[23~", Control = "\u001b[11~", Alt = "\u001b\u001b[11~" } },
+                { Keys.F2,       new StandardMapping { Normal = "\u001b[12~", Shift = "\u001b[24~", Control = "\u001b[12~", Alt = "\u001b\u001b[12~" } },
+                { Keys.F3,       new StandardMapping { Normal = "\u001b[13~", Shift = "\u001b[25~", Control = "\u001b[13~", Alt = "\u001b\u001b[13~" } },
+                { Keys.F4,       new StandardMapping { Normal = "\u001b[14~", Shift = "\u001b[26~", Control = "\u001b[14~", Alt = "\u001b\u001b[14~" } },
+                { Keys.F5,       new StandardMapping { Normal = "\u001b[15~", Shift = "\u001b[28~", Control = "\u001b[15~", Alt = "\u001b\u001b[15~" } },
+                { Keys.F6,       new StandardMapping { Normal = "\u001b[17~", Shift = "\u001b[29~", Control = "\u001b[17~", Alt = "\u001b\u001b[17~" } },
+                { Keys.F7,       new StandardMapping { Normal = "\u001b[18~", Shift = "\u001b[31~", Control = "\u001b[18~", Alt = "\u001b\u001b[18~" } },
+                { Keys.F8,       new StandardMapping { Normal = "\u001b[19~", Shift = "\u001b[32~", Control = "\u001b[19~", Alt = "\u001b\u001b[19~" } },
+                { Keys.F9,       new StandardMapping { Normal = "\u001b[20~", Shift = "\u001b[33~", Control = "\u001b[20~", Alt = "\u001b\u001b[20~" } },
+                { Keys.F10,      new StandardMapping { Normal = "\u001b[21~", Shift = "\u001b[24~", Control = "\u001b[21~", Alt = "\u001b\u001b[21~" } },
+                { Keys.F11,      new StandardMapping { Normal = "\u001b[23~", Shift = "\u001b[23~", Control = "\u001b[23~", Alt = "\u001b\u001b[23~" } },
+                { Keys.F12,      new StandardMapping { Normal = "\u001b[24~", Shift = "\u001b[24~", Control = "\u001b[24~", Alt = "\u001b\u001b[24~" } },
 
                 //
                 // Arrow keys.
                 //
-                { Keys.Up,       new StandardMapping { Normal = "\u001b[A",   Shift = "\u001bOA", Control = "\u001bOA" } },
-                { Keys.Down,     new StandardMapping { Normal = "\u001b[B",   Shift = "\u001bOB", Control = "\u001bOB" } },
-                { Keys.Right,    new StandardMapping { Normal = "\u001b[C",   Shift = "\u001bOC", Control = "\u001bOC" } },
-                { Keys.Left,     new StandardMapping { Normal = "\u001b[D",   Shift = "\u001bOD", Control = "\u001bOD" } },
-                { Keys.Home,     new StandardMapping { Normal = "\u001b[1~",  Shift = "\u001b[1~" } },
-                { Keys.Insert,   new StandardMapping { Normal = "\u001b[2~" } },
-                { Keys.Delete,   new StandardMapping { Normal = "\u001b[3~",  Shift = "\u001b[3~" } },
-                { Keys.End,      new StandardMapping { Normal = "\u001b[4~",  Shift = "\u001b[4~" } },
-                { Keys.PageUp,   new StandardMapping { Normal = "\u001b[5~",  Shift = "\u001b[5~" } },
-                { Keys.PageDown, new StandardMapping { Normal = "\u001b[6~",  Shift = "\u001b[6~" } },
+                { Keys.Up,       new StandardMapping { Normal = "\u001b[A",   Shift = "\u001bOA", Control = "\u001bOA",     Alt = "\u001b\u001b[A" } },
+                { Keys.Down,     new StandardMapping { Normal = "\u001b[B",   Shift = "\u001bOB", Control = "\u001bOB",     Alt = "\u001b\u001b[B" } },
+                { Keys.Right,    new StandardMapping { Normal = "\u001b[C",   Shift = "\u001bOC", Control = "\u001bOC",     Alt = "\u001b\u001b[C" } },
+                { Keys.Left,     new StandardMapping { Normal = "\u001b[D",   Shift = "\u001bOD", Control = "\u001bOD",     Alt = "\u001b\u001b[D" } },
+                { Keys.Home,     new StandardMapping { Normal = "\u001b[1~",  Shift = "\u001b[1~",                          Alt = "\u001b\u001b[1~" } },
+                { Keys.Insert,   new StandardMapping { Normal = "\u001b[2~",                                                Alt = "\u001b\u001b[2~" } },
+                { Keys.Delete,   new StandardMapping { Normal = "\u001b[3~",  Shift = "\u001b[3~",                          Alt = "\u001b\u001b[3~" } },
+                { Keys.End,      new StandardMapping { Normal = "\u001b[4~",  Shift = "\u001b[4~",                          Alt = "\u001b\u001b[4~" } },
+                { Keys.PageUp,   new StandardMapping { Normal = "\u001b[5~",  Shift = "\u001b[5~",                          Alt = "\u001b\u001b[5~" } },
+                { Keys.PageDown, new StandardMapping { Normal = "\u001b[6~",  Shift = "\u001b[6~",                          Alt = "\u001b\u001b[6~" } },
 
                 //
                 // Main keyboard.
                 //
-                { Keys.Back,    new StandardMapping { Normal = "\u007F",      Shift = "\b",        Control = "\u007F" } },
-                { Keys.Tab,     new StandardMapping { Normal = "\t",          Shift = "\u001b[Z" } },
-                { Keys.Return,  new StandardMapping { Normal = "\r",          Shift = "\r",        Control = "\r" } },
+                { Keys.Back,    new StandardMapping { Normal = "\u007F",      Shift = "\b",           Control = "\u007F" } },
+                { Keys.Tab,     new StandardMapping { Normal = "\t",          Shift = "\u001b[Z",     } },
+                { Keys.Return,  new StandardMapping { Normal = "\r",          Shift = "\r",           Control = "\r",       Alt = "\u001b\r" } },
                 { Keys.Escape,  new StandardMapping { Normal = "\u001b\u001b",Shift = "\u001b\u001b", Control = "\u001b\u001b" } },
-                { Keys.Space,   new StandardMapping { Control = "\u0000" } },
+                { Keys.Space,   new StandardMapping { Control = "\u0000",                                                   Alt = "\u001b " } },
                 { Keys.A,       new StandardMapping { Control = "\u0001",     Alt = "\u001ba" } },
                 { Keys.B,       new StandardMapping { Control = "\u0002",     Alt = "\u001bb" } },
                 { Keys.C,       new StandardMapping { Control = "\u0003",     Alt = "\u001bc" } },

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Google.Solutions.IapDesktop.Extensions.Shell.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Google.Solutions.IapDesktop.Extensions.Shell.csproj
@@ -94,6 +94,7 @@
       <DependentUpon>VirtualTerminal.cs</DependentUpon>
     </Compile>
     <Compile Include="Controls\VirtualTerminalKeyHandler.cs" />
+    <Compile Include="Controls\VirtualTerminalKeyTranslation.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\Resources.Designer.cs">


### PR DESCRIPTION
* Use custom key translation table instead of relying on vtnetcore to do key translation
* Remove workarounds that were required for using vtnetcore key translations
* Extend unit tests to cover relevant key translations

This lays the groundwork for #482