### PR TITLE
b/192170307 Include x86 and x64 DLLs, PDBs in libssh2 NuGet package

### DIFF
--- a/dependencies/libssh2.targets
+++ b/dependencies/libssh2.targets
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <NativeLibs Include="$(MSBuildThisFileDirectory)**\*.dll" />
+    <!-- Select files matching tragte platform -->
+    <NativeLibs Include="$(MSBuildThisFileDirectory)\..\**\runtimes\win10-$(PlatformTarget)\native\*.*" />
     <None Include="@(NativeLibs)">
-      <Link>%(RecursiveDir)%(FileName)%(Extension)</Link>
+      <!-- Copy files to output folder, not into a subfolder of it -->
+      <Link>%(FileName)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/dependencies/makefile
+++ b/dependencies/makefile
@@ -21,7 +21,7 @@
 CONFIGURATION = Release
 
 # The tag should be increased whenever one of the dependencies is changed
-TAG = 17
+TAG = 18
 
 VTNETCORE_TAG = 9e68f5561dc52edb780615b3fe133289216b3dba
 VTNETCORE_URL = https://github.com/darrenstarr/VtNetCore.git
@@ -33,7 +33,7 @@ VTNETCORE_VERSION = 1.0.30.$(TAG)
 # - libssh2: vcpkg-ports\libssh2\portfile.cmake
 # - openssl: https://github.com/microsoft/vcpkg/blob/master/ports/openssl/portfile.cmake
 #
-VCPKG_TAG = 85308d1a2135f65bf52603687360f54e9c4e25ba
+VCPKG_TAG = 2021.05.12
 VCPKG_URL = https://github.com/microsoft/vcpkg.git
 LIBSSH2_VERSION = 1.9.0.$(TAG)
 
@@ -127,7 +127,7 @@ $(MAKEDIR)\obj\vcpkg\vcpkg.exe: $(MAKEDIR)\obj\vcpkg\bootstrap-vcpkg.bat
 
 $(MAKEDIR)\obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\libssh2.dll: $(MAKEDIR)\obj\vcpkg\vcpkg.exe
 	@echo "========================================================"
-	@echo "=== Building libssh2                                 ==="
+	@echo "=== Building libssh2 (x86)                           ==="
 	@echo "========================================================"
 
 	-echo | set /p="$(LIBSSH2_VERSION)" > $(MAKEDIR)\vcpkg-ports\libssh2\build.tmp
@@ -138,12 +138,26 @@ $(MAKEDIR)\obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\libssh2.dll: $(MAKE
 		--overlay-ports=$(MAKEDIR)\vcpkg-ports \
 		--overlay-triplets=$(MAKEDIR)\vcpkg-triplets
 
-$(MAKEDIR)\obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\libssh2.$(LIBSSH2_VERSION).nupkg: \
-		$(MAKEDIR)\obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\libssh2.dll
+$(MAKEDIR)\obj\vcpkg\installed\libssh2-x64-windows-mixed\bin\libssh2.dll: $(MAKEDIR)\obj\vcpkg\vcpkg.exe
+	@echo "========================================================"
+	@echo "=== Building libssh2 (x64)                           ==="
+	@echo "========================================================"
+
+	-echo | set /p="$(LIBSSH2_VERSION)" > $(MAKEDIR)\vcpkg-ports\libssh2\build.tmp
+	-echo | set /p="$(LIBSSH2_VERSION:.=,)" > $(MAKEDIR)\vcpkg-ports\libssh2\build-comma.tmp
+
+	$(MAKEDIR)\obj\vcpkg\vcpkg.exe install libssh2 \
+		--triplet libssh2-x64-windows-mixed \
+		--overlay-ports=$(MAKEDIR)\vcpkg-ports \
+		--overlay-triplets=$(MAKEDIR)\vcpkg-triplets
+
+$(MAKEDIR)\obj\libssh2\libssh2.$(LIBSSH2_VERSION).nupkg: \
+		$(MAKEDIR)\obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\libssh2.dll \
+		$(MAKEDIR)\obj\vcpkg\installed\libssh2-x64-windows-mixed\bin\libssh2.dll
 	@echo "========================================================"
 	@echo "=== Building libssh2 nuget package                   ==="
 	@echo "========================================================"
-	nuget pack -OutputDirectory $(MAKEDIR)\obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\ <<libssh2.nuspec
+	nuget pack -OutputDirectory $(MAKEDIR)\obj\libssh2\ <<libssh2.nuspec
 <?xml version="1.0"?>
 <package>
   <metadata>
@@ -157,19 +171,21 @@ $(MAKEDIR)\obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\libssh2.$(LIBSSH2_V
   </metadata>
   <files>
 	<!-- pretend the library is platform-neutral -->
-    <file src="obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\libssh2.dll" target="build" />
-    <file src="obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\libssh2.dll" target="build\net46" />
+    <file src="obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\libssh2.dll" target="runtimes\win10-x86\native" />
+    <file src="obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\libssh2.pdb" target="runtimes\win10-x86\native" />
+    <file src="obj\vcpkg\installed\libssh2-x64-windows-mixed\bin\libssh2.dll" target="runtimes\win10-x64\native" />
+    <file src="obj\vcpkg\installed\libssh2-x64-windows-mixed\bin\libssh2.pdb" target="runtimes\win10-x64\native" />
     <file src="libssh2.targets" target="build" />
   </files>
 </package>
 <<NOKEEP
 
-libssh2: $(MAKEDIR)\obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\libssh2.$(LIBSSH2_VERSION).nupkg $(MAKEDIR)\NuGetPackages
+libssh2: $(MAKEDIR)\obj\libssh2\libssh2.$(LIBSSH2_VERSION).nupkg $(MAKEDIR)\NuGetPackages
 	@echo "========================================================"
 	@echo "=== Publishing libssh2 nuget package                 ===
 	@echo "========================================================"
 	nuget add \
-		$(MAKEDIR)\obj\vcpkg\installed\libssh2-x86-windows-mixed\bin\libssh2.$(LIBSSH2_VERSION).nupkg \
+		$(MAKEDIR)\obj\libssh2\libssh2.$(LIBSSH2_VERSION).nupkg \
 		-Source $(MAKEDIR)\NuGetPackages
 
 clean-libssh2: $(MAKEDIR)\obj\vcpkg\vcpkg.exe
@@ -180,7 +196,12 @@ clean-libssh2: $(MAKEDIR)\obj\vcpkg\vcpkg.exe
 		--triplet libssh2-x86-windows-mixed \
 		--overlay-ports=$(MAKEDIR)\vcpkg-ports \
 		--overlay-triplets=$(MAKEDIR)\vcpkg-triplets
-	rd /S /Q $(LOCALAPPDATA)\vcpkg
+	$(MAKEDIR)\obj\vcpkg\vcpkg.exe remove libssh2 \
+		--triplet libssh2-x64-windows-mixed \
+		--overlay-ports=$(MAKEDIR)\vcpkg-ports \
+		--overlay-triplets=$(MAKEDIR)\vcpkg-triplets
+	rd /S /Q $(MAKEDIR)\obj\libssh2\
+    rd /S /Q $(LOCALAPPDATA)\vcpkg
 
 #------------------------------------------------------------------------------
 # Main targets

--- a/dependencies/vcpkg-triplets/libssh2-x64-windows-mixed.cmake
+++ b/dependencies/vcpkg-triplets/libssh2-x64-windows-mixed.cmake
@@ -1,0 +1,30 @@
+#
+# Copyright 2020 Google LLC
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set(VCPKG_TARGET_ARCHITECTURE x64)
+
+if(${PORT} MATCHES "libssh2")
+	set(VCPKG_CRT_LINKAGE dynamic)
+	set(VCPKG_LIBRARY_LINKAGE dynamic)
+else()
+	set(VCPKG_CRT_LINKAGE static)
+	set(VCPKG_LIBRARY_LINKAGE static)
+endif()


### PR DESCRIPTION
* Update to latest vcpkg tag
* Add x64 triplet for libssh2
* Extend nuspec to include x86 and x64 DLLs, PDBs
* Change targets file to copy architecture-specific files
* Bump tag to 18