### PR TITLE
Update dependencies to include vtnetcore fix

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminal.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminal.cs
@@ -992,5 +992,30 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.SelectWord(4, 0);
             Assert.AreEqual("first", this.terminal.TextSelection);
         }
+
+        //---------------------------------------------------------------------
+        // Unicode
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenReceivedDataContainsSingleHighReversed9QuotationMark_ThenCharacterIsIgnored()
+        {
+            // NB. \u201b "embeds" \u1b, which is the Escape character.
+            var text = $"abc\u201bxyz";
+            this.terminal.ReceiveData(text);
+            var buffer = this.terminal.GetBuffer();
+
+            Assert.AreEqual("abcxyz", buffer.Trim());
+        }
+
+        [Test]
+        public void WhenReceivedDataContainsInvalidUnicodeSequence_ThenCharacterIsIgnored()
+        {
+            var text = $"abc{Esc}\u0090\u0091xyz";
+            this.terminal.ReceiveData(text);
+            var buffer = this.terminal.GetBuffer();
+
+            Assert.AreEqual("abc\u0091xyz", buffer.Trim());
+        }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminal.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminal.cs
@@ -998,14 +998,14 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         //---------------------------------------------------------------------
 
         [Test]
-        public void WhenReceivedDataContainsSingleHighReversed9QuotationMark_ThenCharacterIsIgnored()
+        public void WhenReceivedDataContainsSingleHighReversed9QuotationMark_ThenCharacterIsKept()
         {
             // NB. \u201b "embeds" \u1b, which is the Escape character.
             var text = $"abc\u201bxyz";
             this.terminal.ReceiveData(text);
             var buffer = this.terminal.GetBuffer();
 
-            Assert.AreEqual("abcxyz", buffer.Trim());
+            Assert.AreEqual(text, buffer.Trim());
         }
 
         [Test]

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Google.Solutions.IapDesktop.Extensions.Shell.Test.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Google.Solutions.IapDesktop.Extensions.Shell.Test.csproj
@@ -111,8 +111,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="vtnetcore, Version=1.0.30.18, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\vtnetcore.1.0.30.18\lib\net46\vtnetcore.dll</HintPath>
+    <Reference Include="vtnetcore, Version=1.0.30.19, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\vtnetcore.1.0.30.19\lib\net46\vtnetcore.dll</HintPath>
     </Reference>
     <Reference Include="WeifenLuo.WinFormsUI.Docking, Version=3.0.6.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
       <HintPath>..\packages\DockPanelSuite.3.0.6\lib\net40\WeifenLuo.WinFormsUI.Docking.dll</HintPath>

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/packages.config
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/packages.config
@@ -23,5 +23,5 @@
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net461" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
-  <package id="vtnetcore" version="1.0.30.18" targetFramework="net461" />
+  <package id="vtnetcore" version="1.0.30.19" targetFramework="net461" />
 </packages>

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Google.Solutions.IapDesktop.Extensions.Shell.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Google.Solutions.IapDesktop.Extensions.Shell.csproj
@@ -97,8 +97,8 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="vtnetcore, Version=1.0.30.18, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\vtnetcore.1.0.30.18\lib\net46\vtnetcore.dll</HintPath>
+    <Reference Include="vtnetcore, Version=1.0.30.19, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\vtnetcore.1.0.30.19\lib\net46\vtnetcore.dll</HintPath>
     </Reference>
     <Reference Include="WeifenLuo.WinFormsUI.Docking, Version=3.0.6.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
       <HintPath>..\packages\DockPanelSuite.3.0.6\lib\net40\WeifenLuo.WinFormsUI.Docking.dll</HintPath>

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/packages.config
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/packages.config
@@ -11,5 +11,5 @@
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="System.Text.Encoding" version="4.3.0" targetFramework="net461" />
   <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net461" />
-  <package id="vtnetcore" version="1.0.30.18" targetFramework="net461" />
+  <package id="vtnetcore" version="1.0.30.19" targetFramework="net461" />
 </packages>

--- a/sources/Google.Solutions.Ssh.Test/Google.Solutions.Ssh.Test.csproj
+++ b/sources/Google.Solutions.Ssh.Test/Google.Solutions.Ssh.Test.csproj
@@ -137,8 +137,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\NUnit.3.13.2\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.2\build\NUnit.props'))" />
-    <Error Condition="!Exists('..\packages\libssh2.1.9.0.18\build\libssh2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libssh2.1.9.0.18\build\libssh2.targets'))" />
+    <Error Condition="!Exists('..\packages\libssh2.1.9.0.19\build\libssh2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libssh2.1.9.0.19\build\libssh2.targets'))" />
     <Error Condition="!Exists('..\packages\NUnit3TestAdapter.4.0.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.4.0.0\build\net35\NUnit3TestAdapter.props'))" />
   </Target>
-  <Import Project="..\packages\libssh2.1.9.0.18\build\libssh2.targets" Condition="Exists('..\packages\libssh2.1.9.0.18\build\libssh2.targets')" />
+  <Import Project="..\packages\libssh2.1.9.0.19\build\libssh2.targets" Condition="Exists('..\packages\libssh2.1.9.0.19\build\libssh2.targets')" />
 </Project>

--- a/sources/Google.Solutions.Ssh.Test/packages.config
+++ b/sources/Google.Solutions.Ssh.Test/packages.config
@@ -4,7 +4,7 @@
   <package id="Google.Apis.Auth" version="1.52.0" targetFramework="net461" />
   <package id="Google.Apis.Compute.v1" version="1.52.0" targetFramework="net461" />
   <package id="Google.Apis.Core" version="1.52.0" targetFramework="net461" />
-  <package id="libssh2" version="1.9.0.18" targetFramework="net461" />
+  <package id="libssh2" version="1.9.0.19" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
   <package id="NUnit" version="3.13.2" targetFramework="net461" />
   <package id="NUnit.Console" version="3.12.0" targetFramework="net461" />

--- a/sources/Google.Solutions.Ssh/Google.Solutions.Ssh.csproj
+++ b/sources/Google.Solutions.Ssh/Google.Solutions.Ssh.csproj
@@ -110,11 +110,11 @@
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>
-  <Import Project="..\packages\libssh2.1.9.0.18\build\libssh2.targets" Condition="Exists('..\packages\libssh2.1.9.0.18\build\libssh2.targets')" />
+  <Import Project="..\packages\libssh2.1.9.0.19\build\libssh2.targets" Condition="Exists('..\packages\libssh2.1.9.0.19\build\libssh2.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\libssh2.1.9.0.18\build\libssh2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libssh2.1.9.0.18\build\libssh2.targets'))" />
+    <Error Condition="!Exists('..\packages\libssh2.1.9.0.19\build\libssh2.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\libssh2.1.9.0.19\build\libssh2.targets'))" />
   </Target>
 </Project>

--- a/sources/Google.Solutions.Ssh/packages.config
+++ b/sources/Google.Solutions.Ssh/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.Apis.Core" version="1.52.0" targetFramework="net461" />
-  <package id="libssh2" version="1.9.0.18" targetFramework="net461" />
+  <package id="libssh2" version="1.9.0.19" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
* Update vtnetcore, libssh2 to .19 to ensure that vtnetcore
  includes the fix for cascading exceptions thrown in DCS handling.
* Add unit tests to verify presence of patch