### PR TITLE
b/216743374 Change shortcut for leaving full-screen RDP

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Views/DocumentWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/DocumentWindow.cs
@@ -40,6 +40,17 @@ namespace Google.Solutions.IapDesktop.Application.Views
         /// back to main window.
         /// </summary>
         public const Keys ToggleFocusHotKey = Keys.Control | Keys.Alt | Keys.Home;
+        
+        /// <summary>
+        /// Hotkey to enter full-screen.
+        /// </summary>
+        public const Keys EnterFullScreenHotKey = Keys.F11;
+
+        /// <summary>
+        /// Hotkey to leave full-screen.
+        /// </summary>
+        public const Keys LeaveFullScreenHotKey = Keys.Control | Keys.Alt | Keys.F11;
+
 
         //
         // Full screen form -- created lazily. There can only be one window

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ShellExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ShellExtension.cs
@@ -371,7 +371,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
                     _ => DoWithActiveRemoteDesktopSession(session => session.TrySetFullscreen(FullScreenMode.SingleScreen)))
                 {
                     Image = Resources.Fullscreen_16,
-                    ShortcutKeys = Keys.F11
+                    ShortcutKeys =  DocumentWindow.EnterFullScreenHotKey
                 });
             desktopMenu.AddCommand(
                 new Command<IMainForm>(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/RemoteDesktopPane.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/RemoteDesktopPane.cs
@@ -366,7 +366,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.RemoteDesktop
                 // the same as the main window uses to move the focus to the
                 // control.
                 //
-                // NB. The Ctrl+Alt are implied by the HotKeyFocusRelease properties.
+                // NB. The Ctrl+Alt modifiers are implied by the HotKeyFocusRelease properties.
                 //
                 Debug.Assert(ToggleFocusHotKey.HasFlag(Keys.Control));
                 Debug.Assert(ToggleFocusHotKey.HasFlag(Keys.Alt));
@@ -374,6 +374,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.RemoteDesktop
 
                 advancedSettings.HotKeyFocusReleaseLeft = focusReleaseVirtualKey;
                 advancedSettings.HotKeyFocusReleaseRight = focusReleaseVirtualKey;
+
+                //
+                // NB. The Ctrl+Alt modifiers are implied by the HotKeyFullScreen properties.
+                //
+                Debug.Assert(LeaveFullScreenHotKey.HasFlag(Keys.Control));
+                Debug.Assert(LeaveFullScreenHotKey.HasFlag(Keys.Alt));
+                var leaveFullScreenVirtualKey = (int)(LeaveFullScreenHotKey & ~(Keys.Control | Keys.Alt));
+
+                advancedSettings.HotKeyFullScreen = (int)leaveFullScreenVirtualKey;
 
                 this.connecting = true;
                 this.rdpClient.Connect();


### PR DESCRIPTION
Changing to Ctrl + Alt + F11, which

* works on notebook keyboards (which lack a Break key)
* is more consistent with the F11 shortcut to enter full-screen