### PR TITLE
Unconditionally remove BOM from sponge_log.xml

### DIFF
--- a/sources/build.bat
+++ b/sources/build.bat
@@ -29,8 +29,13 @@ powershell -NoProfile -ExecutionPolicy Bypass -File build.ps1 %*
 
 rem Remove BOM to make file compatible with Sponge.
 set RETURNVALUE=%ERRORLEVEL%
+
+echo "Build exited with %ERRORLEVEL%"
 if exist sponge_log.xml (
+    echo "Sponge_log.xml exists"
     powershell -NoProfile -ExecutionPolicy Bypass -File scripts\strip-bom.ps1 sponge_log.xml
+) else (
+    echo "No sponge_log.xml found"
 )
 
 exit /b %RETURNVALUE%

--- a/sources/build.bat
+++ b/sources/build.bat
@@ -29,13 +29,11 @@ powershell -NoProfile -ExecutionPolicy Bypass -File build.ps1 %*
 
 rem Remove BOM to make file compatible with Sponge.
 set RETURNVALUE=%ERRORLEVEL%
+echo "Build exited with exit code %ERRORLEVEL%"
 
-echo "Build exited with %ERRORLEVEL%"
 if exist sponge_log.xml (
-    echo "Sponge_log.xml exists"
+    echo "Removing BOM from sponge_log.xml"
     powershell -NoProfile -ExecutionPolicy Bypass -File scripts\strip-bom.ps1 sponge_log.xml
-) else (
-    echo "No sponge_log.xml found"
 )
 
 exit /b %RETURNVALUE%

--- a/sources/build.bat
+++ b/sources/build.bat
@@ -27,4 +27,10 @@ cd %~dp0
 rem Invoke build.
 powershell -NoProfile -ExecutionPolicy Bypass -File build.ps1 %*
 
-exit /b %ERRORLEVEL%
+rem Remove BOM to make file compatible with Sponge.
+set RETURNVALUE=%ERRORLEVEL%
+if exist sponge_log.xml (
+    powershell -NoProfile -ExecutionPolicy Bypass -File scripts\strip-bom.ps1 sponge_log.xml
+)
+
+exit /b %RETURNVALUE%

--- a/sources/makefile
+++ b/sources/makefile
@@ -253,8 +253,6 @@ test: $(NUNIT_ASSEMBLIES)
 		-targetdir:coveragereport \
 		-reporttypes:HTML
 
-    $(POWERSHELL) $(MAKEDIR)\scripts\strip-bom.ps1 sponge_log.xml
-    
 installer: $(INSTALLER_PACKAGE)
 installer-snapshot: $(INSTALLER_SNAPSHOT) 
 symbols: $(SYMBOLS_PACKAGE)


### PR DESCRIPTION
BOM needs to be removed regardless of whether tests
suceeded or failed. Previously, the BOM was only removed
if tests succeeded.