### PR TITLE
b/197197943 Enable TLS 1.3 on Windows 11/Windows Server 2022

### DIFF
--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -162,11 +162,23 @@ namespace Google.Solutions.IapDesktop
             ApplicationTraceSources.Default.Switch.Level = SourceLevels.Verbose;
             //SshTraceSources.Default.Switch.Level = SourceLevels.Verbose;
 #endif
+            try
+            {
+                // Use 1.3 if possible.
+                System.Net.ServicePointManager.SecurityProtocol =
+                    SecurityProtocolType.Tls12 |
+                    SecurityProtocolType.Tls11 |
+                    (SecurityProtocolType)0x3000; // TLS 1.3
+            }
+            catch (NotSupportedException)
+            {
+                Debug.Assert(false, "Enabling TLS 1.3 failed");
+                // Use 1.2 if possible.
+                System.Net.ServicePointManager.SecurityProtocol =
+                    SecurityProtocolType.Tls12 |
+                    SecurityProtocolType.Tls11;
+            }
 
-            // Use TLS 1.2 if possible.
-            System.Net.ServicePointManager.SecurityProtocol =
-                SecurityProtocolType.Tls12 |
-                SecurityProtocolType.Tls11;
 
             // Lift limit on concurrent HTTP connections to same endpoint,
             // relevant for GCS downloads.

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -58,6 +58,9 @@ namespace Google.Solutions.IapDesktop
 {
     class Program : SingletonApplicationBase
     {
+        private static readonly Version Windows11 = new Version(10, 0, 22000, 0);
+        private static readonly Version WindowsServer2022 = new Version(10, 0, 20348, 0);
+
         private static bool tracingEnabled = false;
 
         private static readonly TraceSource[] Traces = new[]
@@ -162,26 +165,33 @@ namespace Google.Solutions.IapDesktop
             ApplicationTraceSources.Default.Switch.Level = SourceLevels.Verbose;
             //SshTraceSources.Default.Switch.Level = SourceLevels.Verbose;
 #endif
-            try
+
+            if (Environment.OSVersion.Version >= Windows11 ||
+                Environment.OSVersion.Version >= WindowsServer2022)
             {
-                // Use 1.3 if possible.
+                //
+                // Windows 2022 and Windows 11 fully support TLS 1.3:
+                // https://docs.microsoft.com/en-us/windows/win32/secauthn/protocols-in-tls-ssl--schannel-ssp-
+                //
                 System.Net.ServicePointManager.SecurityProtocol =
                     SecurityProtocolType.Tls12 |
                     SecurityProtocolType.Tls11 |
                     (SecurityProtocolType)0x3000; // TLS 1.3
             }
-            catch (NotSupportedException)
+            else
             {
-                Debug.Assert(false, "Enabling TLS 1.3 failed");
-                // Use 1.2 if possible.
+                //
+                // Windows 10 and below don't properly support TLS 1.3 yet.
+                //
                 System.Net.ServicePointManager.SecurityProtocol =
                     SecurityProtocolType.Tls12 |
                     SecurityProtocolType.Tls11;
             }
 
-
+            //
             // Lift limit on concurrent HTTP connections to same endpoint,
             // relevant for GCS downloads.
+            //
             ServicePointManager.DefaultConnectionLimit = 16;
 
             // Allow custom User-Agent headers.


### PR DESCRIPTION
* Enable TLS 1.3 on Windows 11/Windows Server 2022 as these versions officially
  support TLS 1.3 in WinHTTP and SChannel.
* Use TLS 1.2 on Windows 10 and below.
* Continue to allow fallback to TLS 1.1 as some proxy servers might not support
  TLS 1.2/1.3 yet.

This addresses #544