### PR TITLE
b/229048026 Target .NET 4.6.2

### DIFF
--- a/sources/Google.Solutions.Common.Test/Google.Solutions.Common.Test.csproj
+++ b/sources/Google.Solutions.Common.Test/Google.Solutions.Common.Test.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.Common.Test</RootNamespace>
     <AssemblyName>Google.Solutions.Common.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>

--- a/sources/Google.Solutions.Common/Google.Solutions.Common.csproj
+++ b/sources/Google.Solutions.Common/Google.Solutions.Common.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.Common</RootNamespace>
     <AssemblyName>Google.Solutions.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Google.Solutions.IapDesktop.Application.Test.csproj
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Google.Solutions.IapDesktop.Application.Test.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.IapDesktop.Application.Test</RootNamespace>
     <AssemblyName>Google.Solutions.IapDesktop.Application.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>

--- a/sources/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
+++ b/sources/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.IapDesktop.Application</RootNamespace>
     <AssemblyName>Google.Solutions.IapDesktop.Application</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity.Test/Google.Solutions.IapDesktop.Extensions.Activity.Test.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity.Test/Google.Solutions.IapDesktop.Extensions.Activity.Test.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.IapDesktop.Extensions.Activity.Test</RootNamespace>
     <AssemblyName>Google.Solutions.IapDesktop.Extensions.Activity.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>

--- a/sources/Google.Solutions.IapDesktop.Extensions.Activity/Google.Solutions.IapDesktop.Extensions.Activity.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Activity/Google.Solutions.IapDesktop.Extensions.Activity.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.IapDesktop.Extensions.Activity</RootNamespace>
     <AssemblyName>Google.Solutions.IapDesktop.Extensions.Activity</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>

--- a/sources/Google.Solutions.IapDesktop.Extensions.Os.Test/Google.Solutions.IapDesktop.Extensions.Os.Test.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Os.Test/Google.Solutions.IapDesktop.Extensions.Os.Test.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.IapDesktop.Extensions.Os.Test</RootNamespace>
     <AssemblyName>Google.Solutions.IapDesktop.Extensions.Os.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>

--- a/sources/Google.Solutions.IapDesktop.Extensions.Os/Google.Solutions.IapDesktop.Extensions.Os.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Os/Google.Solutions.IapDesktop.Extensions.Os.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.IapDesktop.Extensions.Os</RootNamespace>
     <AssemblyName>Google.Solutions.IapDesktop.Extensions.Os</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Google.Solutions.IapDesktop.Extensions.Shell.Test.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Google.Solutions.IapDesktop.Extensions.Shell.Test.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.IapDesktop.Extensions.Shell.Test</RootNamespace>
     <AssemblyName>Google.Solutions.IapDesktop.Extensions.Shell.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Google.Solutions.IapDesktop.Extensions.Shell.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Google.Solutions.IapDesktop.Extensions.Shell.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.IapDesktop.Extensions.Shell</RootNamespace>
     <AssemblyName>Google.Solutions.IapDesktop.Extensions.Shell</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <NuGetPackageImportStamp>

--- a/sources/Google.Solutions.IapDesktop/Google.Solutions.IapDesktop.csproj
+++ b/sources/Google.Solutions.IapDesktop/Google.Solutions.IapDesktop.csproj
@@ -10,7 +10,7 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>Google.Solutions.IapDesktop</RootNamespace>
     <AssemblyName>IapDesktop</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>

--- a/sources/Google.Solutions.IapTunneling.Test/Google.Solutions.IapTunneling.Test.csproj
+++ b/sources/Google.Solutions.IapTunneling.Test/Google.Solutions.IapTunneling.Test.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.IapTunneling.Test</RootNamespace>
     <AssemblyName>Google.Solutions.IapTunneling.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/sources/Google.Solutions.IapTunneling/Google.Solutions.IapTunneling.csproj
+++ b/sources/Google.Solutions.IapTunneling/Google.Solutions.IapTunneling.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.IapTunneling</RootNamespace>
     <AssemblyName>Google.Solutions.IapTunneling</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/sources/Google.Solutions.Ssh.Test/Google.Solutions.Ssh.Test.csproj
+++ b/sources/Google.Solutions.Ssh.Test/Google.Solutions.Ssh.Test.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.Ssh.Test</RootNamespace>
     <AssemblyName>Google.Solutions.Ssh.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/sources/Google.Solutions.Ssh/Google.Solutions.Ssh.csproj
+++ b/sources/Google.Solutions.Ssh/Google.Solutions.Ssh.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Google.Solutions.Ssh</RootNamespace>
     <AssemblyName>Google.Solutions.Ssh</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>


### PR DESCRIPTION
Change target framework to 4.6.2 as 4.6.1 will be deprecated
on April 26, 2022.