### PR TITLE
b/210366612 Detect project-wide SSH key pushes in event log

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity/Events/Access/ModifiedMetadata.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity/Events/Access/ModifiedMetadata.cs
@@ -1,0 +1,57 @@
+﻿//
+// Copyright 2022 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.IapDesktop.Extensions.Activity.Logs;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.IapDesktop.Extensions.Activity.Events.Access
+{
+    internal static class ModifiedMetadata
+    {
+        internal static string[] ExtractModifiedMetadataKeys(
+            LogRecord record,
+            string fieldName)
+        {
+            // NB. instanceMetadataDelta contains one of two fields:
+            // - modifiedMetadataKeys 
+            // - addedMetadataKeys
+            // in both cases, the value is an array of metadata keys.
+            var delta = record.ProtoPayload.Metadata?[fieldName];
+            var modifiedMetadataKeys = delta?["modifiedMetadataKeys"];
+            if (modifiedMetadataKeys != null)
+            {
+                return modifiedMetadataKeys.ToObject<string[]>();
+            }
+
+            var addedMetadataKeys = delta?["addedMetadataKeys"];
+            if (addedMetadataKeys != null)
+            {
+                return addedMetadataKeys.ToObject<string[]>();
+            }
+
+            return null;
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity/Events/Access/SetMetadataEvent.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity/Events/Access/SetMetadataEvent.cs
@@ -88,31 +88,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Activity.Events.Access
 
         public bool IsModifyingKey(string key)
         {
-            return ExtractModifiedMetadataKeys(this.LogRecord)
+            return ModifiedMetadata.ExtractModifiedMetadataKeys(
+                    this.LogRecord, 
+                    "instanceMetadataDelta")
                 .EnsureNotNull()
                 .Any(v => v == key);
-        }
-
-        private static string[] ExtractModifiedMetadataKeys(LogRecord record)
-        {
-            // NB. instanceMetadataDelta contains one of two fields:
-            // - modifiedMetadataKeys 
-            // - addedMetadataKeys
-            // in both cases, the value is an array of metadata keys.
-            var delta = record.ProtoPayload.Metadata?["instanceMetadataDelta"];
-            var modifiedMetadataKeys = delta?["modifiedMetadataKeys"];
-            if (modifiedMetadataKeys != null)
-            {
-                return modifiedMetadataKeys.ToObject<string[]>();
-            }
-
-            var addedMetadataKeys = delta?["addedMetadataKeys"];
-            if (addedMetadataKeys != null)
-            {
-                return addedMetadataKeys.ToObject<string[]>();
-            }
-
-            return null;
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity/Google.Solutions.IapDesktop.Extensions.Activity.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity/Google.Solutions.IapDesktop.Extensions.Activity.csproj
@@ -109,6 +109,7 @@
   <ItemGroup>
     <Compile Include="DateTimeUtil.cs" />
     <Compile Include="Events\Access\AuthorizeUserTunnelEvent.cs" />
+    <Compile Include="Events\Access\ModifiedMetadata.cs" />
     <Compile Include="Events\Access\OsLoginContinueSessionEvent.cs" />
     <Compile Include="Events\Access\OsLoginStartSessionEvent.cs" />
     <Compile Include="Events\Access\SetCommonInstanceMetadataEvent.cs" />


### PR DESCRIPTION
* Extract modofied keys from setCommonInstanceMetadata event
  (introduced in b/135056849)
* Adapt event message based on whether 'ssh-keys' was found