### PR TITLE
b/197119916 Handle proxy-induced HTTP 403 errors

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Views/HelpService.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/HelpService.cs
@@ -80,6 +80,10 @@ namespace Google.Solutions.IapDesktop.Application.Views
             "Granting OS Login IAM roles",
             "https://cloud.google.com/compute/docs/instances/managing-instance-access#grant-iam-roles");
 
+        public static readonly IHelpTopic ProxyConfiguration = new HelpTopic(
+            "Proxy Configuration",
+            "https://github.com/GoogleCloudPlatform/iap-desktop/wiki/Proxy-Configuration");
+
         private class HelpTopic : IHelpTopic
         {
             public string Title { get; }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Rdp/RdpConnectionService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Rdp/RdpConnectionService.cs
@@ -114,6 +114,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Rdp
                             "and that your user has the 'IAP-secured Tunnel User' role.",
                             HelpTopics.IapAccess);
                     }
+                    catch (WebSocketConnectionDeniedException)
+                    {
+                        throw new ConnectionFailedException(
+                            "Failed to establish an IAP connection to the VM instance.\n\n" +
+                            "This error might be caused by a proxy server disallowing " + 
+                            "WebSocket connections.",
+                            HelpTopics.ProxyConfiguration);
+
+                    }
                 }).ConfigureAwait(true);
 
             this.sessionBroker.Connect(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Ssh/SshConnectionService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Ssh/SshConnectionService.cs
@@ -156,6 +156,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Ssh
                             "and that your user has the 'IAP-secured Tunnel User' role.",
                             HelpTopics.IapAccess);
                     }
+                    catch (WebSocketConnectionDeniedException)
+                    {
+                        throw new ConnectionFailedException(
+                            "Failed to establish an IAP connection to the VM instance.\n\n" +
+                            "This error might be caused by a proxy server disallowing " +
+                            "WebSocket connections.",
+                            HelpTopics.ProxyConfiguration);
+
+                    }
                 });
 
 

--- a/sources/Google.Solutions.IapTunneling.Test/Iap/TestSshRelayStreamReading.cs
+++ b/sources/Google.Solutions.IapTunneling.Test/Iap/TestSshRelayStreamReading.cs
@@ -634,5 +634,24 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                 bytesRead = relay.ReadAsync(buffer, 0, buffer.Length, tokenSource.Token).Result;
             });
         }
+
+        [Test]
+        public void WhenServerClosesConnectionWithNotAuthorized_ThenTestConnectionAsyncThrowsUnauthorizedException()
+        {
+            var stream = new MockStream()
+            {
+                ExpectServerCloseCodeOnRead = (WebSocketCloseStatus)CloseCode.NOT_AUTHORIZED
+            };
+            var endpoint = new MockSshRelayEndpoint()
+            {
+                ExpectedStream = stream
+            };
+            var relay = new SshRelayStream(endpoint);
+
+            AssertEx.ThrowsAggregateException<UnauthorizedException>(
+                () => relay
+                    .TestConnectionAsync(TimeSpan.FromSeconds(2))
+                    .Wait());
+        }
     }
 }

--- a/sources/Google.Solutions.IapTunneling/Iap/SshRelayStream.cs
+++ b/sources/Google.Solutions.IapTunneling/Iap/SshRelayStream.cs
@@ -25,6 +25,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.WebSockets;
 using System.Runtime.Serialization;
 using System.Threading;
@@ -253,6 +254,9 @@ namespace Google.Solutions.IapTunneling.Iap
             catch (WebSocketStreamClosedByServerException e)
                 when ((CloseCode)e.CloseStatus == CloseCode.NOT_AUTHORIZED)
             {
+                //
+                // Request was rejected by access level or IAM policy.
+                //
                 throw new UnauthorizedException(e.CloseStatusDescription);
             }
             catch (OperationCanceledException)

--- a/sources/Google.Solutions.IapTunneling/Net/WebSocketStream.cs
+++ b/sources/Google.Solutions.IapTunneling/Net/WebSocketStream.cs
@@ -293,6 +293,19 @@ namespace Google.Solutions.IapTunneling.Net
     }
 
     [Serializable]
+    public class WebSocketConnectionDeniedException : Exception
+    {
+        protected WebSocketConnectionDeniedException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+
+        public WebSocketConnectionDeniedException()
+        {
+        }
+    }
+
+    [Serializable]
     public class WebSocketStreamClosedByServerException : NetworkStreamClosedException
     {
         public WebSocketCloseStatus CloseStatus { get; private set; }


### PR DESCRIPTION
Handle HTTP 403 errors when connecting to IAP, and
indicate that errors might be caused by proxy servers
as opposed to IAM policies.