### PR TITLE
Rename AssertEx class

### DIFF
--- a/sources/Google.Solutions.Common.Test/ApiExtensions/Instance/TestAddMetadata.cs
+++ b/sources/Google.Solutions.Common.Test/ApiExtensions/Instance/TestAddMetadata.cs
@@ -165,7 +165,7 @@ namespace Google.Solutions.Common.Test.Extensions
             var key = Guid.NewGuid().ToString();
 
             int callbacks = 0;
-            AssertEx.ThrowsAggregateException<GoogleApiException>(
+            ExceptionAssert.ThrowsAggregateException<GoogleApiException>(
                 () => this.instancesResource.UpdateMetadataAsync(
                     locator,
                     metadata =>
@@ -279,7 +279,7 @@ namespace Google.Solutions.Common.Test.Extensions
             var key = Guid.NewGuid().ToString();
 
             int callbacks = 0;
-            AssertEx.ThrowsAggregateException<GoogleApiException>(
+            ExceptionAssert.ThrowsAggregateException<GoogleApiException>(
                 () => this.projectsResource.UpdateMetadataAsync(
                     TestProject.ProjectId,
                     metadata =>

--- a/sources/Google.Solutions.Common.Test/ApiExtensions/Request/TestExecuteAsStreamExtensions.cs
+++ b/sources/Google.Solutions.Common.Test/ApiExtensions/Request/TestExecuteAsStreamExtensions.cs
@@ -45,7 +45,7 @@ namespace Google.Solutions.Common.Test.Extensions
                 HttpClientInitializer = await credential
             });
 
-            AssertEx.ThrowsAggregateException<GoogleApiException>(
+            ExceptionAssert.ThrowsAggregateException<GoogleApiException>(
                 () => computeService.Instances.Get("invalid", "invalid", "invalid")
                     .ExecuteAsStreamOrThrowAsync(CancellationToken.None).Wait());
         }

--- a/sources/Google.Solutions.Common.Test/Assert.cs
+++ b/sources/Google.Solutions.Common.Test/Assert.cs
@@ -29,7 +29,7 @@ using System.Reflection;
 
 namespace Google.Solutions.Common.Test
 {
-    public static class AssertEx
+    public static class ExceptionAssert
     {
         public static TActual ThrowsAggregateException<TActual>(TestDelegate code) where TActual : Exception
         {
@@ -45,7 +45,10 @@ namespace Google.Solutions.Common.Test
                 }
             });
         }
+    }
 
+    public static class PropertyAssert
+    { 
         public static void ArePropertiesEqual<T>(T expected, T actual)
         {
             var properties = typeof(T).GetProperties(BindingFlags.Public | BindingFlags.Instance);

--- a/sources/Google.Solutions.Common.Test/Google.Solutions.Common.Test.csproj
+++ b/sources/Google.Solutions.Common.Test/Google.Solutions.Common.Test.csproj
@@ -96,7 +96,7 @@
     <Compile Include="ApiExtensions\Instance\TestAddMetadata.cs" />
     <Compile Include="ApiExtensions\Instance\TestMetadataExtensions.cs" />
     <Compile Include="ApiExtensions\Request\TestExecuteAsStreamExtensions.cs" />
-    <Compile Include="AssertEx.cs" />
+    <Compile Include="Assert.cs" />
     <Compile Include="Auth\TestAuthorization.cs" />
     <Compile Include="Auth\TestGoogleAuthAdapter.cs" />
     <Compile Include="Diagnostics\TestClrVersion.cs" />

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestComputeEngineAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestComputeEngineAdapter.cs
@@ -61,7 +61,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         {
             var adapter = new ComputeEngineAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.GetProjectAsync(
                     TestProject.ProjectId,
                     CancellationToken.None).Wait());
@@ -73,7 +73,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         {
             var adapter = new ComputeEngineAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<GoogleApiException>(
+            ExceptionAssert.ThrowsAggregateException<GoogleApiException>(
                 () => adapter.GetProjectAsync(
                     TestProject.InvalidProjectId,
                     CancellationToken.None).Wait());
@@ -129,7 +129,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         {
             var adapter = new ComputeEngineAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.ListInstancesAsync(
                     TestProject.ProjectId,
                     CancellationToken.None).Wait());
@@ -141,7 +141,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         {
             var adapter = new ComputeEngineAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.ListInstancesAsync(
                     new ZoneLocator(TestProject.ProjectId, "us-central1-a"),
                     CancellationToken.None).Wait());
@@ -155,7 +155,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
             var locator = await testInstance;
             var adapter = new ComputeEngineAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.GetInstanceAsync(
                     locator,
                     CancellationToken.None).Wait());
@@ -173,7 +173,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
             var locator = await testInstance;
             var adapter = new ComputeEngineAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.GetGuestAttributesAsync(
                     locator,
                     "somepath/",
@@ -190,7 +190,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         {
             var adapter = new ComputeEngineAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.ListNodeGroupsAsync(
                     TestProject.ProjectId,
                     CancellationToken.None).Wait());
@@ -202,12 +202,12 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         {
             var adapter = new ComputeEngineAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.ListNodesAsync(
                     TestProject.ProjectId,
                     CancellationToken.None).Wait());
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.ListNodesAsync(
                     new ZoneLocator(TestProject.ProjectId, "us-central1-a"),
                     "group-1",
@@ -224,7 +224,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         {
             var adapter = new ComputeEngineAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.ListDisksAsync(
                     TestProject.ProjectId,
                     CancellationToken.None).Wait());
@@ -236,7 +236,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         {
             var adapter = new ComputeEngineAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.GetImageAsync(
                     new ImageLocator(TestProject.ProjectId, "someimage"),
                     CancellationToken.None).Wait());

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestResourceManagerAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestResourceManagerAdapter.cs
@@ -96,7 +96,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         {
             using (var adapter = new ResourceManagerAdapter(await credential))
             {
-                AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+                ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                     () => adapter.GetProjectAsync(
                         TestProject.ProjectId,
                         CancellationToken.None).Wait());
@@ -109,7 +109,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         {
             using (var adapter = new ResourceManagerAdapter(await credential))
             {
-                AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+                ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                     () => adapter.GetProjectAsync(
                         "invalid",
                         CancellationToken.None).Wait());

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestWindowsCredentialAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestWindowsCredentialAdapter.cs
@@ -177,7 +177,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
             {
                 cts.Cancel();
 
-                AssertEx.ThrowsAggregateException<TaskCanceledException>(
+                ExceptionAssert.ThrowsAggregateException<TaskCanceledException>(
                     () => adapter.CreateWindowsCredentialsAsync(
                     instanceLocator,
                     "test" + Guid.NewGuid().ToString().Substring(20),
@@ -197,7 +197,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
             var instanceLocator = await testInstance;
             using (var cts = new CancellationTokenSource())
             {
-                AssertEx.ThrowsAggregateException<WindowsCredentialCreationFailedException>(
+                ExceptionAssert.ThrowsAggregateException<WindowsCredentialCreationFailedException>(
                     () => adapter.CreateWindowsCredentialsAsync(
                     instanceLocator,
                     "test" + Guid.NewGuid().ToString().Substring(20),
@@ -248,7 +248,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
             var adapter = new WindowsCredentialAdapter(new ComputeEngineAdapter(await credential));
             var username = "test" + Guid.NewGuid().ToString();
 
-            AssertEx.ThrowsAggregateException<WindowsCredentialCreationFailedException>(
+            ExceptionAssert.ThrowsAggregateException<WindowsCredentialCreationFailedException>(
                 () => adapter.CreateWindowsCredentialsAsync(
                     locator,
                     username,
@@ -282,7 +282,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
             var adapter = new WindowsCredentialAdapter(new ComputeEngineAdapter(await credential));
             var username = "test" + Guid.NewGuid().ToString();
 
-            AssertEx.ThrowsAggregateException<WindowsCredentialCreationFailedException>(
+            ExceptionAssert.ThrowsAggregateException<WindowsCredentialCreationFailedException>(
                 () => adapter.CreateWindowsCredentialsAsync(
                     locator,
                     username,

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/Integration/TestJobService.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/Integration/TestJobService.cs
@@ -162,7 +162,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Integration
         {
             this.jobHost.Setup(h => h.ConfirmReauthorization()).Returns(false);
 
-            AssertEx.ThrowsAggregateException<TaskCanceledException>(() =>
+            ExceptionAssert.ThrowsAggregateException<TaskCanceledException>(() =>
             {
                 this.jobService.RunInBackground<string>(
                     new JobDescription("test"),
@@ -186,7 +186,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Integration
             this.authService.Setup(a => a.ReauthorizeAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new ApplicationException()));
 
-            AssertEx.ThrowsAggregateException<ApplicationException>(() =>
+            ExceptionAssert.ThrowsAggregateException<ApplicationException>(() =>
             {
                 this.jobService.RunInBackground<string>(
                     new JobDescription("test"),
@@ -273,7 +273,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Integration
         {
             this.jobHost.Setup(h => h.ConfirmReauthorization()).Returns(false);
 
-            AssertEx.ThrowsAggregateException<TaskCanceledException>(() =>
+            ExceptionAssert.ThrowsAggregateException<TaskCanceledException>(() =>
             {
                 this.jobService.RunInBackground<string>(
                     new JobDescription("test"),
@@ -298,7 +298,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Integration
             this.authService.Setup(a => a.ReauthorizeAsync(It.IsAny<CancellationToken>()))
                 .Returns(Task.FromException(new ApplicationException()));
 
-            AssertEx.ThrowsAggregateException<ApplicationException>(() =>
+            ExceptionAssert.ThrowsAggregateException<ApplicationException>(() =>
             {
                 this.jobService.RunInBackground<string>(
                     new JobDescription("test"),

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/ProjectModel/TestProjectModelService.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/ProjectModel/TestProjectModelService.cs
@@ -334,7 +334,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.ProjectModel
 
             var modelService = new ProjectModelService(serviceRegistry);
 
-            AssertEx.ThrowsAggregateException<TokenResponseException>(
+            ExceptionAssert.ThrowsAggregateException<TokenResponseException>(
                 () => modelService.GetRootNodeAsync(false, CancellationToken.None).Wait());
         }
 
@@ -533,7 +533,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.ProjectModel
                 .GetRootNodeAsync(false, CancellationToken.None)
                 .ConfigureAwait(true);
 
-            AssertEx.ThrowsAggregateException<ArgumentException>(() => modelService.GetNodeAsync(
+            ExceptionAssert.ThrowsAggregateException<ArgumentException>(() => modelService.GetNodeAsync(
                 new DiskTypeLocator(SampleProjectId, "zone-1", "type-1"),
                 CancellationToken.None).Wait());
         }
@@ -843,7 +843,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.ProjectModel
 
             var modelService = new ProjectModelService(serviceRegistry);
 
-            AssertEx.ThrowsAggregateException<ArgumentException>(
+            ExceptionAssert.ThrowsAggregateException<ArgumentException>(
                 () => modelService.SetActiveNodeAsync(
                     new DiskTypeLocator(SampleProjectId, "zone-1", "type-1"),
                     CancellationToken.None).Wait());

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/Settings/TestAuthSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/Settings/TestAuthSettingsRepository.cs
@@ -79,7 +79,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Settings
             var baseKey = hkcu.CreateSubKey(TestKeyPath);
             var repository = new AuthSettingsRepository(baseKey);
 
-            AssertEx.ThrowsAggregateException<KeyNotFoundException>(() =>
+            ExceptionAssert.ThrowsAggregateException<KeyNotFoundException>(() =>
             {
                 repository.DeleteAsync<string>("invalidkey");
             });
@@ -91,7 +91,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Settings
             var baseKey = hkcu.CreateSubKey(TestKeyPath);
             var repository = new AuthSettingsRepository(baseKey);
 
-            AssertEx.ThrowsAggregateException<KeyNotFoundException>(() =>
+            ExceptionAssert.ThrowsAggregateException<KeyNotFoundException>(() =>
             {
                 repository.GetAsync<string>("invalidkey");
             });
@@ -103,7 +103,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Settings
             var baseKey = hkcu.CreateSubKey(TestKeyPath);
             var repository = new AuthSettingsRepository(baseKey);
 
-            AssertEx.ThrowsAggregateException<KeyNotFoundException>(() =>
+            ExceptionAssert.ThrowsAggregateException<KeyNotFoundException>(() =>
             {
                 repository.StoreAsync<string>("invalidkey", null);
             });

--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity.Test/Services/Adapters/TestAuditLogAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity.Test/Services/Adapters/TestAuditLogAdapter.cs
@@ -160,7 +160,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Test.Services.Adapters
 
             var adapter = new AuditLogAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.ProcessInstanceEventsAsync(
                     new[] { TestProject.ProjectId },
                     null,  // all zones.
@@ -193,7 +193,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Test.Services.Adapters
             };
 
             var adapter = new AuditLogAdapter(await credential);
-            AssertEx.ThrowsAggregateException<GoogleApiException>(
+            ExceptionAssert.ThrowsAggregateException<GoogleApiException>(
                 () => adapter.ListEventsAsync(
                     request,
                     _ => { },
@@ -295,7 +295,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Test.Services.Adapters
         {
             var adapter = new AuditLogAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.ListCloudStorageSinksAsync(
                     TestProject.ProjectId,
                     CancellationToken.None).Wait());

--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity.Test/Services/Adapters/TestAuditLogStorageSinkAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity.Test/Services/Adapters/TestAuditLogStorageSinkAdapter.cs
@@ -266,7 +266,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Test.Services.Adapters
                 new StorageAdapter(await credential),
                 new AuditLogAdapter(await credential));
 
-            AssertEx.ThrowsAggregateException<JsonReaderException>(
+            ExceptionAssert.ThrowsAggregateException<JsonReaderException>(
                 () => service.ListInstanceEventsAsync(GarbageLocator, CancellationToken.None).Wait());
         }
 
@@ -314,7 +314,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Test.Services.Adapters
                 new StorageAdapter(await credential),
                 new AuditLogAdapter(await credential));
 
-            AssertEx.ThrowsAggregateException<JsonReaderException>(
+            ExceptionAssert.ThrowsAggregateException<JsonReaderException>(
                 () => service.ListInstanceEventsAsync(
                     new[] { ValidLocator_Jan1_00, GarbageLocator },
                     CancellationToken.None).Wait());
@@ -348,7 +348,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Test.Services.Adapters
                 new StorageAdapter(await credential),
                 new AuditLogAdapter(await credential));
 
-            AssertEx.ThrowsAggregateException<ArgumentException>(
+            ExceptionAssert.ThrowsAggregateException<ArgumentException>(
                 () => service.FindAuditLogExportObjectsGroupedByDay(
                     GcsTestData.Bucket,
                     new DateTime(2020, 1, 2, 0, 0, 0, DateTimeKind.Utc),

--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity.Test/Services/Adapters/TestStorageAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity.Test/Services/Adapters/TestStorageAdapter.cs
@@ -65,7 +65,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Test.Services.Adapters
         {
             var adapter = new StorageAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.ListBucketsAsync(
                     TestProject.ProjectId,
                     CancellationToken.None).Wait());
@@ -98,7 +98,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Test.Services.Adapters
         {
             var adapter = new StorageAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.ListObjectsAsync(
                     GcsTestData.Bucket,
                     null,
@@ -133,7 +133,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Test.Services.Adapters
         {
             var adapter = new StorageAdapter(await credential);
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => adapter.DownloadObjectToMemoryAsync(
                     SampleLocator,
                     CancellationToken.None).Wait());

--- a/sources/Google.Solutions.IapDesktop.Extensions.Os.Test/Services/Inventory/TestInventoryService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Os.Test/Services/Inventory/TestInventoryService.cs
@@ -94,7 +94,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Test.Services.Inventory
             var service = new InventoryService(
                 new ComputeEngineAdapter(await credential));
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => service.GetInstanceInventoryAsync(
                     instanceRef,
                     CancellationToken.None).Wait());
@@ -156,7 +156,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Test.Services.Inventory
             var service = new InventoryService(
                 new ComputeEngineAdapter(await credential));
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => service.ListProjectInventoryAsync(
                     TestProject.ProjectId,
                     OperatingSystems.All,
@@ -219,7 +219,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Test.Services.Inventory
             var service = new InventoryService(
                 new ComputeEngineAdapter(await credential));
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => service.ListZoneInventoryAsync(
                     new ZoneLocator(TestProject.ProjectId, instanceRef.Zone),
                     OperatingSystems.All,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Os.Test/Views/InstanceProperties/TestInstancePropertiesInspectorViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Os.Test/Views/InstanceProperties/TestInstancePropertiesInspectorViewModel.cs
@@ -161,7 +161,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Os.Test.Views.InstancePropertie
             deniedNode.SetupGet(n => n.Instance).Returns(
                 new InstanceLocator("project-1", "zone-1", "denied-1"));
 
-            AssertEx.ThrowsAggregateException<ResourceAccessDeniedException>(
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
                 () => viewModel.SwitchToModelAsync(deniedNode.Object).Wait());
 
             Assert.IsFalse(viewModel.IsInformationBarVisible);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Ssh/TestAuthorizedKeyService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Ssh/TestAuthorizedKeyService.cs
@@ -325,7 +325,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Ssh
                 CreateResourceManagerAdapterMock(true).Object,
                 CreateOsLoginServiceMock().Object);
 
-            AssertEx.ThrowsAggregateException<InvalidOperationException>(
+            ExceptionAssert.ThrowsAggregateException<InvalidOperationException>(
                 () => service.AuthorizeKeyAsync(
                     SampleLocator,
                     new Mock<ISshKey>().Object,
@@ -350,7 +350,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Ssh
                 CreateResourceManagerAdapterMock(true).Object,
                 CreateOsLoginServiceMock().Object);
 
-            AssertEx.ThrowsAggregateException<InvalidOperationException>(
+            ExceptionAssert.ThrowsAggregateException<InvalidOperationException>(
                 () => service.AuthorizeKeyAsync(
                     SampleLocator,
                     new Mock<ISshKey>().Object,
@@ -379,7 +379,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Ssh
                 CreateResourceManagerAdapterMock(true).Object,
                 CreateOsLoginServiceMock().Object);
 
-            AssertEx.ThrowsAggregateException<UnsupportedLegacySshKeyEncounteredException>(
+            ExceptionAssert.ThrowsAggregateException<UnsupportedLegacySshKeyEncounteredException>(
                 () => service.AuthorizeKeyAsync(
                     SampleLocator,
                     new Mock<ISshKey>().Object,
@@ -688,7 +688,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Ssh
                 CreateResourceManagerAdapterMock(true).Object,
                 CreateOsLoginServiceMock().Object);
 
-            AssertEx.ThrowsAggregateException<InvalidOperationException>(
+            ExceptionAssert.ThrowsAggregateException<InvalidOperationException>(
                 () => service.AuthorizeKeyAsync(
                     SampleLocator,
                     new Mock<ISshKey>().Object,
@@ -807,7 +807,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Ssh
 
             using (var key = RsaSshKey.NewEphemeralKey())
             {
-                AssertEx.ThrowsAggregateException<SshKeyPushFailedException>(
+                ExceptionAssert.ThrowsAggregateException<SshKeyPushFailedException>(
                     () => service.AuthorizeKeyAsync(
                         SampleLocator,
                         key,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Ssh/TestOsLoginService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Ssh/TestOsLoginService.cs
@@ -41,21 +41,21 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Ssh
         {
             var service = new OsLoginService(new Mock<IOsLoginAdapter>().Object);
 
-            AssertEx.ThrowsAggregateException<ArgumentException>(() => service.AuthorizeKeyAsync(
+            ExceptionAssert.ThrowsAggregateException<ArgumentException>(() => service.AuthorizeKeyAsync(
                 "",
                 OsLoginSystemType.Linux,
                 new Mock<ISshKey>().Object,
                 TimeSpan.FromDays(1),
                 CancellationToken.None).Wait());
 
-            AssertEx.ThrowsAggregateException<ArgumentException>(() => service.AuthorizeKeyAsync(
+            ExceptionAssert.ThrowsAggregateException<ArgumentException>(() => service.AuthorizeKeyAsync(
                 null,
                 OsLoginSystemType.Linux,
                 new Mock<ISshKey>().Object,
                 TimeSpan.FromDays(1),
                 CancellationToken.None).Wait());
 
-            AssertEx.ThrowsAggregateException<ArgumentNullException>(() => service.AuthorizeKeyAsync(
+            ExceptionAssert.ThrowsAggregateException<ArgumentNullException>(() => service.AuthorizeKeyAsync(
                 "project-1",
                 OsLoginSystemType.Linux,
                 null,
@@ -68,13 +68,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Ssh
         {
             var service = new OsLoginService(new Mock<IOsLoginAdapter>().Object);
 
-            AssertEx.ThrowsAggregateException<ArgumentException>(() => service.AuthorizeKeyAsync(
+            ExceptionAssert.ThrowsAggregateException<ArgumentException>(() => service.AuthorizeKeyAsync(
                 "project-1",
                 OsLoginSystemType.Linux,
                 new Mock<ISshKey>().Object,
                 TimeSpan.FromDays(-1),
                 CancellationToken.None).Wait());
-            AssertEx.ThrowsAggregateException<ArgumentException>(() => service.AuthorizeKeyAsync(
+            ExceptionAssert.ThrowsAggregateException<ArgumentException>(() => service.AuthorizeKeyAsync(
                 "project-1",
                 OsLoginSystemType.Linux,
                 new Mock<ISshKey>().Object,
@@ -148,7 +148,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Ssh
                 .ReturnsAsync(new LoginProfile());
             var service = new OsLoginService(adapter.Object);
 
-            AssertEx.ThrowsAggregateException<OsLoginSshKeyImportFailedException>(
+            ExceptionAssert.ThrowsAggregateException<OsLoginSshKeyImportFailedException>(
                 () => service.AuthorizeKeyAsync(
                     "project-1",
                     OsLoginSystemType.Linux,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Ssh/TestSshConnectionService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Ssh/TestSshConnectionService.cs
@@ -320,7 +320,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Ssh
             vmNode.SetupGet(n => n.Instance).Returns(SampleLocator);
 
             var service = new SshConnectionService(this.serviceRegistry);
-            AssertEx.ThrowsAggregateException<ConnectionFailedException>(
+            ExceptionAssert.ThrowsAggregateException<ConnectionFailedException>(
                 () => service.ActivateOrConnectInstanceAsync(vmNode.Object).Wait());
         }
 
@@ -346,7 +346,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Ssh
             var vmNode = CreateInstanceNodeMock();
 
             var service = new SshConnectionService(this.serviceRegistry);
-            AssertEx.ThrowsAggregateException<SshKeyPushFailedException>(
+            ExceptionAssert.ThrowsAggregateException<SshKeyPushFailedException>(
                 () => service.ActivateOrConnectInstanceAsync(vmNode.Object).Wait());
         }
     }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Tunnel/TestTunnelBrokerService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Tunnel/TestTunnelBrokerService.cs
@@ -159,7 +159,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Tunnel
                     It.IsAny<ISshRelayPolicy>()))
                 .Returns(Task.FromException<ITunnel>(new ApplicationException()));
 
-            AssertEx.ThrowsAggregateException<ApplicationException>(() =>
+            ExceptionAssert.ThrowsAggregateException<ApplicationException>(() =>
             {
                 broker.ConnectAsync(
                     destination,
@@ -191,7 +191,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Tunnel
                     It.IsAny<ISshRelayPolicy>()))
                 .Returns(Task.FromResult(mockTunnel.Object));
 
-            AssertEx.ThrowsAggregateException<ApplicationException>(() =>
+            ExceptionAssert.ThrowsAggregateException<ApplicationException>(() =>
             {
                 broker.ConnectAsync(
                     destination,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Tunnel/TestTunnelService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Tunnel/TestTunnelService.cs
@@ -104,7 +104,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Tunnel
             {
                 Assert.AreEqual(destination, tunnel.Destination);
 
-                AssertEx.ThrowsAggregateException<UnauthorizedException>(
+                ExceptionAssert.ThrowsAggregateException<UnauthorizedException>(
                     () => tunnel.Probe(TimeSpan.FromSeconds(20)).Wait());
             }
         }
@@ -129,7 +129,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Tunnel
             {
                 Assert.AreEqual(destination, tunnel.Destination);
 
-                AssertEx.ThrowsAggregateException<UnauthorizedException>(
+                ExceptionAssert.ThrowsAggregateException<UnauthorizedException>(
                     () => tunnel.Probe(TimeSpan.FromSeconds(20)).Wait());
             }
         }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Credentials/TestCredentialPrompt.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Credentials/TestCredentialPrompt.cs
@@ -245,7 +245,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
             settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.AllowIfNoCredentialsFound;
 
-            AssertEx.ThrowsAggregateException<TaskCanceledException>(
+            ExceptionAssert.ThrowsAggregateException<TaskCanceledException>(
                 () => credentialPrompt.ShowCredentialsPromptAsync(
                 null,
                 SampleInstance,
@@ -340,7 +340,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
             settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.Disallow;
 
-            AssertEx.ThrowsAggregateException<TaskCanceledException>(
+            ExceptionAssert.ThrowsAggregateException<TaskCanceledException>(
                 () => credentialPrompt.ShowCredentialsPromptAsync(
                 null,
                 SampleInstance,
@@ -510,7 +510,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
             settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.Force;
 
-            AssertEx.ThrowsAggregateException<TaskCanceledException>(
+            ExceptionAssert.ThrowsAggregateException<TaskCanceledException>(
                 () => credentialPrompt.ShowCredentialsPromptAsync(
                 null,
                 SampleInstance,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Credentials/TestCredentialsService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Credentials/TestCredentialsService.cs
@@ -65,7 +65,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             settings.RdpUsername.Value = "alice";
 
             var credentialsService = new CredentialsService(serviceRegistry);
-            AssertEx.ThrowsAggregateException<TaskCanceledException>(
+            ExceptionAssert.ThrowsAggregateException<TaskCanceledException>(
                 () => credentialsService.GenerateCredentialsAsync(
                     null,
                     SampleInstance,
@@ -100,7 +100,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
 
             var credentialsService = new CredentialsService(serviceRegistry);
-            AssertEx.ThrowsAggregateException<TaskCanceledException>(
+            ExceptionAssert.ThrowsAggregateException<TaskCanceledException>(
                 () => credentialsService.GenerateCredentialsAsync(
                     null,
                     SampleInstance,
@@ -135,7 +135,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             settings.RdpUsername.Value = "";
 
             var credentialsService = new CredentialsService(serviceRegistry);
-            AssertEx.ThrowsAggregateException<TaskCanceledException>(
+            ExceptionAssert.ThrowsAggregateException<TaskCanceledException>(
                 () => credentialsService.GenerateCredentialsAsync(
                     null,
                     SampleInstance,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshAuthenticationPromptViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshAuthenticationPromptViewModel.cs
@@ -33,7 +33,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
         public void WhenTitleSet_ThenNotificationIsRaised()
         {
             var viewModel = new SshAuthenticationPromptViewModel();
-            AssertEx.RaisesPropertyChangedNotification(
+            PropertyAssert.RaisesPropertyChangedNotification(
                 viewModel,
                 () => viewModel.Title = "test",
                 v => v.Title);
@@ -43,7 +43,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
         public void WhenDescriptionSet_ThenNotificationIsRaised()
         {
             var viewModel = new SshAuthenticationPromptViewModel();
-            AssertEx.RaisesPropertyChangedNotification(
+            PropertyAssert.RaisesPropertyChangedNotification(
                 viewModel,
                 () => viewModel.Description = "test",
                 v => v.Description);
@@ -62,12 +62,12 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
         public void WhenInputSet_ThenNotificationIsRaised()
         {
             var viewModel = new SshAuthenticationPromptViewModel();
-            AssertEx.RaisesPropertyChangedNotification(
+            PropertyAssert.RaisesPropertyChangedNotification(
                 viewModel,
                 () => viewModel.Input = "test",
                 v => v.Input);
-            
-            AssertEx.RaisesPropertyChangedNotification(
+
+            PropertyAssert.RaisesPropertyChangedNotification(
                 viewModel,
                 () => viewModel.Input = "test",
                 v => v.IsOkButtonEnabled);
@@ -77,7 +77,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
         public void WhenIsPasswordMaskedSet_ThenNotificationIsRaised()
         {
             var viewModel = new SshAuthenticationPromptViewModel();
-            AssertEx.RaisesPropertyChangedNotification(
+            PropertyAssert.RaisesPropertyChangedNotification(
                 viewModel,
                 () => viewModel.IsPasswordMasked = true,
                 v => v.IsPasswordMasked);

--- a/sources/Google.Solutions.IapTunneling.Test/Iap/TestHttpOverIapDirectTunnel.cs
+++ b/sources/Google.Solutions.IapTunneling.Test/Iap/TestHttpOverIapDirectTunnel.cs
@@ -67,7 +67,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
 
             byte[] buffer = new byte[64];
 
-            AssertEx.ThrowsAggregateException<IndexOutOfRangeException>(() =>
+            ExceptionAssert.ThrowsAggregateException<IndexOutOfRangeException>(() =>
             {
                 stream.ReadAsync(buffer, 0, buffer.Length, CancellationToken.None).Wait();
             });
@@ -94,7 +94,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                 .WriteAsync(request, 0, request.Length, CancellationToken.None)
                 .ConfigureAwait(false);
 
-            AssertEx.ThrowsAggregateException<UnauthorizedException>(() =>
+            ExceptionAssert.ThrowsAggregateException<UnauthorizedException>(() =>
             {
                 byte[] buffer = new byte[64 * 1024];
                 stream.ReadAsync(buffer, 0, buffer.Length, CancellationToken.None).Wait();
@@ -147,7 +147,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                 .WriteAsync(request, 0, request.Length, CancellationToken.None)
                 .ConfigureAwait(false);
 
-            AssertEx.ThrowsAggregateException<WebSocketStreamClosedByServerException>(() =>
+            ExceptionAssert.ThrowsAggregateException<WebSocketStreamClosedByServerException>(() =>
             {
                 byte[] buffer = new byte[stream.MinReadSize];
                 stream.ReadAsync(buffer, 0, buffer.Length, CancellationToken.None).Wait();

--- a/sources/Google.Solutions.IapTunneling.Test/Iap/TestSshRelayProber.cs
+++ b/sources/Google.Solutions.IapTunneling.Test/Iap/TestSshRelayProber.cs
@@ -51,7 +51,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                     IapTunnelingEndpoint.DefaultNetworkInterface,
                     TestProject.UserAgent)))
             {
-                AssertEx.ThrowsAggregateException<UnauthorizedException>(() =>
+                ExceptionAssert.ThrowsAggregateException<UnauthorizedException>(() =>
                     stream.TestConnectionAsync(TimeSpan.FromSeconds(10)).Wait());
             }
         }
@@ -71,7 +71,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                     IapTunnelingEndpoint.DefaultNetworkInterface,
                     TestProject.UserAgent)))
             {
-                AssertEx.ThrowsAggregateException<UnauthorizedException>(() =>
+                ExceptionAssert.ThrowsAggregateException<UnauthorizedException>(() =>
                     stream.TestConnectionAsync(TimeSpan.FromSeconds(10)).Wait());
             }
         }
@@ -91,7 +91,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                     IapTunnelingEndpoint.DefaultNetworkInterface,
                     TestProject.UserAgent)))
             {
-                AssertEx.ThrowsAggregateException<UnauthorizedException>(() =>
+                ExceptionAssert.ThrowsAggregateException<UnauthorizedException>(() =>
                     stream.TestConnectionAsync(TimeSpan.FromSeconds(10)).Wait());
             }
         }
@@ -128,7 +128,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                     IapTunnelingEndpoint.DefaultNetworkInterface,
                     TestProject.UserAgent)))
             {
-                AssertEx.ThrowsAggregateException<NetworkStreamClosedException>(() =>
+                ExceptionAssert.ThrowsAggregateException<NetworkStreamClosedException>(() =>
                     stream.TestConnectionAsync(TimeSpan.FromSeconds(5)).Wait());
             }
         }

--- a/sources/Google.Solutions.IapTunneling.Test/Iap/TestSshRelayStreamReading.cs
+++ b/sources/Google.Solutions.IapTunneling.Test/Iap/TestSshRelayStreamReading.cs
@@ -87,7 +87,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
 
             byte[] buffer = new byte[relay.MinReadSize - 1];
 
-            AssertEx.ThrowsAggregateException<IndexOutOfRangeException>(() =>
+            ExceptionAssert.ThrowsAggregateException<IndexOutOfRangeException>(() =>
             {
                 relay.ReadAsync(buffer, 0, buffer.Length, tokenSource.Token).Wait();
             });
@@ -114,7 +114,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
 
             byte[] buffer = new byte[relay.MinReadSize];
 
-            AssertEx.ThrowsAggregateException<InvalidServerResponseException>(() =>
+            ExceptionAssert.ThrowsAggregateException<InvalidServerResponseException>(() =>
             {
                 relay.ReadAsync(buffer, 0, buffer.Length, tokenSource.Token).Wait();
             });
@@ -145,7 +145,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
 
             Assert.AreEqual(0, endpoint.ConnectCount);
 
-            AssertEx.ThrowsAggregateException<InvalidServerResponseException>(() =>
+            ExceptionAssert.ThrowsAggregateException<InvalidServerResponseException>(() =>
             {
                 byte[] buffer = new byte[relay.MinReadSize];
                 relay.ReadAsync(buffer, 0, buffer.Length, tokenSource.Token).Wait();
@@ -260,7 +260,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                 .ConfigureAwait(false);
 
             // Receive invalid ACK.
-            AssertEx.ThrowsAggregateException<InvalidServerResponseException>(() =>
+            ExceptionAssert.ThrowsAggregateException<InvalidServerResponseException>(() =>
             {
                 byte[] buffer = new byte[relay.MinReadSize];
                 int bytesRead = relay.ReadAsync(buffer, 0, buffer.Length, tokenSource.Token).Result;
@@ -290,7 +290,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                 .ConfigureAwait(false);
 
             // Receive invalid ACK for byte 10.
-            AssertEx.ThrowsAggregateException<InvalidServerResponseException>(() =>
+            ExceptionAssert.ThrowsAggregateException<InvalidServerResponseException>(() =>
             {
                 byte[] buffer = new byte[relay.MinReadSize];
                 int bytesRead = relay.ReadAsync(buffer, 0, buffer.Length, tokenSource.Token).Result;
@@ -461,7 +461,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
             Assert.AreEqual(1, bytesRead);
 
             // connection breaks, triggering a reconnect that will fail.
-            AssertEx.ThrowsAggregateException<WebSocketStreamClosedByServerException>(() =>
+            ExceptionAssert.ThrowsAggregateException<WebSocketStreamClosedByServerException>(() =>
             {
                 relay.ReadAsync(buffer, 0, buffer.Length, tokenSource.Token).Wait();
             });
@@ -629,7 +629,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                 .CloseAsync(tokenSource.Token)
                 .ConfigureAwait(false);
 
-            AssertEx.ThrowsAggregateException<NetworkStreamClosedException>(() =>
+            ExceptionAssert.ThrowsAggregateException<NetworkStreamClosedException>(() =>
             {
                 bytesRead = relay.ReadAsync(buffer, 0, buffer.Length, tokenSource.Token).Result;
             });
@@ -648,7 +648,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
             };
             var relay = new SshRelayStream(endpoint);
 
-            AssertEx.ThrowsAggregateException<UnauthorizedException>(
+            ExceptionAssert.ThrowsAggregateException<UnauthorizedException>(
                 () => relay
                     .TestConnectionAsync(TimeSpan.FromSeconds(2))
                     .Wait());

--- a/sources/Google.Solutions.IapTunneling.Test/Iap/TestSshRelayStreamWriting.cs
+++ b/sources/Google.Solutions.IapTunneling.Test/Iap/TestSshRelayStreamWriting.cs
@@ -167,7 +167,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                 .ConfigureAwait(false);
 
             // Write another request - this should fail.
-            AssertEx.ThrowsAggregateException<WebSocketStreamClosedByServerException>(() =>
+            ExceptionAssert.ThrowsAggregateException<WebSocketStreamClosedByServerException>(() =>
             {
                 request = new byte[] { 2 };
                 relay.WriteAsync(request, 0, request.Length, tokenSource.Token).Wait();
@@ -200,7 +200,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                 .ConfigureAwait(false);
 
             // Write another request - this should fail.
-            AssertEx.ThrowsAggregateException<NetworkStreamClosedException>(() =>
+            ExceptionAssert.ThrowsAggregateException<NetworkStreamClosedException>(() =>
             {
                 request = new byte[] { 2 };
                 relay.WriteAsync(request, 0, request.Length, tokenSource.Token).Wait();
@@ -231,7 +231,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
                 .ConfigureAwait(false);
 
             // Write another request - this should fail.
-            AssertEx.ThrowsAggregateException<WebSocketStreamClosedByServerException>(() =>
+            ExceptionAssert.ThrowsAggregateException<WebSocketStreamClosedByServerException>(() =>
             {
                 request = new byte[] { 2 };
                 relay.WriteAsync(request, 0, request.Length, tokenSource.Token).Wait();
@@ -393,7 +393,7 @@ namespace Google.Solutions.IapTunneling.Test.Iap
             var relay = new SshRelayStream(endpoint);
 
             // Write first request - this should fail.
-            AssertEx.ThrowsAggregateException<UnauthorizedException>(() =>
+            ExceptionAssert.ThrowsAggregateException<UnauthorizedException>(() =>
             {
                 var request = new byte[] { 2 };
                 relay.WriteAsync(request, 0, request.Length, tokenSource.Token).Wait();

--- a/sources/Google.Solutions.Ssh.Test/Native/TestSshSession.cs
+++ b/sources/Google.Solutions.Ssh.Test/Native/TestSshSession.cs
@@ -300,7 +300,7 @@ namespace Google.Solutions.Ssh.Test.Native
                 12);
             using (var session = CreateSession())
             {
-                AssertEx.ThrowsAggregateException<SocketException>(
+                ExceptionAssert.ThrowsAggregateException<SocketException>(
                     () => session.Connect(endpoint));
             }
         }

--- a/sources/Google.Solutions.Ssh.Test/TestSshShellConnection.cs
+++ b/sources/Google.Solutions.Ssh.Test/TestSshShellConnection.cs
@@ -116,7 +116,7 @@ namespace Google.Solutions.Ssh.Test
                 {
                     await connection.ConnectAsync().ConfigureAwait(false);
 
-                    AssertEx.ThrowsAggregateException<InvalidOperationException>(
+                    ExceptionAssert.ThrowsAggregateException<InvalidOperationException>(
                         () => connection.ConnectAsync().Wait());
 
                     await connection.SendAsync("whoami\n").ConfigureAwait(false);
@@ -216,7 +216,7 @@ namespace Google.Solutions.Ssh.Test
                         .ConnectAsync()
                         .ConfigureAwait(false);
 
-                    AssertEx.ThrowsAggregateException<InvalidOperationException>(
+                    ExceptionAssert.ThrowsAggregateException<InvalidOperationException>(
                         () => connection.ConnectAsync().Wait());
 
                     await connection
@@ -282,7 +282,7 @@ namespace Google.Solutions.Ssh.Test
                         .ConnectAsync()
                         .ConfigureAwait(false);
 
-                    AssertEx.ThrowsAggregateException<InvalidOperationException>(
+                    ExceptionAssert.ThrowsAggregateException<InvalidOperationException>(
                         () => connection.ConnectAsync().Wait());
 
                     await connection
@@ -346,7 +346,7 @@ namespace Google.Solutions.Ssh.Test
                         .ConnectAsync()
                         .ConfigureAwait(false);
 
-                    AssertEx.ThrowsAggregateException<InvalidOperationException>(
+                    ExceptionAssert.ThrowsAggregateException<InvalidOperationException>(
                         () => connection.ConnectAsync().Wait());
 
                     await connection


### PR DESCRIPTION
- Split into ExceptionAssert and PropertyAssert
- Use naming scheme that matches NUnit's classes