### PR TITLE
Enable TLS 1.2 for integration tests

### DIFF
--- a/sources/Google.Solutions.Common.Test/Integration/TestProject.cs
+++ b/sources/Google.Solutions.Common.Test/Integration/TestProject.cs
@@ -28,6 +28,7 @@ using Google.Apis.Services;
 using Google.Solutions.Common.Net;
 using System;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 
@@ -48,6 +49,13 @@ namespace Google.Solutions.Common.Test.Integration
             UserAgent = new UserAgent(
                 "IAP-Desktop-TestSuite",
                 Assembly.GetExecutingAssembly().GetName().Version);
+
+            //
+            // Enable TLS 1.2.
+            //
+            ServicePointManager.SecurityProtocol =
+                SecurityProtocolType.Tls12 |
+                SecurityProtocolType.Tls11;
         }
 
         public static GoogleCredential GetAdminCredential()


### PR DESCRIPTION
Enable TLS 1.2 before test execution starts. Some endpoints 
don't support TLS 1.1 anymore.