### PR TITLE
b/214344362 Use mTLS for sign-in

### DIFF
--- a/sources/Google.Solutions.Common/Google.Solutions.Common.csproj
+++ b/sources/Google.Solutions.Common/Google.Solutions.Common.csproj
@@ -92,6 +92,7 @@
     </Compile>
     <Compile Include="Locator\ProjectLocator.cs" />
     <Compile Include="Locator\ZoneLocator.cs" />
+    <Compile Include="Net\HttpClientHandlerExtensions.cs" />
     <Compile Include="Text\IAsyncReader.cs" />
     <Compile Include="Net\RestClient.cs" />
     <Compile Include="Net\UserAgent.cs" />

--- a/sources/Google.Solutions.Common/Net/HttpClientHandlerExtensions.cs
+++ b/sources/Google.Solutions.Common/Net/HttpClientHandlerExtensions.cs
@@ -1,0 +1,81 @@
+﻿//
+// Copyright 2020 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.Common.Net
+{
+    public static class HttpClientHandlerExtensions
+    {
+        //
+        // NB. The ClientCertificate property is only available as of v4.7.1. 
+        //
+        // In older framework versions, WebRequestHandler can be used for mTLS,
+        // but this is incompatible with the Google Http library.
+        //
+        internal static readonly PropertyInfo clientCertificatesProperty =
+            typeof(HttpClientHandler).GetProperty(
+                "ClientCertificates",
+                BindingFlags.Instance | BindingFlags.Public);
+
+        public static bool IsClientCertificateSupported
+            => clientCertificatesProperty != null;
+
+        public static bool TryAddClientCertificate(
+            this HttpClientHandler handler,
+            X509Certificate2 certificate)
+        {
+            if (IsClientCertificateSupported)
+            {
+                var clientCertificates = (X509CertificateCollection)
+                    clientCertificatesProperty.GetValue(handler);
+                clientCertificates.Add(certificate);
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        public static IEnumerable<X509Certificate2> GetClientCertificates(
+            this HttpClientHandler handler)
+        {
+            if (IsClientCertificateSupported)
+            {
+                var certificates = (X509CertificateCollection)
+                    clientCertificatesProperty.GetValue(handler);
+                return certificates.Cast<X509Certificate2>();
+            }
+            else
+            {
+                return Enumerable.Empty<X509Certificate2>();
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/Authorization/TestSignInAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/Authorization/TestSignInAdapter.cs
@@ -21,8 +21,10 @@
 
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Auth.OAuth2.Flows;
+using Google.Apis.Auth.OAuth2.Requests;
 using Google.Apis.Auth.OAuth2.Responses;
 using Google.Apis.Util.Store;
+using Google.Solutions.Common.Test;
 using Google.Solutions.IapDesktop.Application.Services.Adapters;
 using Moq;
 using NUnit.Framework;
@@ -34,22 +36,6 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Authorization
     [TestFixture]
     public class TestSignInAdapter : ApplicationFixtureBase
     {
-        [Test]
-        public async Task WhenCalled_ThenQueryOpenIdConfigurationAsyncReturnsInfo()
-        {
-            var adapter = new SignInAdapter(
-                new Apis.Auth.OAuth2.ClientSecrets(),
-                new[] { "openid" },
-                new NullDataStore(),
-                string.Empty);
-
-            var config = await adapter
-                .QueryOpenIdConfigurationAsync(CancellationToken.None)
-                .ConfigureAwait(false);
-
-            Assert.IsNotNull(config.UserInfoEndpoint);
-        }
-
         //---------------------------------------------------------------------
         // TrySignInWithRefreshTokenAsync.
         //---------------------------------------------------------------------
@@ -69,13 +55,12 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Authorization
             flow.Setup(f => f.ShouldForceTokenRetrieval())
                 .Returns(false);
 
-            var dataStore = new Mock<IDataStore>();
-
             var adapter = new SignInAdapter(
+                null,
                 new Apis.Auth.OAuth2.ClientSecrets(),
                 new[] { "scope-1" },
-                dataStore.Object,
-                string.Empty,
+                new Mock<IDataStore>().Object,
+                new Mock<ICodeReceiver>().Object,
                 _ => flow.Object);
 
             var credential = await adapter
@@ -101,13 +86,12 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Authorization
             flow.Setup(f => f.ShouldForceTokenRetrieval())
                 .Returns(false);
 
-            var dataStore = new Mock<IDataStore>();
-
             var adapter = new SignInAdapter(
+                null,
                 new Apis.Auth.OAuth2.ClientSecrets(),
                 new[] { "scope-1", "scope-2" },
-                dataStore.Object,
-                string.Empty,
+                new Mock<IDataStore>().Object,
+                new Mock<ICodeReceiver>().Object,
                 _ => flow.Object);
 
             var credential = await adapter
@@ -121,16 +105,14 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Authorization
         public async Task WhenRefreshTokenInvalid_ThenTrySignInWithRefreshTokenAsyncReturnsNull()
         {
             var flow = new Mock<IAuthorizationCodeFlow>();
-            flow.Setup(f => f.ShouldForceTokenRetrieval())
-                .Returns(true);
-
-            var dataStore = new Mock<IDataStore>();
+            flow.Setup(f => f.ShouldForceTokenRetrieval()).Returns(true);
 
             var adapter = new SignInAdapter(
+                null,
                 new Apis.Auth.OAuth2.ClientSecrets(),
                 new[] { "scope-1" },
-                dataStore.Object,
-                string.Empty,
+                new Mock<IDataStore>().Object,
+                new Mock<ICodeReceiver>().Object,
                 _ => flow.Object);
 
             var credential = await adapter
@@ -138,6 +120,93 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Authorization
                 .ConfigureAwait(false);
 
             Assert.IsNull(credential);
+        }
+
+        //---------------------------------------------------------------------
+        // SignInWithBrowserAsync.
+        //---------------------------------------------------------------------
+        
+        [Test]
+        public async Task WhenSignInSucceeds_ThenSignInWithBrowserAsyncReturnsCredential()
+        {
+            var receiver = new Mock<ICodeReceiver>();
+            receiver.Setup(r => r.ReceiveCodeAsync(
+                    It.IsAny<AuthorizationCodeRequestUrl>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new AuthorizationCodeResponseUrl()
+                {
+                    Code = "123"
+                });
+
+            var flow = new Mock<IAuthorizationCodeFlow>();
+            flow.Setup(f => f.ShouldForceTokenRetrieval()).Returns(true);
+            flow.Setup(f => f.ExchangeCodeForTokenAsync(
+                    It.IsAny<string>(),
+                    It.Is<string>(code => code == "123"),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TokenResponse()
+                {
+                    Scope = "scope-1",
+                    AccessToken = "token-1",
+                    RefreshToken = "refreshtoken-1"
+                });
+
+            var adapter = new SignInAdapter(
+                null,
+                new Apis.Auth.OAuth2.ClientSecrets(),
+                new[] { "scope-1" },
+                new Mock<IDataStore>().Object,
+                receiver.Object,
+                _ => flow.Object);
+
+            var credential = await adapter.SignInWithBrowserAsync(
+                    "bob@example.com",
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.NotNull(credential);
+        }
+
+        [Test]
+        public void WhenSignInLacksScopes_ThenSignInWithBrowserAsyncThrowsException()
+        {
+
+            var receiver = new Mock<ICodeReceiver>();
+            receiver.Setup(r => r.ReceiveCodeAsync(
+                    It.IsAny<AuthorizationCodeRequestUrl>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new AuthorizationCodeResponseUrl()
+                {
+                    Code = "123"
+                });
+
+            var flow = new Mock<IAuthorizationCodeFlow>();
+            flow.Setup(f => f.ShouldForceTokenRetrieval()).Returns(true);
+            flow.Setup(f => f.ExchangeCodeForTokenAsync(
+                    It.IsAny<string>(),
+                    It.Is<string>(code => code == "123"),
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new TokenResponse()
+                {
+                    Scope = "", // Scope missing
+                    AccessToken = "token-1",
+                    RefreshToken = "refreshtoken-1"
+                });
+
+            var adapter = new SignInAdapter(
+                null,
+                new Apis.Auth.OAuth2.ClientSecrets(),
+                new[] { "scope-1" },
+                new Mock<IDataStore>().Object,
+                receiver.Object,
+                _ => flow.Object);
+
+            ExceptionAssert.ThrowsAggregateException<AuthorizationFailedException>(
+                () => adapter.SignInWithBrowserAsync(
+                    "bob@example.com",
+                    CancellationToken.None).Wait());
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/ComputeEngineAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/ComputeEngineAdapter.cs
@@ -27,6 +27,7 @@ using Google.Solutions.Common.ApiExtensions;
 using Google.Solutions.Common.ApiExtensions.Instance;
 using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.Common.Locator;
+using Google.Solutions.Common.Net;
 using Google.Solutions.Common.Text;
 using Google.Solutions.Common.Util;
 using Google.Solutions.IapDesktop.Application.ObjectModel;

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/ResourceManagerAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/ResourceManagerAdapter.cs
@@ -25,6 +25,7 @@ using Google.Apis.CloudResourceManager.v1.Data;
 using Google.Apis.Requests;
 using Google.Solutions.Common.ApiExtensions;
 using Google.Solutions.Common.Diagnostics;
+using Google.Solutions.Common.Net;
 using Google.Solutions.Common.Util;
 using Google.Solutions.IapDesktop.Application.ObjectModel;
 using Google.Solutions.IapDesktop.Application.Services.Authorization;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity/Services/Adapters/AuditLogAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity/Services/Adapters/AuditLogAdapter.cs
@@ -25,6 +25,7 @@ using Google.Apis.Logging.v2.Data;
 using Google.Apis.Util;
 using Google.Solutions.Common.ApiExtensions.Request;
 using Google.Solutions.Common.Diagnostics;
+using Google.Solutions.Common.Net;
 using Google.Solutions.Common.Util;
 using Google.Solutions.IapDesktop.Application;
 using Google.Solutions.IapDesktop.Application.ObjectModel;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity/Services/Adapters/StorageAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity/Services/Adapters/StorageAdapter.cs
@@ -24,6 +24,7 @@ using Google.Apis.Requests;
 using Google.Apis.Storage.v1;
 using Google.Apis.Storage.v1.Data;
 using Google.Solutions.Common.Diagnostics;
+using Google.Solutions.Common.Net;
 using Google.Solutions.Common.Util;
 using Google.Solutions.IapDesktop.Application;
 using Google.Solutions.IapDesktop.Application.ObjectModel;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Adapter/OsLoginAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Adapter/OsLoginAdapter.cs
@@ -23,6 +23,7 @@ using Google.Apis.CloudOSLogin.v1;
 using Google.Apis.CloudOSLogin.v1.Data;
 using Google.Solutions.Common.ApiExtensions;
 using Google.Solutions.Common.Diagnostics;
+using Google.Solutions.Common.Net;
 using Google.Solutions.IapDesktop.Application;
 using Google.Solutions.IapDesktop.Application.ObjectModel;
 using Google.Solutions.IapDesktop.Application.Services.Adapters;

--- a/sources/Google.Solutions.IapDesktop/Windows/MainFormViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop/Windows/MainFormViewModel.cs
@@ -19,6 +19,7 @@
 // under the License.
 //
 
+using Google.Apis.Auth.OAuth2;
 using Google.Solutions.CloudIap;
 using Google.Solutions.IapDesktop.Application;
 using Google.Solutions.IapDesktop.Application.ObjectModel;
@@ -222,10 +223,11 @@ namespace Google.Solutions.IapDesktop.Windows
                 this.applicationSettings).Result;
 
             var signInAdapter = new SignInAdapter(
+                deviceEnrollment.Certificate,
                 OAuthClient.Secrets,
                 new[] { IapTunnelingEndpoint.RequiredScope },
                 this.authSettings,
-                Resources.AuthorizationSuccessful);
+                new LocalServerCodeReceiver(Resources.AuthorizationSuccessful));
 
             //
             // Get the user authorization, either by using stored


### PR DESCRIPTION
Use mTLS for fetching tokens and OIDC userinfo when
a device certificate exists.