### PR TITLE
b/191138997 Close local connection when server connection is closed

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Adapter/OsLoginAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Adapter/OsLoginAdapter.cs
@@ -119,7 +119,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Adapter
                 {
                     //
                     // Likely reason: The user account is a consumer account or
-                    // an administrator has disable POSIX account/SSH key information
+                    // an administrator has disabled POSIX account/SSH key information
                     // updates in the Admin Console.
                     //
                     throw new ResourceAccessDeniedException(

--- a/sources/Google.Solutions.IapTunneling/Iap/SshRelayListener.cs
+++ b/sources/Google.Solutions.IapTunneling/Iap/SshRelayListener.cs
@@ -191,6 +191,9 @@ namespace Google.Solutions.IapTunneling.Iap
                                     }
 
                                     OnClientDisconnected(clientStream.ToString());
+
+                                    clientStream.Dispose();
+                                    serverStream.Dispose();
                                 });
                         }
                         catch (SocketException e) when (e.SocketErrorCode == SocketError.Interrupted)


### PR DESCRIPTION
This fixes an issue where a lost server connection (or failed
SSH keepalive) did not cause the SSH terminal pane to show
the "Session disconnected" panel.