### PR TITLE
b/193758410 Client certificate selection

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Google.Solutions.IapDesktop.Application.Test.csproj
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Google.Solutions.IapDesktop.Application.Test.csproj
@@ -121,6 +121,8 @@
     <Compile Include="Services\Integration\TestSessionBroker.cs" />
     <Compile Include="Services\ProjectModel\TestProjectModelNodes.cs" />
     <Compile Include="Services\ProjectModel\TestProjectModelService.cs" />
+    <Compile Include="Services\SecureConnect\TestChromeCertificateSelector.cs" />
+    <Compile Include="Services\SecureConnect\TestChromeMatchPattern.cs" />
     <Compile Include="Services\Settings\TestToolWindowStateRepository.cs" />
     <Compile Include="Services\Settings\TestApplicationSettingsRepository.cs" />
     <Compile Include="Services\Settings\TestAppProtocolRegistry.cs" />

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestCertificateStoreAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestCertificateStoreAdapter.cs
@@ -104,30 +104,32 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         }
 
         [Test]
-        public void WhenSubjectUnknown_ThenListCertificatesReturnsEmptyEnumeration()
-        {
-            var adapter = new CertificateStoreAdapter();
-            var certificates = adapter.ListUserCertitficates(
-                "unknown-issuer", "unknown-subject");
-
-            Assert.IsNotNull(certificates);
-            CollectionAssert.IsEmpty(certificates);
-        }
-
-        [Test]
-        public void WhenSubjectMatches_ThenListCertificatesReturnsEnumeration()
+        public void ListUserCertificatesReturnsUserCertificate()
         {
             var adapter = new CertificateStoreAdapter();
             adapter.AddUserCertitficate(ExampleCertificate);
 
-            var certificates = adapter.ListUserCertitficates(
-                ExampleCertitficateSubject, ExampleCertitficateSubject);
+            var certificates = adapter.ListUserCertitficates()
+                .Where(cert => cert.Thumbprint == ExampleCertificate.Thumbprint);
 
             Assert.IsNotNull(certificates);
             Assert.AreEqual(1, certificates.Count());
             Assert.AreEqual(
                 TestCertificateStoreAdapter.ExampleCertificate.Thumbprint,
                 certificates.First().Thumbprint);
+        }
+
+        [Test]
+        public void ListComputerCertificatesDoesNotReturnUserCertificate()
+        {
+            var adapter = new CertificateStoreAdapter();
+            adapter.AddUserCertitficate(ExampleCertificate);
+
+            var certificates = adapter.ListComputerCertitficates()
+                .Where(cert => cert.Thumbprint == ExampleCertificate.Thumbprint);
+
+            Assert.IsNotNull(certificates);
+            Assert.IsFalse(certificates.Any());
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeCertificateSelector.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeCertificateSelector.cs
@@ -288,8 +288,8 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.SecureConnect
             var selector = ChromeCertificateSelector.Parse(
                 @"{
                     'pattern': 'https://*.google.com/', 
-                    'THUMBPRINT': 'abcd',
                     'filter':{
+                        'THUMBPRINT': 'abcd',
                         'SUBJECT': {
                             'CN': 'Somethingelse'
                         }

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeCertificateSelector.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeCertificateSelector.cs
@@ -1,0 +1,240 @@
+﻿using Google.Solutions.IapDesktop.Application.Services.SecureConnect;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.IapDesktop.Application.Test.Services.SecureConnect
+{
+    [TestFixture]
+    public class TestChromeCertificateSelector : ApplicationFixtureBase
+    {
+        private static readonly X500DistinguishedName ComplexIssuerDn = 
+            new X500DistinguishedName("C=US,S=CA,L=MTV,O=Acme,OU=Sales,CN=Issuer");
+        private static readonly X500DistinguishedName ComplexSubjectDn =
+            new X500DistinguishedName("C=US,S=CA,L=MTV,O=Acme,OU=Sales,CN=Subject");
+
+        private static readonly X500DistinguishedName SimpleIssuerDn =
+            new X500DistinguishedName("CN=Issuer");
+        private static readonly X500DistinguishedName SimpleSubjectDn =
+            new X500DistinguishedName("CN=Subject");
+
+        //---------------------------------------------------------------------
+        // URL match.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenUrlMismatches_ThenIsMatchReturnsFalse()
+        {
+            var selector = ChromeCertificateSelector.Parse(
+                @"{
+                    'pattern': 'https://*.google.com/', 
+                    'filter':{}
+                }");
+
+            Assert.IsNotNull(selector.Pattern);
+            Assert.IsNull(selector.Filter.Issuer);
+            Assert.IsNull(selector.Filter.Subject);
+
+            Assert.IsFalse(selector.IsMatch(
+                new Uri("https://www.google.de"),
+                SimpleIssuerDn,
+                SimpleSubjectDn));
+        }
+
+        [Test]
+        public void WhenUrlAndFilterEmpty_ThenIsMatchReturnsTrue()
+        {
+            var selector = ChromeCertificateSelector.Parse(
+                @"{
+                }");
+
+            Assert.IsNotNull(selector.Pattern);
+            Assert.IsNull(selector.Filter.Issuer);
+            Assert.IsNull(selector.Filter.Subject);
+
+            Assert.IsTrue(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                SimpleIssuerDn,
+                SimpleSubjectDn));
+        }
+
+        [Test]
+        public void WhenUrlMatchesAndFilterEmpty_ThenIsMatchReturnsTrue()
+        {
+            var selector = ChromeCertificateSelector.Parse(
+                @"{
+                    'pattern': 'https://*.google.com/', 
+                    'filter':{}
+                }");
+
+            Assert.IsNotNull(selector.Pattern);
+            Assert.IsNull(selector.Filter.Issuer);
+            Assert.IsNull(selector.Filter.Subject);
+
+            Assert.IsTrue(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                SimpleIssuerDn,
+                SimpleSubjectDn));
+        }
+
+        //---------------------------------------------------------------------
+        // Issuer match.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenUrlAndIssuerMatchesBySingleField_ThenIsMatchReturnsTrue()
+        {
+            var selector = ChromeCertificateSelector.Parse(
+                @"{
+                    'pattern': 'https://*.google.com/', 
+                    'filter':{
+                        'ISSUER': {
+                            'CN': 'Issuer'
+                        }
+                    }
+                }");
+
+            Assert.IsNotNull(selector.Pattern);
+            Assert.IsNotNull(selector.Filter.Issuer);
+            Assert.IsNull(selector.Filter.Subject);
+
+            Assert.IsTrue(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                ComplexIssuerDn,
+                ComplexSubjectDn));
+
+            Assert.IsTrue(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                SimpleIssuerDn,
+                ComplexSubjectDn));
+        }
+
+        [Test]
+        public void WhenUrlAndIssuerMatchByAllFields_ThenIsMatchReturnsTrue()
+        {
+            var selector = ChromeCertificateSelector.Parse(
+                @"{
+                    'pattern': 'https://*.google.com/', 
+                    'filter':{
+                        'ISSUER': {
+                            'CN': 'Issuer',
+                            'C': 'US',
+                            'S': 'CA',
+                            'L': 'MTV',
+                            'O': 'Acme',
+                            'OU': 'Sales'
+                        }
+                    }
+                }");
+
+            Assert.IsNotNull(selector.Pattern);
+            Assert.IsNotNull(selector.Filter.Issuer);
+            Assert.IsNull(selector.Filter.Subject);
+
+            Assert.IsTrue(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                ComplexIssuerDn,
+                SimpleSubjectDn));
+
+            Assert.IsFalse(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                SimpleIssuerDn,
+                SimpleSubjectDn));
+        }
+
+        [Test]
+        public void WhenUrlAndIssuerMatchButSubjectMismatches_ThenIsMatchReturnsFalse()
+        {
+            var selector = ChromeCertificateSelector.Parse(
+                @"{
+                    'pattern': 'https://*.google.com/', 
+                    'filter':{
+                        'ISSUER': {
+                            'CN': 'Issuer'
+                        },
+                        'SUBJECT': {
+                            'CN': 'Xxx'
+                        }
+                    }
+                }");
+
+            Assert.IsNotNull(selector.Pattern);
+            Assert.IsNotNull(selector.Filter.Issuer);
+            Assert.IsNotNull(selector.Filter.Subject);
+
+            Assert.IsFalse(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                ComplexIssuerDn,
+                ComplexSubjectDn));
+        }
+
+        //---------------------------------------------------------------------
+        // Subject match.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenUrlAndSubjectMatchesBySingleField_ThenIsMatchReturnsTrue()
+        {
+            var selector = ChromeCertificateSelector.Parse(
+                @"{
+                    'pattern': 'https://*.google.com/', 
+                    'filter':{
+                        'SUBJECT': {
+                            'CN': 'Subject'
+                        }
+                    }
+                }");
+
+            Assert.IsNotNull(selector.Pattern);
+            Assert.IsNull(selector.Filter.Issuer);
+            Assert.IsNotNull(selector.Filter.Subject);
+
+            Assert.IsTrue(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                SimpleIssuerDn,
+                SimpleSubjectDn));
+
+            Assert.IsTrue(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                SimpleIssuerDn,
+                ComplexSubjectDn));
+        }
+
+        [Test]
+        public void WhenUrlAndSubjectMatchByAllFields_ThenIsMatchReturnsTrue()
+        {
+            var selector = ChromeCertificateSelector.Parse(
+                @"{
+                    'pattern': 'https://*.google.com/', 
+                    'filter':{
+                        'SUBJECT': {
+                            'CN': 'Subject',
+                            'C': 'US',
+                            'S': 'CA',
+                            'L': 'MTV',
+                            'O': 'Acme',
+                            'OU': 'Sales'
+                        }
+                    }
+                }");
+
+            Assert.IsNotNull(selector.Pattern);
+            Assert.IsNull(selector.Filter.Issuer);
+            Assert.IsNotNull(selector.Filter.Subject);
+
+            Assert.IsTrue(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                SimpleIssuerDn,
+                ComplexSubjectDn));
+
+            Assert.IsFalse(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                SimpleIssuerDn,
+                SimpleSubjectDn));
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeCertificateSelector.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeCertificateSelector.cs
@@ -42,7 +42,8 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.SecureConnect
             Assert.IsFalse(selector.IsMatch(
                 new Uri("https://www.google.de"),
                 SimpleIssuerDn,
-                SimpleSubjectDn));
+                SimpleSubjectDn,
+                null));
         }
 
         [Test]
@@ -59,7 +60,8 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.SecureConnect
             Assert.IsTrue(selector.IsMatch(
                 new Uri("https://www.google.com"),
                 SimpleIssuerDn,
-                SimpleSubjectDn));
+                SimpleSubjectDn,
+                null));
         }
 
         [Test]
@@ -78,7 +80,8 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.SecureConnect
             Assert.IsTrue(selector.IsMatch(
                 new Uri("https://www.google.com"),
                 SimpleIssuerDn,
-                SimpleSubjectDn));
+                SimpleSubjectDn,
+                null));
         }
 
         //---------------------------------------------------------------------
@@ -105,12 +108,14 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.SecureConnect
             Assert.IsTrue(selector.IsMatch(
                 new Uri("https://www.google.com"),
                 ComplexIssuerDn,
-                ComplexSubjectDn));
+                ComplexSubjectDn,
+                null));
 
             Assert.IsTrue(selector.IsMatch(
                 new Uri("https://www.google.com"),
                 SimpleIssuerDn,
-                ComplexSubjectDn));
+                ComplexSubjectDn,
+                null));
         }
 
         [Test]
@@ -138,12 +143,14 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.SecureConnect
             Assert.IsTrue(selector.IsMatch(
                 new Uri("https://www.google.com"),
                 ComplexIssuerDn,
-                SimpleSubjectDn));
+                SimpleSubjectDn,
+                null));
 
             Assert.IsFalse(selector.IsMatch(
                 new Uri("https://www.google.com"),
                 SimpleIssuerDn,
-                SimpleSubjectDn));
+                SimpleSubjectDn,
+                null));
         }
 
         [Test]
@@ -169,7 +176,8 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.SecureConnect
             Assert.IsFalse(selector.IsMatch(
                 new Uri("https://www.google.com"),
                 ComplexIssuerDn,
-                ComplexSubjectDn));
+                ComplexSubjectDn,
+                null));
         }
 
         //---------------------------------------------------------------------
@@ -196,12 +204,14 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.SecureConnect
             Assert.IsTrue(selector.IsMatch(
                 new Uri("https://www.google.com"),
                 SimpleIssuerDn,
-                SimpleSubjectDn));
+                SimpleSubjectDn,
+                null));
 
             Assert.IsTrue(selector.IsMatch(
                 new Uri("https://www.google.com"),
                 SimpleIssuerDn,
-                ComplexSubjectDn));
+                ComplexSubjectDn,
+                null));
         }
 
         [Test]
@@ -229,12 +239,73 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.SecureConnect
             Assert.IsTrue(selector.IsMatch(
                 new Uri("https://www.google.com"),
                 SimpleIssuerDn,
-                ComplexSubjectDn));
+                ComplexSubjectDn,
+                null));
 
             Assert.IsFalse(selector.IsMatch(
                 new Uri("https://www.google.com"),
                 SimpleIssuerDn,
-                SimpleSubjectDn));
+                SimpleSubjectDn,
+                null));
+        }
+
+        //---------------------------------------------------------------------
+        // Thumbprint match.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenThumbprintMatches_ThenIsMatchReturnsTrue()
+        {
+            var selector = ChromeCertificateSelector.Parse(
+                @"{
+                    'pattern': 'https://*.google.com/', 
+                    'filter':{
+                        'THUMBPRINT': 'abcd'
+                    }
+                }");
+
+            Assert.IsNotNull(selector.Pattern);
+            Assert.IsNull(selector.Filter.Issuer);
+            Assert.IsNull(selector.Filter.Subject);
+            Assert.IsNotNull(selector.Filter.Thumbprint);
+
+            Assert.IsTrue(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                SimpleIssuerDn,
+                SimpleSubjectDn,
+                "ABCD"));
+
+            Assert.IsFalse(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                SimpleIssuerDn,
+                SimpleSubjectDn,
+                "0123"));
+        }
+
+        [Test]
+        public void WhenThumbprintMatchesButSubjectDoesnt_ThenIsMatchReturnsFalse()
+        {
+            var selector = ChromeCertificateSelector.Parse(
+                @"{
+                    'pattern': 'https://*.google.com/', 
+                    'THUMBPRINT': 'abcd',
+                    'filter':{
+                        'SUBJECT': {
+                            'CN': 'Somethingelse'
+                        }
+                    }
+                }");
+
+            Assert.IsNotNull(selector.Pattern);
+            Assert.IsNull(selector.Filter.Issuer);
+            Assert.IsNotNull(selector.Filter.Subject);
+            Assert.IsNotNull(selector.Filter.Thumbprint);
+
+            Assert.IsFalse(selector.IsMatch(
+                new Uri("https://www.google.com"),
+                SimpleIssuerDn,
+                ComplexSubjectDn,
+                "abcd"));
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeCertificateSelector.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeCertificateSelector.cs
@@ -23,6 +23,18 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.SecureConnect
             new X500DistinguishedName("CN=Subject");
 
         //---------------------------------------------------------------------
+        // TryParse.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenJsonMalformed_ThenTryParseReturnsFalse()
+        {
+            Assert.IsFalse(ChromeCertificateSelector.TryParse(
+                "{asd'", 
+                out var _));
+        }
+
+        //---------------------------------------------------------------------
         // URL match.
         //---------------------------------------------------------------------
 

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeCertificateSelector.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeCertificateSelector.cs
@@ -1,4 +1,25 @@
-﻿using Google.Solutions.IapDesktop.Application.Services.SecureConnect;
+﻿//
+// Copyright 2021 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.IapDesktop.Application.Services.SecureConnect;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeMatchPattern.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeMatchPattern.cs
@@ -1,0 +1,146 @@
+﻿using Google.Solutions.IapDesktop.Application.Services.SecureConnect;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.IapDesktop.Application.Test.Services.SecureConnect
+{
+    [TestFixture]
+    public class TestChromeMatchPattern : ApplicationFixtureBase
+    {
+        [Test]
+        public void WhenPatternIsMalformed_ThenParseThrowsException()
+        {
+            Assert.Throws<ArgumentException>(
+                () => ChromeMatchPattern.Parse(":"));
+            Assert.Throws<ArgumentException>(
+                () => ChromeMatchPattern.Parse("a:"));
+            Assert.Throws<ArgumentException>(
+                () => ChromeMatchPattern.Parse(":host"));
+            Assert.Throws<ArgumentException>(
+                () => ChromeMatchPattern.Parse("not/a/proper/url/*"));
+        }
+
+        [Test]
+        public void WhenPatternIsHttpUrl_ThenOnlyExactUrlsMatch()
+        {
+            var pattern = ChromeMatchPattern.Parse("http://example.org/foo/bar.html");
+
+            Assert.IsTrue(pattern.IsMatch("http://example.org/foo/bar.html"));
+            Assert.IsTrue(pattern.IsMatch("http://example.org/foo/bar.html"));
+
+            Assert.IsFalse(pattern.IsMatch("http://example.org/foo/bar.html?a=b"));
+        }
+
+        [Test]
+        public void WhenPatternIsHttpUrlAndHostAndPathAreWildcards_ThenSomeUrlsMatch()
+        {
+            var pattern = ChromeMatchPattern.Parse("http://*/*");
+
+            Assert.IsTrue(pattern.IsMatch("http://www.google.com/"));
+            Assert.IsTrue(pattern.IsMatch("http://example.org/foo/bar.html"));
+
+            Assert.IsTrue(pattern.IsMatch("HTTP://WWW.GOOGLE.COM/"));
+            Assert.IsTrue(pattern.IsMatch("HTTP://EXAMPLE.ORG/FOO/BAR.HTML"));
+
+            Assert.IsFalse(pattern.IsMatch("https://www.google.com/"));
+        }
+
+        [Test]
+        public void WhenPatternIsHttpUrlAndPathEmbedsWildcard_ThenSomeUrlsMatch()
+        {
+            var pattern = ChromeMatchPattern.Parse("http://*/foo*");
+            
+            Assert.IsTrue(pattern.IsMatch("http://example.com/foo/bar.html"));
+            Assert.IsTrue(pattern.IsMatch("http://www.google.com/foo"));
+
+            Assert.IsTrue(pattern.IsMatch("HTTP://EXAMPLE.COM/FOO/BAR.HTML"));
+            Assert.IsTrue(pattern.IsMatch("HTTP://WWW.GOOGLE.COM/FOO"));
+            
+            Assert.IsFalse(pattern.IsMatch("http://www.google.com/bar"));
+        }
+
+        [Test]
+        public void WhenPatternIsHttpUrlAndHostAndPathEmbedWildcards_ThenSomeUrlsMatch()
+        {
+            var pattern = ChromeMatchPattern.Parse("https://*.google.com/foo*bar");
+
+            Assert.IsTrue(pattern.IsMatch("https://www.google.com/foo/baz/bar"));
+            Assert.IsTrue(pattern.IsMatch("https://docs.google.com/foobar"));
+
+            Assert.IsTrue(pattern.IsMatch("HTTPS://WWW.GOOGLE.COM/FOO/BAZ/BAR"));
+            Assert.IsTrue(pattern.IsMatch("HTTPS://DOCS.GOOGLE.COM/FOOBAR"));
+
+            Assert.IsFalse(pattern.IsMatch("https://google.com/foobar"));
+            Assert.IsFalse(pattern.IsMatch("https://docs.google.com/foo"));
+        }
+
+        [Test]
+        public void WhenPatternIsFileUrlWithEmptyHostAndWildcardInPath_ThenSomeUrlsMatch()
+        {
+            var pattern = ChromeMatchPattern.Parse("file:///foo*");
+
+            Assert.IsTrue(pattern.IsMatch("file:///foo/bar.html"));
+            Assert.IsTrue(pattern.IsMatch("file:///foo"));
+
+            Assert.IsTrue(pattern.IsMatch("FILE:///FOO/BAR.HTML"));
+            Assert.IsTrue(pattern.IsMatch("FILE:///FOO"));
+
+            Assert.IsFalse(pattern.IsMatch("http:///foo"));
+            Assert.IsFalse(pattern.IsMatch("https://docs.google.com/foo"));
+        }
+
+        [Test]
+        public void WhenPatternIsHttpUrlPathIsWildcard_ThenSomeUrlsMatch()
+        {
+            var pattern = ChromeMatchPattern.Parse("http://127.0.0.1/*");
+
+            Assert.IsTrue(pattern.IsMatch("http://127.0.0.1/"));
+            Assert.IsTrue(pattern.IsMatch("http://127.0.0.1/foo/bar.html"));
+
+            Assert.IsTrue(pattern.IsMatch("HTTP://127.0.0.1/"));
+            Assert.IsTrue(pattern.IsMatch("HTTP://127.0.0.1/FOO/BAR.HTML"));
+
+            Assert.IsFalse(pattern.IsMatch("http://127.0.0.2/"));
+        }
+
+        [Test]
+        public void WhenPatternHasWildcardScheme_ThenSomeUrlsMatch()
+        {
+            var pattern = ChromeMatchPattern.Parse("*://mail.google.com/*");
+
+            Assert.IsTrue(pattern.IsMatch("http://mail.google.com/foo/baz/bar"));
+            Assert.IsTrue(pattern.IsMatch("https://mail.google.com/foobar"));
+
+            Assert.IsTrue(pattern.IsMatch("HTTP://MAIL.GOOGLE.COM/FOO/BAZ/BAR"));
+            Assert.IsTrue(pattern.IsMatch("HTTPS://MAIL.GOOGLE.COM/FOOBAR"));
+
+            Assert.IsFalse(pattern.IsMatch("file://mail.google.com/foobar"));
+        }
+
+        [Test]
+        public void WhenPatternIsUrn_ThenSomeUrlsMatch()
+        {
+            var pattern = ChromeMatchPattern.Parse("urn:*");
+
+            Assert.IsTrue(pattern.IsMatch("urn:uuid:54723bea-c94e-480e-80c8-a69846c3f582"));
+
+            Assert.IsFalse(pattern.IsMatch("file://mail.google.com/foobar"));
+        }
+
+        [Test]
+        public void WhenPatternIsAllUrls_ThenAllUrlsMatch()
+        {
+            var pattern = ChromeMatchPattern.Parse("<all_urls>");
+
+            Assert.IsTrue(pattern.IsMatch("http://mail.google.com/foo/baz/bar"));
+            Assert.IsTrue(pattern.IsMatch("FILE:///FOO/BAR.HTML"));
+            Assert.IsTrue(pattern.IsMatch("urn:uuid:54723bea-c94e-480e-80c8-a69846c3f582"));
+        }
+
+        // TODO: Test square brackets around wildcards, IPv6 addresses
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeMatchPattern.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/SecureConnect/TestChromeMatchPattern.cs
@@ -1,4 +1,25 @@
-﻿using Google.Solutions.IapDesktop.Application.Services.SecureConnect;
+﻿//
+// Copyright 2021 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.IapDesktop.Application.Services.SecureConnect;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;

--- a/sources/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
+++ b/sources/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
@@ -137,6 +137,8 @@
     <Compile Include="Services\ProjectModel\ProjectModelEvents.cs" />
     <Compile Include="Services\ProjectModel\ProjectModelNodes.cs" />
     <Compile Include="Services\ProjectModel\ProjectModelService.cs" />
+    <Compile Include="Services\SecureConnect\ChromeCertificateSelector.cs" />
+    <Compile Include="Services\SecureConnect\ChromeMatchPattern.cs" />
     <Compile Include="Services\SecureConnect\SecureConnectEnrollment.cs" />
     <Compile Include="Services\Integration\SessionBroker.cs" />
     <Compile Include="Services\Integration\EventService.cs" />

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/CertificateStoreAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/CertificateStoreAdapter.cs
@@ -28,9 +28,9 @@ namespace Google.Solutions.IapDesktop.Application.Services.Adapters
 {
     public interface ICertificateStoreAdapter
     {
-        IEnumerable<X509Certificate2> ListUserCertitficates(
-            string issuer,
-            string subject);
+        IEnumerable<X509Certificate2> ListComputerCertitficates();
+
+        IEnumerable<X509Certificate2> ListUserCertitficates();
     }
 
     public class CertificateStoreAdapter : ICertificateStoreAdapter
@@ -56,19 +56,22 @@ namespace Google.Solutions.IapDesktop.Application.Services.Adapters
             }
         }
 
-        public IEnumerable<X509Certificate2> ListUserCertitficates(
-            string issuer,
-            string subject)
+        private IEnumerable<X509Certificate2> ListCertitficates(
+            StoreLocation storeLocation)
         {
-            using (ApplicationTraceSources.Default.TraceMethod().WithParameters(issuer, subject))
-            using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser))
+            using (ApplicationTraceSources.Default.TraceMethod().WithParameters(storeLocation))
+            using (var store = new X509Store(StoreName.My, storeLocation))
             {
                 store.Open(OpenFlags.ReadOnly);
                 return store.Certificates
-                    .Cast<X509Certificate2>()
-                    .Where(c => c.Issuer == issuer)
-                    .Where(c => c.Subject == subject);
+                    .Cast<X509Certificate2>();
             }
         }
+
+        public IEnumerable<X509Certificate2> ListUserCertitficates()
+            => ListCertitficates(StoreLocation.CurrentUser);
+
+        public IEnumerable<X509Certificate2> ListComputerCertitficates()
+            => ListCertitficates(StoreLocation.LocalMachine);
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Application/Services/SecureConnect/ChromeCertificateSelector.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/SecureConnect/ChromeCertificateSelector.cs
@@ -36,6 +36,20 @@ namespace Google.Solutions.IapDesktop.Application.Services.SecureConnect
             return JsonConvert.DeserializeObject<ChromeCertificateSelector>(json);
         }
 
+        public static bool TryParse(string json, out ChromeCertificateSelector selector)
+        {
+            try
+            {
+                selector = Parse(json);
+                return true;
+            }
+            catch
+            {
+                selector = null;
+                return false;
+            }
+        }
+
         public bool IsMatch(
             Uri uri,
             X500DistinguishedName issuer,

--- a/sources/Google.Solutions.IapDesktop.Application/Services/SecureConnect/ChromeCertificateSelector.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/SecureConnect/ChromeCertificateSelector.cs
@@ -1,0 +1,121 @@
+﻿using Google.Apis.Util;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.IapDesktop.Application.Services.SecureConnect
+{
+    /// <summary>
+    /// Certificate selector as defined in
+    /// https://chromeenterprise.google/policies/?policy=AutoSelectCertificateForUrls.
+    /// </summary>
+    internal class ChromeCertificateSelector
+    {
+        public ChromeMatchPattern Pattern { get; }
+        public CertificateFilter Filter { get; }
+
+        [JsonConstructor]
+        public ChromeCertificateSelector(
+            [JsonProperty("pattern")] string pattern,
+            [JsonProperty("filter")] CertificateFilter filter)
+        {
+            this.Pattern = ChromeMatchPattern.Parse(pattern ?? ChromeMatchPattern.AllUrls);
+            this.Filter = filter ?? new CertificateFilter();
+        }
+
+        public static ChromeCertificateSelector Parse(string json)
+        {
+            Utilities.ThrowIfNullOrEmpty(json, nameof(json));
+            return JsonConvert.DeserializeObject<ChromeCertificateSelector>(json);
+        }
+
+        public bool IsMatch(
+            Uri uri,
+            X500DistinguishedName issuer,
+            X500DistinguishedName subject)
+        {
+            return
+                this.Pattern.IsMatch(uri) &&
+                (this.Filter.Issuer == null || this.Filter.Issuer.IsMatch(issuer)) &&
+                (this.Filter.Subject == null || this.Filter.Subject.IsMatch(subject));
+        }
+
+        public bool IsMatch(
+            Uri uri,
+            X509Certificate2 certificate)
+            => IsMatch(uri, certificate.IssuerName, certificate.SubjectName);
+
+        //---------------------------------------------------------------------
+        // Inner classes for deserialization.
+        //---------------------------------------------------------------------
+
+        public class CertificateFilter
+        {
+            [JsonConstructor]
+            public CertificateFilter(
+                [JsonProperty("ISSUER")] DistinguishedNameFilter issuer,
+                [JsonProperty("SUBJECT")] DistinguishedNameFilter subject)
+            {
+                Issuer = issuer;
+                Subject = subject;
+            }
+
+            public CertificateFilter() : this(null, null)
+            {
+            }
+
+            [JsonProperty("ISSUER")]
+            public DistinguishedNameFilter Issuer { get; }
+            
+            [JsonProperty("SUBJECT")]
+            public DistinguishedNameFilter Subject { get; }
+        }
+
+        public class DistinguishedNameFilter
+        {
+            [JsonConstructor]
+            public DistinguishedNameFilter(
+                [JsonProperty("CN")] string commonName,
+                [JsonProperty("L")] string location,
+                [JsonProperty("O")] string organization,
+                [JsonProperty("OU")] string orgUnit)
+            {
+                CommonName = commonName;
+                Location = location;
+                Organization = organization;
+                OrgUnit = orgUnit;
+            }
+
+            [JsonProperty("CN")]
+            public string CommonName { get; }
+
+            [JsonProperty("L")]
+            public string Location { get; }
+
+            [JsonProperty("O")]
+            public string Organization { get; }
+
+            [JsonProperty("OU")]
+            public string OrgUnit { get; }
+
+            public bool IsMatch(X500DistinguishedName dn)
+            {
+                var components = dn
+                    .Format(true)
+                    .Split('\n')
+                    .Select(s => s.Trim())
+                    .ToList();
+
+                return
+                    (this.CommonName == null || components.Contains($"CN={this.CommonName}")) &&
+                    (this.Location == null || components.Contains($"L={this.Location}")) &&
+                    (this.Organization == null || components.Contains($"O={this.Organization}")) &&
+                    (this.OrgUnit == null || components.Contains($"OU={this.OrgUnit}"));
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Application/Services/SecureConnect/ChromeCertificateSelector.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/SecureConnect/ChromeCertificateSelector.cs
@@ -1,4 +1,25 @@
-﻿using Google.Apis.Util;
+﻿//
+// Copyright 2021 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Apis.Util;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/sources/Google.Solutions.IapDesktop.Application/Services/SecureConnect/ChromeMatchPattern.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/SecureConnect/ChromeMatchPattern.cs
@@ -1,0 +1,77 @@
+﻿using Google.Apis.Util;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.IapDesktop.Application.Services.SecureConnect
+{
+    /// <summary>
+    /// Match pattern as defined in 
+    /// https://developer.chrome.com/docs/extensions/mv3/match_patterns/.
+    /// </summary>
+    internal class ChromeMatchPattern
+    {
+        public const string AllUrls = "<all_urls>";
+
+        private readonly Regex pattern;
+
+        private ChromeMatchPattern(Regex pattern)
+        {
+            this.pattern = pattern;
+        }
+
+        public bool IsMatch(string input)
+        {
+            return this.pattern.IsMatch(input);
+        }
+
+        public bool IsMatch(Uri input)
+            => IsMatch(input.ToString());
+
+        public static ChromeMatchPattern Parse(string pattern)
+        {
+            Utilities.ThrowIfNullOrEmpty(pattern, nameof(pattern));
+
+            //
+            // The pattern can contain * wildcards, but the semantics
+            // differ on whether the location is in the scheme, host,
+            // or path portion of the URL.
+            //
+            if (pattern == AllUrls)
+            {
+                return new ChromeMatchPattern(new Regex(".*"));
+            }
+
+            var colonIndex = pattern.IndexOf(':');
+            if (colonIndex < 1 || colonIndex == pattern.Length -1)
+            {
+                throw new ArgumentException("Pattern must use syntax scheme://host/path");
+            }
+
+            //
+            // If the scheme is *, then it matches either http or https, and
+            // not file, ftp, or urn.
+            //
+            var scheme = pattern.Substring(0, colonIndex);
+            scheme = scheme == "*" ? "(http|https)" : scheme;
+
+            //
+            // If the host is just *, then it matches any host. If the host
+            // is *._hostname_, then it matches the specified host or any of its subdomains.
+            //
+            // In the path section, each '*' matches 0 or more characters. 
+            //
+            var hostAndPath = pattern.Substring(colonIndex + 1, pattern.Length - colonIndex - 1);
+            hostAndPath = hostAndPath
+                .Replace(".", "\\.")
+                .Replace("*", ".*");
+
+            return new ChromeMatchPattern(new Regex(
+                $"^{scheme}:{hostAndPath}$",
+                RegexOptions.IgnoreCase));
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Application/Services/SecureConnect/ChromeMatchPattern.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/SecureConnect/ChromeMatchPattern.cs
@@ -1,4 +1,25 @@
-﻿using Google.Apis.Util;
+﻿//
+// Copyright 2021 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Apis.Util;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/sources/Google.Solutions.IapDesktop.Application/Services/SecureConnect/SecureConnectEnrollment.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/SecureConnect/SecureConnectEnrollment.cs
@@ -22,7 +22,9 @@
 using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.IapDesktop.Application.Services.Adapters;
 using Google.Solutions.IapDesktop.Application.Services.Settings;
+using System;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
@@ -30,10 +32,43 @@ namespace Google.Solutions.IapDesktop.Application.Services.SecureConnect
 {
     public class SecureConnectEnrollment : IDeviceEnrollment
     {
-        private const string DeviceCertIssuer = "CN=Google Endpoint Verification";
+        //
+        // By default, use the certificate provisioned by the
+        // SecureConnect native helper.
+        //
+        public const string DefaultDeviceCertificateSelector =
+            @"{
+                'filter':{
+                    'ISSUER': {
+                        'CN': 'Google Endpoint Verification'
+                    },
+                    'SUBJECT': {
+                        'CN': 'Google Endpoint Verification'
+                    }
+                }
+            }";
+
+        //
+        // URL Endpoint Verification uses to select a device certificate,
+        // cf. go/ec-sc-design.
+        //
+        private static readonly Uri CertificateSelectorUrl 
+            = new Uri("https://secureconnect-pa.mtls.clients6.google.com/");
+
+        private const string EnhancedKeyUsageOid = "2.5.29.37";
+        private const string ClientAuthenticationKeyUsageOid = "1.3.6.1.5.5.7.3.2";
 
         private readonly ApplicationSettingsRepository applicationSettingsRepository;
         private readonly ICertificateStoreAdapter certificateStore;
+
+        private static bool IsCertificateUsableForClientAuthentication(X509Certificate2 certificate)
+        {
+            return certificate.Extensions
+                .OfType<X509EnhancedKeyUsageExtension>()
+                .Where(ext => ext.Oid.Value == EnhancedKeyUsageOid)
+                .SelectMany(ext => ext.EnhancedKeyUsages.Cast<Oid>())
+                .Any(oid => oid.Value == ClientAuthenticationKeyUsageOid);
+        }
 
         private SecureConnectEnrollment(
             ICertificateStoreAdapter certificateStore,
@@ -62,42 +97,52 @@ namespace Google.Solutions.IapDesktop.Application.Services.SecureConnect
                 }
 
                 //
-                // Check if there is a certificate in the certificate store.
+                // Get the selector that determines how to find the device
+                // certificate.
                 //
-                var certificate = this.certificateStore.ListUserCertitficates(
-                        DeviceCertIssuer,
-                        DeviceCertIssuer)
-                    .FirstOrDefault();
-
-                if (certificate != null)
+                if (ChromeCertificateSelector.TryParse(
+                    this.applicationSettingsRepository.GetSettings().DeviceCertificateSelector.StringValue,
+                    out var selector))
                 {
                     //
-                    // Certificate found - this does not necessarily mean that it's
-                    // associated with the signed-on user, but finding out
-                    // would require interacting with the undocumented APIs
-                    // of the native helper. 
+                    // Check if there is a certificate in the certificate store.
+                    // Check computer certificates first, then user certificates.
                     //
-                    // False positives are harmless, so assume the device is enrolled.
-                    //
+                    var certificate = this.certificateStore.ListComputerCertitficates()
+                        .Concat(this.certificateStore.ListUserCertitficates())
+                        .Where(IsCertificateUsableForClientAuthentication)
+                        .Where(cert => selector.IsMatch(CertificateSelectorUrl, cert))
+                        .FirstOrDefault();
 
-                    ApplicationTraceSources.Default.TraceInformation("Device certificate found " +
-                        "in certificate store, assuming device to be enrolled");
+                    if (certificate != null)
+                    {
+                        //
+                        // Certificate found - this does not necessarily mean that it's
+                        // associated with the signed-on user, but finding out
+                        // would require interacting with the undocumented APIs
+                        // of the native helper. 
+                        //
+                        // False positives are harmless, so assume the device is enrolled.
+                        //
 
-                    this.State = DeviceEnrollmentState.Enrolled;
-                    this.Certificate = certificate;
+                        ApplicationTraceSources.Default.TraceInformation("Device certificate found " +
+                            "in certificate store, assuming device to be enrolled");
+
+                        this.State = DeviceEnrollmentState.Enrolled;
+                        this.Certificate = certificate;
+                        return;
+                    }
                 }
-                else
-                {
-                    //
-                    // No certiticate found, so the device cannot be enrolled.
-                    // 
 
-                    ApplicationTraceSources.Default.TraceInformation("No device certificate found " +
-                        "in certificate store, device not enrolled");
+                //
+                // No certiticate found, so the device cannot be enrolled.
+                // 
+                ApplicationTraceSources.Default.TraceInformation(
+                    "No suitable device certificate found " +
+                    "in certificate store, device not enrolled");
 
-                    this.State = DeviceEnrollmentState.NotEnrolled;
-                    this.Certificate = null;
-                }
+                this.State = DeviceEnrollmentState.NotEnrolled;
+                this.Certificate = null;
             }
         }
 

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Settings/ApplicationSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Settings/ApplicationSettingsRepository.cs
@@ -21,6 +21,7 @@
 
 using Google.Apis.Util;
 using Google.Solutions.IapDesktop.Application.Services.Adapters;
+using Google.Solutions.IapDesktop.Application.Services.SecureConnect;
 using Google.Solutions.IapDesktop.Application.Settings;
 using Microsoft.Win32;
 using System;
@@ -88,6 +89,8 @@ namespace Google.Solutions.IapDesktop.Application.Services.Settings
 
         public RegistryEnumSetting<OperatingSystems> IncludeOperatingSystems { get; private set; }
 
+        public RegistryStringSetting DeviceCertificateSelector { get; private set; }
+
         public IEnumerable<ISetting> Settings => new ISetting[]
         {
             this.IsMainWindowMaximized,
@@ -102,7 +105,8 @@ namespace Google.Solutions.IapDesktop.Application.Services.Settings
             this.ProxyPassword,
             this.IsDeviceCertificateAuthenticationEnabled,
             this.FullScreenDevices,
-            this.IncludeOperatingSystems
+            this.IncludeOperatingSystems,
+            this.DeviceCertificateSelector
         };
 
         private ApplicationSettings()
@@ -170,6 +174,16 @@ namespace Google.Solutions.IapDesktop.Application.Services.Settings
                         url => url == null || Uri.TryCreate(url, UriKind.Absolute, out Uri _))
                     .ApplyPolicy(userPolicyKey)
                     .ApplyPolicy(machinePolicyKey),
+                DeviceCertificateSelector = RegistryStringSetting.FromKey(
+                        "DeviceCertificateSelector",
+                        "DeviceCertificateSelector",
+                        null,
+                        null,
+                        SecureConnectEnrollment.DefaultDeviceCertificateSelector,
+                        settingsKey,
+                        selector => selector == null || ChromeCertificateSelector.TryParse(selector, out var _))
+                    .ApplyPolicy(userPolicyKey)
+                    .ApplyPolicy(machinePolicyKey), // TODO: extend ADMX
 
                 //
                 // User preferences. These cannot be overriden by policy.


### PR DESCRIPTION
Allow selecting a custom client certificate in place of the default
EV-provisioned certificate. The filter uses a syntax derived from
Chrome's AutoSelectCertificateForUrls filter syntax.