### PR TITLE
b/189199398 Extend keyboard translations to support modifyOtherKeys mode

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminal.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminal.cs
@@ -182,7 +182,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableShiftInsert = false;
             this.terminal.SimulateKey(Keys.Shift | Keys.Insert);
 
-            Assert.AreEqual("", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[2;2~", this.sendData.ToString());
         }
 
         //---------------------------------------------------------------------
@@ -291,7 +291,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.SimulateKey(Keys.Control | Keys.Insert);
 
             Assert.AreEqual("", Clipboard.GetText());
-            Assert.AreEqual("", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[2;5~", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
 
@@ -325,7 +325,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.SimulateKey(Keys.Control | Keys.Insert);
 
             Assert.AreEqual("", Clipboard.GetText());
-            Assert.AreEqual("", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[2;5~", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
 
@@ -531,7 +531,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableShiftLeftRight = false;
             this.terminal.SimulateKey(Keys.Shift | Keys.Left);
 
-            Assert.AreEqual($"{Esc}OD", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2D", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
 
@@ -541,7 +541,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableShiftLeftRight = false;
             this.terminal.SimulateKey(Keys.Shift | Keys.Right);
 
-            Assert.AreEqual($"{Esc}OC", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2C", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
 
@@ -590,7 +590,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableShiftUpDown = false;
             this.terminal.SimulateKey(Keys.Shift | Keys.Down);
 
-            Assert.AreEqual($"{Esc}OB", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2B", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
 
@@ -600,7 +600,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableShiftUpDown = false;
             this.terminal.SimulateKey(Keys.Shift | Keys.Up);
 
-            Assert.AreEqual($"{Esc}OA", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2A", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
 
@@ -666,7 +666,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlLeftRight = false;
             this.terminal.SimulateKey(Keys.Control | Keys.Right);
 
-            Assert.AreEqual($"{Esc}OC", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5C", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
 
@@ -676,7 +676,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlLeftRight = false;
             this.terminal.SimulateKey(Keys.Control | Keys.Left);
 
-            Assert.AreEqual($"{Esc}OD", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5D", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
 
@@ -752,7 +752,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlUpDown = false;
             this.terminal.SimulateKey(Keys.Control | Keys.Up);
 
-            Assert.AreEqual($"{Esc}OA", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5A", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
 
@@ -762,7 +762,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlUpDown = false;
             this.terminal.SimulateKey(Keys.Control | Keys.Down);
 
-            Assert.AreEqual($"{Esc}OB", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5B", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
 
@@ -834,22 +834,22 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         }
 
         [Test]
-        public void WhenControlHomeEndDisabled_ThenTypingControlHomeIsIgnored()
+        public void WhenControlHomeEndDisabled_ThenTypingControlHomeSendsKeystroke()
         {
             this.terminal.EnableCtrlHomeEnd = false;
             this.terminal.SimulateKey(Keys.Control | Keys.Home);
 
-            Assert.AreEqual("", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5H", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
 
         [Test]
-        public void WhenControlHomeEndDisabled_ThenTypingControlEndIsIgnored()
+        public void WhenControlHomeEndDisabled_ThenTypingControlEndSendsKeystroke()
         {
             this.terminal.EnableCtrlHomeEnd = false;
             this.terminal.SimulateKey(Keys.Control | Keys.End);
 
-            Assert.AreEqual("", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5F", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminalKeyHandler.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminalKeyHandler.cs
@@ -70,7 +70,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F1 | Keys.Alt));
-            Assert.AreEqual($"{Esc}[1;9P", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;3P", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -90,7 +90,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F2 | Keys.Alt));
-            Assert.AreEqual($"{Esc}[1;9Q", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;3Q", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -110,7 +110,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F3 | Keys.Alt));
-            Assert.AreEqual($"{Esc}[1;9R", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;3R", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -130,7 +130,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F4 | Keys.Alt));
-            Assert.AreEqual($"{Esc}[1;9S", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;3S", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -150,7 +150,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F5 | Keys.Alt));
-            Assert.AreEqual($"{Esc}[15;9~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[15;3~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -170,7 +170,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F6 | Keys.Alt));
-            Assert.AreEqual($"{Esc}[17;9~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[17;3~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -190,7 +190,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F7 | Keys.Alt));
-            Assert.AreEqual($"{Esc}[18;9~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[18;3~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -210,7 +210,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F8 | Keys.Alt));
-            Assert.AreEqual($"{Esc}[19;9~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[19;3~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -230,7 +230,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F9 | Keys.Alt));
-            Assert.AreEqual($"{Esc}[20;9~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[20;3~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -250,7 +250,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F10 | Keys.Alt));
-            Assert.AreEqual($"{Esc}[21;9~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[21;3~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -270,7 +270,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F11 | Keys.Alt));
-            Assert.AreEqual($"{Esc}[23;9~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[23;3~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -290,7 +290,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F12 | Keys.Alt));
-            Assert.AreEqual($"{Esc}[24;9~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[24;3~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -306,15 +306,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Up | Keys.Shift));
-            Assert.AreEqual($"{Esc}OA", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2A", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Up | Keys.Control));
-            Assert.AreEqual($"{Esc}OA", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5A", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Up | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[A", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;3A", this.sendData.ToString());
             this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
@@ -331,15 +331,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Down | Keys.Shift));
-            Assert.AreEqual($"{Esc}OB", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2B", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Down | Keys.Control));
-            Assert.AreEqual($"{Esc}OB", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5B", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Down | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[B", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;3B", this.sendData.ToString());
             this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
@@ -356,15 +356,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Right | Keys.Shift));
-            Assert.AreEqual($"{Esc}OC", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2C", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Right | Keys.Control));
-            Assert.AreEqual($"{Esc}OC", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5C", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Right | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[C", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;3C", this.sendData.ToString());
             this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
@@ -381,15 +381,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Left | Keys.Shift));
-            Assert.AreEqual($"{Esc}OD", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2D", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Left | Keys.Control));
-            Assert.AreEqual($"{Esc}OD", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5D", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Left | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[D", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;3D", this.sendData.ToString());
             this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
@@ -402,23 +402,24 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         public void Home()
         {
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home));
-            Assert.AreEqual($"{Esc}[1~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[H", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home | Keys.Shift));
-            Assert.AreEqual($"{Esc}[1~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2H", this.sendData.ToString());
             this.sendData.Clear();
 
-            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Home | Keys.Control));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home | Keys.Control));
+            Assert.AreEqual($"{Esc}[1;5H", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[1~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;3H", this.sendData.ToString());
             this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Home));
-            Assert.AreEqual($"{Esc}[1~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}OH", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -426,23 +427,24 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         public void End()
         {
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.End));
-            Assert.AreEqual($"{Esc}[4~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[F", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.End | Keys.Shift));
-            Assert.AreEqual($"{Esc}[4~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2F", this.sendData.ToString());
             this.sendData.Clear();
 
-            Assert.IsFalse(this.keyHandler.KeyDown(Keys.End | Keys.Control));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.End | Keys.Control));
+            Assert.AreEqual($"{Esc}[1;5F", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.End | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[4~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;3F", this.sendData.ToString());
             this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.End));
-            Assert.AreEqual($"{Esc}[4~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}OF", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -453,14 +455,16 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[2~", this.sendData.ToString());
             this.sendData.Clear();
 
-            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Insert | Keys.Shift));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Insert | Keys.Shift));
+            Assert.AreEqual($"{Esc}[2;2~", this.sendData.ToString());
             this.sendData.Clear();
 
-            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Insert | Keys.Control));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Insert | Keys.Control));
+            Assert.AreEqual($"{Esc}[2;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Insert | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[2~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[2;3~", this.sendData.ToString());
             this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
@@ -477,14 +481,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Delete | Keys.Shift));
-            Assert.AreEqual($"{Esc}[3~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[3;2~", this.sendData.ToString());
             this.sendData.Clear();
 
-            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Delete | Keys.Control));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Delete | Keys.Control));
+            Assert.AreEqual($"{Esc}[3;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Delete | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[3~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[3;3~", this.sendData.ToString());
             this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
@@ -501,14 +506,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageUp | Keys.Shift));
-            Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[5;2~", this.sendData.ToString());
             this.sendData.Clear();
 
-            Assert.IsFalse(this.keyHandler.KeyDown(Keys.PageUp | Keys.Control));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageUp | Keys.Control));
+            Assert.AreEqual($"{Esc}[5;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageUp | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[5~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[5;3~", this.sendData.ToString());
             this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
@@ -525,14 +531,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Prior | Keys.Shift));
-            Assert.AreEqual($"{Esc}[5~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[5;2~", this.sendData.ToString());
             this.sendData.Clear();
 
-            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Prior | Keys.Control));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Prior | Keys.Control));
+            Assert.AreEqual($"{Esc}[5;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Prior | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[5~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[5;3~", this.sendData.ToString());
             this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
@@ -549,14 +556,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageDown | Keys.Shift));
-            Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[6;2~", this.sendData.ToString());
             this.sendData.Clear();
 
-            Assert.IsFalse(this.keyHandler.KeyDown(Keys.PageDown | Keys.Control));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageDown | Keys.Control));
+            Assert.AreEqual($"{Esc}[6;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.PageDown | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[6~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[6;3~", this.sendData.ToString());
             this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
@@ -573,14 +581,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Next | Keys.Shift));
-            Assert.AreEqual($"{Esc}[6~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[6;2~", this.sendData.ToString());
             this.sendData.Clear();
 
-            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Next | Keys.Control));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Next | Keys.Control));
+            Assert.AreEqual($"{Esc}[6;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Next | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[6~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[6;3~", this.sendData.ToString());
             this.sendData.Clear();
 
             this.controller.EnableApplicationCursorKeys(true);
@@ -601,14 +610,16 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Back | Keys.Shift));
-            Assert.AreEqual($"\b", this.sendData.ToString());
+            Assert.AreEqual($"\u007f", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Back | Keys.Control));
-            Assert.AreEqual("\u007f", this.sendData.ToString());
+            Assert.AreEqual("\b", this.sendData.ToString());
             this.sendData.Clear();
 
-            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Back | Keys.Alt));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Back | Keys.Alt));
+            Assert.AreEqual($"{Esc}\u007f", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -622,7 +633,25 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.AreEqual($"{Esc}[Z", this.sendData.ToString());
             this.sendData.Clear();
 
-            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Tab | Keys.Control));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Tab | Keys.Control));
+            Assert.AreEqual("\t", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.Tab | Keys.Alt));
+
+            this.controller.ModifyOtherKeys = ModifyOtherKeysMode.EnabledWithExceptions;
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Tab));
+            Assert.AreEqual("\t", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Tab | Keys.Shift));
+            Assert.AreEqual($"{Esc}[Z", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Tab | Keys.Control));
+            Assert.AreEqual($"{Esc}[27;5;9", this.sendData.ToString());
+            this.sendData.Clear();
 
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.Tab | Keys.Alt));
         }
@@ -644,6 +673,24 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Return | Keys.Alt));
             Assert.AreEqual($"{Esc}\r", this.sendData.ToString());
+            this.sendData.Clear();
+
+            this.controller.ModifyOtherKeys = ModifyOtherKeysMode.EnabledWithExceptions;
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Return));
+            Assert.AreEqual("\r", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Return | Keys.Shift));
+            Assert.AreEqual($"{Esc}[27;2;13", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Return | Keys.Control));
+            Assert.AreEqual($"{Esc}[27;5;13", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.Return | Keys.Alt));
+            Assert.AreEqual($"{Esc}[27;3;13", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -671,15 +718,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         public void Escape()
         {
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Escape));
-            Assert.AreEqual($"{Esc}{Esc}", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Escape | Keys.Shift));
-            Assert.AreEqual($"{Esc}{Esc}", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.Escape | Keys.Control));
-            Assert.AreEqual($"{Esc}{Esc}", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.Escape | Keys.Alt));
@@ -747,6 +794,18 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.D0 | Keys.Alt));
             Assert.AreEqual($"{Esc}0", this.sendData.ToString());
             this.sendData.Clear();
+
+            this.controller.ModifyOtherKeys = ModifyOtherKeysMode.EnabledWithExceptions;
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D0));
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D0 | Keys.Shift));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D0 | Keys.Control));
+            Assert.AreEqual($"{Esc}[27;5;48", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D0 | Keys.Alt));
+            Assert.AreEqual($"{Esc}0", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -755,6 +814,18 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.D1));
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.D1 | Keys.Shift));
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.D1 | Keys.Control));
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D1 | Keys.Alt));
+            Assert.AreEqual($"{Esc}1", this.sendData.ToString());
+            this.sendData.Clear();
+
+            this.controller.ModifyOtherKeys = ModifyOtherKeysMode.EnabledWithExceptions;
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D1));
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D1 | Keys.Shift));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D1 | Keys.Control));
+            Assert.AreEqual($"{Esc}[27;5;49", this.sendData.ToString());
+            this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.D1 | Keys.Alt));
             Assert.AreEqual($"{Esc}1", this.sendData.ToString());
@@ -774,11 +845,37 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.D2 | Keys.Alt));
             Assert.AreEqual($"{Esc}2", this.sendData.ToString());
             this.sendData.Clear();
+
+            this.controller.ModifyOtherKeys = ModifyOtherKeysMode.EnabledWithExceptions;
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D2));
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D2 | Keys.Shift));
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D2 | Keys.Control));
+            Assert.AreEqual($"\u0000", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D2 | Keys.Alt));
+            Assert.AreEqual($"{Esc}2", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
         public void D3()
         {
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D3));
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D3 | Keys.Shift));
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D3 | Keys.Control));
+            Assert.AreEqual($"{Esc}", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D3 | Keys.Alt));
+            Assert.AreEqual($"{Esc}3", this.sendData.ToString());
+            this.sendData.Clear();
+
+            this.controller.ModifyOtherKeys = ModifyOtherKeysMode.EnabledWithExceptions;
+
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.D3));
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.D3 | Keys.Shift));
 
@@ -804,11 +901,37 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.D4 | Keys.Alt));
             Assert.AreEqual($"{Esc}4", this.sendData.ToString());
             this.sendData.Clear();
+
+            this.controller.ModifyOtherKeys = ModifyOtherKeysMode.EnabledWithExceptions;
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D4));
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D4 | Keys.Shift));
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D4 | Keys.Control));
+            Assert.AreEqual($"\u001c", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D4 | Keys.Alt));
+            Assert.AreEqual($"{Esc}4", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
         public void D5()
         {
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D5));
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D5 | Keys.Shift));
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D5 | Keys.Control));
+            Assert.AreEqual($"\u001d", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D5 | Keys.Alt));
+            Assert.AreEqual($"{Esc}5", this.sendData.ToString());
+            this.sendData.Clear();
+
+            this.controller.ModifyOtherKeys = ModifyOtherKeysMode.EnabledWithExceptions;
+
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.D5));
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.D5 | Keys.Shift));
 
@@ -834,11 +957,37 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.D6 | Keys.Alt));
             Assert.AreEqual($"{Esc}6", this.sendData.ToString());
             this.sendData.Clear();
+
+            this.controller.ModifyOtherKeys = ModifyOtherKeysMode.EnabledWithExceptions;
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D6));
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D6 | Keys.Shift));
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D6 | Keys.Control));
+            Assert.AreEqual($"\u001e", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D6 | Keys.Alt));
+            Assert.AreEqual($"{Esc}6", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
         public void D7()
         {
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D7));
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D7 | Keys.Shift));
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D7 | Keys.Control));
+            Assert.AreEqual($"\u001f", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D7 | Keys.Alt));
+            Assert.AreEqual($"{Esc}7", this.sendData.ToString());
+            this.sendData.Clear();
+
+            this.controller.ModifyOtherKeys = ModifyOtherKeysMode.EnabledWithExceptions;
+
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.D7));
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.D7 | Keys.Shift));
 
@@ -864,6 +1013,19 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.D8 | Keys.Alt));
             Assert.AreEqual($"{Esc}8", this.sendData.ToString());
             this.sendData.Clear();
+
+            this.controller.ModifyOtherKeys = ModifyOtherKeysMode.EnabledWithExceptions;
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D8));
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D8 | Keys.Shift));
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D8 | Keys.Control));
+            Assert.AreEqual($"\u007f", this.sendData.ToString());
+            this.sendData.Clear();
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D8 | Keys.Alt));
+            Assert.AreEqual($"{Esc}8", this.sendData.ToString());
+            this.sendData.Clear();
         }
 
         [Test]
@@ -872,6 +1034,18 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.D9));
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.D9 | Keys.Shift));
             Assert.IsFalse(this.keyHandler.KeyDown(Keys.D9 | Keys.Control));
+
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D9 | Keys.Alt));
+            Assert.AreEqual($"{Esc}9", this.sendData.ToString());
+            this.sendData.Clear();
+
+            this.controller.ModifyOtherKeys = ModifyOtherKeysMode.EnabledWithExceptions;
+
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D9));
+            Assert.IsFalse(this.keyHandler.KeyDown(Keys.D9 | Keys.Shift));
+            Assert.IsTrue(this.keyHandler.KeyDown(Keys.D9 | Keys.Control));
+            Assert.AreEqual($"{Esc}[27;5;57", this.sendData.ToString());
+            this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.D9 | Keys.Alt));
             Assert.AreEqual($"{Esc}9", this.sendData.ToString());

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminalKeyHandler.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminalKeyHandler.cs
@@ -19,16 +19,10 @@
 // under the License.
 //
 
-using Google.Solutions.IapDesktop.Application.Test;
 using Google.Solutions.IapDesktop.Extensions.Shell.Controls;
 using NUnit.Framework;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Drawing;
 using System.Globalization;
-using System.Linq;
 using System.Text;
-using System.Threading;
 using System.Windows.Forms;
 using VtNetCore.VirtualTerminal;
 
@@ -37,7 +31,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
     [TestFixture]
     public class TestVirtualTerminalKeyHandler
     {
-        private readonly string Esc = "\u001b";
+        private static readonly string Esc = "\u001b";
+        private static readonly string Ss3 = Esc + "O";
 
         private VirtualTerminalController controller;
         private VirtualTerminalKeyHandler keyHandler;
@@ -63,19 +58,19 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         public void F1()
         {
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F1));
-            Assert.AreEqual($"{Esc}[11~", this.sendData.ToString());
+            Assert.AreEqual($"{Ss3}P", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F1 | Keys.Shift));
-            Assert.AreEqual($"{Esc}[23~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2P", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F1 | Keys.Control));
-            Assert.AreEqual($"{Esc}[11~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5P", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F1 | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[11~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;9P", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -83,19 +78,19 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         public void F2()
         {
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F2));
-            Assert.AreEqual($"{Esc}[12~", this.sendData.ToString());
+            Assert.AreEqual($"{Ss3}Q", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F2 | Keys.Shift));
-            Assert.AreEqual($"{Esc}[24~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2Q", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F2 | Keys.Control));
-            Assert.AreEqual($"{Esc}[12~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5Q", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F2 | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[12~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;9Q", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -103,19 +98,19 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         public void F3()
         {
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F3));
-            Assert.AreEqual($"{Esc}[13~", this.sendData.ToString());
+            Assert.AreEqual($"{Ss3}R", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F3 | Keys.Shift));
-            Assert.AreEqual($"{Esc}[25~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2R", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F3 | Keys.Control));
-            Assert.AreEqual($"{Esc}[13~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5R", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F3 | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[13~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;9R", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -123,19 +118,19 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         public void F4()
         {
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F4));
-            Assert.AreEqual($"{Esc}[14~", this.sendData.ToString());
+            Assert.AreEqual($"{Ss3}S", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F4 | Keys.Shift));
-            Assert.AreEqual($"{Esc}[26~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;2S", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F4 | Keys.Control));
-            Assert.AreEqual($"{Esc}[14~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;5S", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F4 | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[14~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[1;9S", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -147,15 +142,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F5 | Keys.Shift));
-            Assert.AreEqual($"{Esc}[28~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[15;2~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F5 | Keys.Control));
-            Assert.AreEqual($"{Esc}[15~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[15;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F5 | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[15~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[15;9~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -167,15 +162,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F6 | Keys.Shift));
-            Assert.AreEqual($"{Esc}[29~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[17;2~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F6 | Keys.Control));
-            Assert.AreEqual($"{Esc}[17~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[17;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F6 | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[17~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[17;9~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -187,15 +182,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F7 | Keys.Shift));
-            Assert.AreEqual($"{Esc}[31~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[18;2~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F7 | Keys.Control));
-            Assert.AreEqual($"{Esc}[18~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[18;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F7 | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[18~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[18;9~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -207,15 +202,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F8 | Keys.Shift));
-            Assert.AreEqual($"{Esc}[32~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[19;2~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F8 | Keys.Control));
-            Assert.AreEqual($"{Esc}[19~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[19;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F8 | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[19~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[19;9~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -227,15 +222,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F9 | Keys.Shift));
-            Assert.AreEqual($"{Esc}[33~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[20;2~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F9 | Keys.Control));
-            Assert.AreEqual($"{Esc}[20~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[20;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F9 | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[20~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[20;9~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -247,15 +242,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F10 | Keys.Shift));
-            Assert.AreEqual($"{Esc}[24~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[21;2~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F10 | Keys.Control));
-            Assert.AreEqual($"{Esc}[21~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[21;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F10 | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[21~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[21;9~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -267,15 +262,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F11 | Keys.Shift));
-            Assert.AreEqual($"{Esc}[23~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[23;2~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F11 | Keys.Control));
-            Assert.AreEqual($"{Esc}[23~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[23;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F11 | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[23~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[23;9~", this.sendData.ToString());
             this.sendData.Clear();
         }
 
@@ -287,15 +282,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F12 | Keys.Shift));
-            Assert.AreEqual($"{Esc}[24~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[24;2~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F12 | Keys.Control));
-            Assert.AreEqual($"{Esc}[24~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[24;5~", this.sendData.ToString());
             this.sendData.Clear();
 
             Assert.IsTrue(this.keyHandler.KeyDown(Keys.F12 | Keys.Alt));
-            Assert.AreEqual($"{Esc}{Esc}[24~", this.sendData.ToString());
+            Assert.AreEqual($"{Esc}[24;9~", this.sendData.ToString());
             this.sendData.Clear();
         }
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyHandler.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyHandler.cs
@@ -84,7 +84,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
                 alt, 
                 control, 
                 shift,
-                this.controller.CursorState.ApplicationCursorKeysMode);
+                this.controller.CursorState.ApplicationCursorKeysMode,
+                this.controller.ModifyOtherKeys);
 
             if (translation != null)
             {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyTranslation.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyTranslation.cs
@@ -67,9 +67,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
             }
         }
 
-        private static string Esc = "\u001b";
-        private static string Ss3 = Esc + "O";
-        private static string DecimalSeparator = CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
+        private static readonly string Esc = "\u001b";
+        private static readonly string Ss3 = Esc + "O";
+        private static readonly string DecimalSeparator = CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
 
         /// <summary>
         /// Standard Xterm key translations.
@@ -80,18 +80,22 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
                 //
                 // Function keys.
                 //
-                { Keys.F1,       new StandardMapping { Normal = Esc + "[11~", Shift = Esc + "[23~", Control = Esc + "[11~", Alt = Esc + Esc + "[11~" } },
-                { Keys.F2,       new StandardMapping { Normal = Esc + "[12~", Shift = Esc + "[24~", Control = Esc + "[12~", Alt = Esc + Esc + "[12~" } },
-                { Keys.F3,       new StandardMapping { Normal = Esc + "[13~", Shift = Esc + "[25~", Control = Esc + "[13~", Alt = Esc + Esc + "[13~" } },
-                { Keys.F4,       new StandardMapping { Normal = Esc + "[14~", Shift = Esc + "[26~", Control = Esc + "[14~", Alt = Esc + Esc + "[14~" } },
-                { Keys.F5,       new StandardMapping { Normal = Esc + "[15~", Shift = Esc + "[28~", Control = Esc + "[15~", Alt = Esc + Esc + "[15~" } },
-                { Keys.F6,       new StandardMapping { Normal = Esc + "[17~", Shift = Esc + "[29~", Control = Esc + "[17~", Alt = Esc + Esc + "[17~" } },
-                { Keys.F7,       new StandardMapping { Normal = Esc + "[18~", Shift = Esc + "[31~", Control = Esc + "[18~", Alt = Esc + Esc + "[18~" } },
-                { Keys.F8,       new StandardMapping { Normal = Esc + "[19~", Shift = Esc + "[32~", Control = Esc + "[19~", Alt = Esc + Esc + "[19~" } },
-                { Keys.F9,       new StandardMapping { Normal = Esc + "[20~", Shift = Esc + "[33~", Control = Esc + "[20~", Alt = Esc + Esc + "[20~" } },
-                { Keys.F10,      new StandardMapping { Normal = Esc + "[21~", Shift = Esc + "[24~", Control = Esc + "[21~", Alt = Esc + Esc + "[21~" } },
-                { Keys.F11,      new StandardMapping { Normal = Esc + "[23~", Shift = Esc + "[23~", Control = Esc + "[23~", Alt = Esc + Esc + "[23~" } },
-                { Keys.F12,      new StandardMapping { Normal = Esc + "[24~", Shift = Esc + "[24~", Control = Esc + "[24~", Alt = Esc + Esc + "[24~" } },
+                // Note that F1 through F4 are prefixed with SS3 , while the other keys are
+                // prefixed with CSI. Older versions of xterm implement different escape
+                // sequences for F1 through F4, with a CSI prefix.
+                //
+                { Keys.F1,       new StandardMapping { Normal = Ss3 + "P",    Shift = Esc + "[1;2P",  Control = Esc + "[1;5P",  Alt = Esc + "[1;9P" } },
+                { Keys.F2,       new StandardMapping { Normal = Ss3 + "Q",    Shift = Esc + "[1;2Q",  Control = Esc + "[1;5Q",  Alt = Esc + "[1;9Q" } },
+                { Keys.F3,       new StandardMapping { Normal = Ss3 + "R",    Shift = Esc + "[1;2R",  Control = Esc + "[1;5R",  Alt = Esc + "[1;9R" } },
+                { Keys.F4,       new StandardMapping { Normal = Ss3 + "S",    Shift = Esc + "[1;2S",  Control = Esc + "[1;5S",  Alt = Esc + "[1;9S" } },
+                { Keys.F5,       new StandardMapping { Normal = Esc + "[15~", Shift = Esc + "[15;2~", Control = Esc + "[15;5~", Alt = Esc + "[15;9~" } },
+                { Keys.F6,       new StandardMapping { Normal = Esc + "[17~", Shift = Esc + "[17;2~", Control = Esc + "[17;5~", Alt = Esc + "[17;9~" } },
+                { Keys.F7,       new StandardMapping { Normal = Esc + "[18~", Shift = Esc + "[18;2~", Control = Esc + "[18;5~", Alt = Esc + "[18;9~" } },
+                { Keys.F8,       new StandardMapping { Normal = Esc + "[19~", Shift = Esc + "[19;2~", Control = Esc + "[19;5~", Alt = Esc + "[19;9~" } },
+                { Keys.F9,       new StandardMapping { Normal = Esc + "[20~", Shift = Esc + "[20;2~", Control = Esc + "[20;5~", Alt = Esc + "[20;9~" } },
+                { Keys.F10,      new StandardMapping { Normal = Esc + "[21~", Shift = Esc + "[21;2~", Control = Esc + "[21;5~", Alt = Esc + "[21;9~" } },
+                { Keys.F11,      new StandardMapping { Normal = Esc + "[23~", Shift = Esc + "[23;2~", Control = Esc + "[23;5~", Alt = Esc + "[23;9~" } },
+                { Keys.F12,      new StandardMapping { Normal = Esc + "[24~", Shift = Esc + "[24;2~", Control = Esc + "[24;5~", Alt = Esc + "[24;9~" } },
 
                 //
                 // Arrow keys.

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyTranslation.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminalKeyTranslation.cs
@@ -84,40 +84,40 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
                 // prefixed with CSI. Older versions of xterm implement different escape
                 // sequences for F1 through F4, with a CSI prefix.
                 //
-                { Keys.F1,       new StandardMapping { Normal = Ss3 + "P",    Shift = Esc + "[1;2P",  Control = Esc + "[1;5P",  Alt = Esc + "[1;9P" } },
-                { Keys.F2,       new StandardMapping { Normal = Ss3 + "Q",    Shift = Esc + "[1;2Q",  Control = Esc + "[1;5Q",  Alt = Esc + "[1;9Q" } },
-                { Keys.F3,       new StandardMapping { Normal = Ss3 + "R",    Shift = Esc + "[1;2R",  Control = Esc + "[1;5R",  Alt = Esc + "[1;9R" } },
-                { Keys.F4,       new StandardMapping { Normal = Ss3 + "S",    Shift = Esc + "[1;2S",  Control = Esc + "[1;5S",  Alt = Esc + "[1;9S" } },
-                { Keys.F5,       new StandardMapping { Normal = Esc + "[15~", Shift = Esc + "[15;2~", Control = Esc + "[15;5~", Alt = Esc + "[15;9~" } },
-                { Keys.F6,       new StandardMapping { Normal = Esc + "[17~", Shift = Esc + "[17;2~", Control = Esc + "[17;5~", Alt = Esc + "[17;9~" } },
-                { Keys.F7,       new StandardMapping { Normal = Esc + "[18~", Shift = Esc + "[18;2~", Control = Esc + "[18;5~", Alt = Esc + "[18;9~" } },
-                { Keys.F8,       new StandardMapping { Normal = Esc + "[19~", Shift = Esc + "[19;2~", Control = Esc + "[19;5~", Alt = Esc + "[19;9~" } },
-                { Keys.F9,       new StandardMapping { Normal = Esc + "[20~", Shift = Esc + "[20;2~", Control = Esc + "[20;5~", Alt = Esc + "[20;9~" } },
-                { Keys.F10,      new StandardMapping { Normal = Esc + "[21~", Shift = Esc + "[21;2~", Control = Esc + "[21;5~", Alt = Esc + "[21;9~" } },
-                { Keys.F11,      new StandardMapping { Normal = Esc + "[23~", Shift = Esc + "[23;2~", Control = Esc + "[23;5~", Alt = Esc + "[23;9~" } },
-                { Keys.F12,      new StandardMapping { Normal = Esc + "[24~", Shift = Esc + "[24;2~", Control = Esc + "[24;5~", Alt = Esc + "[24;9~" } },
+                { Keys.F1,       new StandardMapping { Normal = Ss3 + "P",    Shift = Esc + "[1;2P",  Control = Esc + "[1;5P",  Alt = Esc + "[1;3P" } },
+                { Keys.F2,       new StandardMapping { Normal = Ss3 + "Q",    Shift = Esc + "[1;2Q",  Control = Esc + "[1;5Q",  Alt = Esc + "[1;3Q" } },
+                { Keys.F3,       new StandardMapping { Normal = Ss3 + "R",    Shift = Esc + "[1;2R",  Control = Esc + "[1;5R",  Alt = Esc + "[1;3R" } },
+                { Keys.F4,       new StandardMapping { Normal = Ss3 + "S",    Shift = Esc + "[1;2S",  Control = Esc + "[1;5S",  Alt = Esc + "[1;3S" } },
+                { Keys.F5,       new StandardMapping { Normal = Esc + "[15~", Shift = Esc + "[15;2~", Control = Esc + "[15;5~", Alt = Esc + "[15;3~" } },
+                { Keys.F6,       new StandardMapping { Normal = Esc + "[17~", Shift = Esc + "[17;2~", Control = Esc + "[17;5~", Alt = Esc + "[17;3~" } },
+                { Keys.F7,       new StandardMapping { Normal = Esc + "[18~", Shift = Esc + "[18;2~", Control = Esc + "[18;5~", Alt = Esc + "[18;3~" } },
+                { Keys.F8,       new StandardMapping { Normal = Esc + "[19~", Shift = Esc + "[19;2~", Control = Esc + "[19;5~", Alt = Esc + "[19;3~" } },
+                { Keys.F9,       new StandardMapping { Normal = Esc + "[20~", Shift = Esc + "[20;2~", Control = Esc + "[20;5~", Alt = Esc + "[20;3~" } },
+                { Keys.F10,      new StandardMapping { Normal = Esc + "[21~", Shift = Esc + "[21;2~", Control = Esc + "[21;5~", Alt = Esc + "[21;3~" } },
+                { Keys.F11,      new StandardMapping { Normal = Esc + "[23~", Shift = Esc + "[23;2~", Control = Esc + "[23;5~", Alt = Esc + "[23;3~" } },
+                { Keys.F12,      new StandardMapping { Normal = Esc + "[24~", Shift = Esc + "[24;2~", Control = Esc + "[24;5~", Alt = Esc + "[24;3~" } },
 
                 //
                 // Arrow keys.
                 //
-                { Keys.Up,       new StandardMapping { Normal = Esc + "[A",   Shift = Esc + "OA", Control = Esc + "OA",     Alt = Esc + Esc + "[A" } },
-                { Keys.Down,     new StandardMapping { Normal = Esc + "[B",   Shift = Esc + "OB", Control = Esc + "OB",     Alt = Esc + Esc + "[B" } },
-                { Keys.Right,    new StandardMapping { Normal = Esc + "[C",   Shift = Esc + "OC", Control = Esc + "OC",     Alt = Esc + Esc + "[C" } },
-                { Keys.Left,     new StandardMapping { Normal = Esc + "[D",   Shift = Esc + "OD", Control = Esc + "OD",     Alt = Esc + Esc + "[D" } },
-                { Keys.Home,     new StandardMapping { Normal = Esc + "[1~",  Shift = Esc + "[1~",                          Alt = Esc + Esc + "[1~" } },
-                { Keys.Insert,   new StandardMapping { Normal = Esc + "[2~",                                                Alt = Esc + Esc + "[2~" } },
-                { Keys.Delete,   new StandardMapping { Normal = Esc + "[3~",  Shift = Esc + "[3~",                          Alt = Esc + Esc + "[3~" } },
-                { Keys.End,      new StandardMapping { Normal = Esc + "[4~",  Shift = Esc + "[4~",                          Alt = Esc + Esc + "[4~" } },
-                { Keys.PageUp,   new StandardMapping { Normal = Esc + "[5~",  Shift = Esc + "[5~",                          Alt = Esc + Esc + "[5~" } },
-                { Keys.PageDown, new StandardMapping { Normal = Esc + "[6~",  Shift = Esc + "[6~",                          Alt = Esc + Esc + "[6~" } },
+                { Keys.Up,       new StandardMapping { Normal = Esc + "[A",   Shift = Esc + "[1;2A",  Control = Esc + "[1;5A",  Alt = Esc + "[1;3A" } },
+                { Keys.Down,     new StandardMapping { Normal = Esc + "[B",   Shift = Esc + "[1;2B",  Control = Esc + "[1;5B",  Alt = Esc + "[1;3B" } },
+                { Keys.Right,    new StandardMapping { Normal = Esc + "[C",   Shift = Esc + "[1;2C",  Control = Esc + "[1;5C",  Alt = Esc + "[1;3C" } },
+                { Keys.Left,     new StandardMapping { Normal = Esc + "[D",   Shift = Esc + "[1;2D",  Control = Esc + "[1;5D",  Alt = Esc + "[1;3D" } },
+                { Keys.Home,     new StandardMapping { Normal = Esc + "[H",   Shift = Esc + "[1;2H",  Control = Esc + "[1;5H",  Alt = Esc + "[1;3H" } },
+                { Keys.End,      new StandardMapping { Normal = Esc + "[F",   Shift = Esc + "[1;2F",  Control = Esc + "[1;5F",  Alt = Esc + "[1;3F" } },
+                { Keys.Insert,   new StandardMapping { Normal = Esc + "[2~",  Shift = Esc + "[2;2~",  Control = Esc + "[2;5~",  Alt = Esc + "[2;3~" } },
+                { Keys.Delete,   new StandardMapping { Normal = Esc + "[3~",  Shift = Esc + "[3;2~",  Control = Esc + "[3;5~",  Alt = Esc + "[3;3~" } },
+                { Keys.PageUp,   new StandardMapping { Normal = Esc + "[5~",  Shift = Esc + "[5;2~",  Control = Esc + "[5;5~",  Alt = Esc + "[5;3~" } },
+                { Keys.PageDown, new StandardMapping { Normal = Esc + "[6~",  Shift = Esc + "[6;2~",  Control = Esc + "[6;5~",  Alt = Esc + "[6;3~" } },
 
                 //
                 // Main keyboard.
                 //
-                { Keys.Back,    new StandardMapping { Normal = "\u007F",      Shift = "\b",           Control = "\u007F" } },
-                { Keys.Tab,     new StandardMapping { Normal = "\t",          Shift = Esc + "[Z",     } },
-                { Keys.Return,  new StandardMapping { Normal = "\r",          Shift = "\r",           Control = "\r",       Alt = Esc + "\r" } },
-                { Keys.Escape,  new StandardMapping { Normal = Esc + Esc,     Shift = Esc + Esc,      Control = Esc + Esc } },
+                { Keys.Back,    new StandardMapping { Normal = "\u007F",      Shift = "\u007F",       Control = "\b",           Alt = Esc + "\u007f" } },
+                { Keys.Tab,     new StandardMapping { Normal = "\t",          Shift = Esc + "[Z",     Control = "\t"                                 } },
+                { Keys.Return,  new StandardMapping { Normal = "\r",          Shift = "\r",           Control = "\r",           Alt = Esc + "\r" } },
+                { Keys.Escape,  new StandardMapping { Normal = Esc,           Shift = Esc,            Control = Esc } },
                 { Keys.Pause,   new StandardMapping { Normal = "\u001a",      Shift = "\u001a",                             Alt = Esc + "\u001a" } },
                 { Keys.Space,   new StandardMapping {                                                 Control = "\u0000",   Alt = Esc + " " } },
 
@@ -198,6 +198,30 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
                 { Keys.Down,     new StandardMapping { Normal = Ss3 + "B" } },
                 { Keys.Right,    new StandardMapping { Normal = Ss3 + "C" } },
                 { Keys.Left,     new StandardMapping { Normal = Ss3 + "D" } },
+                { Keys.Home,     new StandardMapping { Normal = Ss3 + "H" } },
+                { Keys.End,      new StandardMapping { Normal = Ss3 + "F" } },
+            };
+
+        /// <summary>
+        /// Extra translations to apply when modifyOtherKeys = 1.
+        /// 
+        /// See https://invisible-island.net/xterm/manpage/xterm.html#VT100-Widget-Resources:modifyOtherKeys
+        /// </summary>
+        private static readonly Dictionary<Keys, StandardMapping> ModifyOtherKeysModeWithExceptionTranslations
+            = new Dictionary<Keys, StandardMapping>
+            {
+                //
+                // NB. To manually enter this mode, run
+                //     printf '\033[>4;1m'
+                // To disable:
+                //     printf '\033[>4;2m'
+                //
+                { Keys.Tab,      new StandardMapping {                           Control = Esc + "[27;5;9"  } },
+                { Keys.Return,   new StandardMapping { Shift = Esc + "[27;2;13", Control = Esc + "[27;5;13" ,    Alt = Esc + "[27;3;13" } },
+
+                { Keys.D0,       new StandardMapping {                           Control = Esc + "[27;5;48"  } },
+                { Keys.D1,       new StandardMapping {                           Control = Esc + "[27;5;49"  } },
+                { Keys.D9,       new StandardMapping {                           Control = Esc + "[27;5;57"  } },
             };
 
         public static string ForKey(
@@ -205,7 +229,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
             bool alt,
             bool control,
             bool shift,
-            bool applicationCursorKeysMode)
+            bool applicationCursorKeysMode,
+            ModifyOtherKeysMode modifyOtherKeysMode)
         {
             Debug.Assert((keyCode & Keys.KeyCode) == keyCode, "No modifiers");
 
@@ -216,22 +241,28 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
                 //
                 return null;
             }
+
+            if (modifyOtherKeysMode == ModifyOtherKeysMode.EnabledWithExceptions &&
+                ModifyOtherKeysModeWithExceptionTranslations.TryGetValue(keyCode, out var modMapping) &&
+                modMapping.Apply(alt, control, shift) is string modSequence)
+            {
+                return modSequence;
+            }
+
             if (applicationCursorKeysMode &&
                 ApplicationCursorKeysModeTranslations.TryGetValue(keyCode, out var appMapping) &&
                 appMapping.Apply(alt, control, shift) is string appSequence)
             {
                 return appSequence;
             }
-            else if (
-                StandardTranslations.TryGetValue(keyCode, out var stdMapping) &&
+
+            if (StandardTranslations.TryGetValue(keyCode, out var stdMapping) &&
                 stdMapping.Apply(alt, control, shift) is string stdSequence)
             {
                 return stdSequence;
             }
-            else
-            {
-                return null;
-            }
+
+            return null;
         }
     }
 }


### PR DESCRIPTION
* Use xterm's translation for function keys instead of PuTTY's (legacy) ones
* Add translation table for 'modifyOtherKeys = 1' mode
* Add tests

This addresses #482