### PR TITLE
Add patch: Fix throw statement to avoid cascading exception

### DIFF
--- a/dependencies/makefile
+++ b/dependencies/makefile
@@ -21,7 +21,7 @@
 CONFIGURATION = Release
 
 # The tag should be increased whenever one of the dependencies is changed
-TAG = 18
+TAG = 19
 
 VTNETCORE_TAG = 9e68f5561dc52edb780615b3fe133289216b3dba
 VTNETCORE_URL = https://github.com/darrenstarr/VtNetCore.git
@@ -74,6 +74,7 @@ $(MAKEDIR)\obj\vtnetcore\VtNetCore\VtNetCore.csproj:
 	git am $(MAKEDIR)\vtnetcore-patches\0002-Fix-escape-sequences-for-bracketed-text-mode.patch
 	git am $(MAKEDIR)\vtnetcore-patches\0003-Detect-key-modifier-options-XTMODKEYS.patch
 	git am $(MAKEDIR)\vtnetcore-patches\0004-Handle-single-parameter-OSC-sequences.patch
+	git am $(MAKEDIR)\vtnetcore-patches\0005-Fix-throw-statement-to-avoid-cascading-exception.patch 
 
 	cd $(MAKEDIR)
 

--- a/dependencies/vtnetcore-patches/0005-Fix-throw-statement-to-avoid-cascading-exception.patch
+++ b/dependencies/vtnetcore-patches/0005-Fix-throw-statement-to-avoid-cascading-exception.patch
@@ -1,0 +1,29 @@
+From f91707dd22145481bff410da65f3f3ddfb027beb Mon Sep 17 00:00:00 2001
+From: IAP Desktop Build <iap-desktop+build@google.com>
+Date: Tue, 17 Aug 2021 16:39:02 +0200
+Subject: [PATCH 5/5] Fix `throw` statement to avoid cascading exception
+
+Throw proper exception when no handler has been registered
+for a DCS sequence. This fixes an issue where throwing
+an exception could cause another exception if the first
+parameter has not been extracted yet.
+---
+ VtNetCore/XTermParser/XTermSequenceHandlers.cs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/VtNetCore/XTermParser/XTermSequenceHandlers.cs b/VtNetCore/XTermParser/XTermSequenceHandlers.cs
+index 6a78250..9c406bd 100644
+--- a/VtNetCore/XTermParser/XTermSequenceHandlers.cs
++++ b/VtNetCore/XTermParser/XTermSequenceHandlers.cs
+@@ -1922,7 +1922,7 @@
+                     .SingleOrDefault();
+ 
+                 if (handler == null)
+-                    throw new Exception("There are no sequence handlers configured for type DcsSequence with param0 = " + sequence.Parameters[0].ToString());
++                    throw new EscapeSequenceException("There are no sequence handlers configured for type DcsSequence " + sequence.ToString(), sequence);
+ 
+                 handler.Handler(sequence, controller);
+ 
+-- 
+2.17.1.windows.2
+


### PR DESCRIPTION
Fix `throw` statement to avoid cascading exception

Throw proper exception when no handler has been registered
for a DCS sequence. This fixes an issue where throwing
an exception could cause another exception if the first
parameter has not been extracted yet.

This addresses #545