### PR TITLE
Verify that all requested scopes are granted

### DIFF
--- a/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
+++ b/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
@@ -220,6 +220,15 @@ namespace Google.Solutions.IapDesktop.Windows
                     // NB. If the user cancels, no exception is thrown.
                     this.viewModel.Authorize();
                 }
+                catch (AuthorizationFailedException e)
+                {
+                    //
+                    // Authorization failed for reasons not related to networking.
+                    //
+                    this.serviceProvider
+                        .GetService<IExceptionDialog>()
+                        .Show(this, "Authorization failed", e);
+                }
                 catch (Exception e)
                 {
                     //


### PR DESCRIPTION
If an admin changes the access level for the app (in the Admin Console),
then it's possible that some of the requested scopes haven't been granted.
This can cause subsequent API calls to fail.