### PR TITLE
Add SynchronizationContext helper classes

### DIFF
--- a/sources/Google.Solutions.Common.Test/Google.Solutions.Common.Test.csproj
+++ b/sources/Google.Solutions.Common.Test/Google.Solutions.Common.Test.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Locator\TestDiskTypeLocator.cs" />
     <Compile Include="Integration\InstanceFactory.cs" />
     <Compile Include="Integration\CredentialAttribute.cs" />
+    <Compile Include="Threading\TestSingleThreadSynchronizationContext.cs" />
     <Compile Include="Util\TestCancellationTokenExtensions.cs" />
     <Compile Include="Util\TestDateTimeOffsetExtensions.cs" />
     <Compile Include="Util\TestEnumExtensions.cs" />

--- a/sources/Google.Solutions.Common.Test/Threading/TestSingleThreadSynchronizationContext.cs
+++ b/sources/Google.Solutions.Common.Test/Threading/TestSingleThreadSynchronizationContext.cs
@@ -1,0 +1,142 @@
+﻿//
+// Copyright 2022 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Threading;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.Common.Test.Threading
+{
+    [TestFixture]
+    public class TestSingleThreadSynchronizationContext : CommonFixtureBase
+    {
+        //---------------------------------------------------------------------
+        // Post.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenPostingCallback_ThenCallbackIsInvokedOnDesignatedThread()
+        {
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                var ctx = new SingleThreadSynchronizationContext();
+                var thread = new Thread(_ =>
+                {
+                    ctx.Pump(tokenSource.Token);
+                });
+
+                thread.Start();
+
+                void callback(object state)
+                {
+                    Assert.AreEqual("test", state);
+                    Assert.AreEqual(Thread.CurrentThread.ManagedThreadId, thread.ManagedThreadId);
+                    
+                    tokenSource.Cancel();
+                }
+
+                ctx.Post(callback, "test");
+
+                thread.Join();
+            }
+        }
+
+        //---------------------------------------------------------------------
+        // Pump.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenCalledOnWrongThread_ThenPumpThrowsException()
+        {
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                tokenSource.Cancel();
+
+                var ctx = new SingleThreadSynchronizationContext();
+                var thread = new Thread(_ =>
+                {
+                    ctx.Pump(tokenSource.Token);
+                });
+
+                thread.Start();
+
+                ctx.Pump(tokenSource.Token);
+                thread.Join();
+            }
+        }
+
+        [Test]
+        public void WhenCallbackThrowsException_ThenPumpThrowsException()
+        {
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                var ctx = new SingleThreadSynchronizationContext();
+                var thread = new Thread(_ =>
+                {
+                    Assert.Throws<TargetInvocationException>(
+                        () => ctx.Pump(tokenSource.Token));
+                });
+
+                thread.Start();
+
+                ctx.Post(_ => throw new ArgumentException(), null);
+                
+                thread.Join();
+            }
+        }
+
+        //---------------------------------------------------------------------
+        // RunAsync.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public async Task WhenPostingCallbackUsingRunAsync_ThenCallbackIsInvokedOnDesignatedThread(
+            [Values(true, false)] bool continueOnCapturedContext)
+        {
+            using (var tokenSource = new CancellationTokenSource())
+            {
+                var ctx = new SingleThreadSynchronizationContext();
+                var thread = new Thread(_ =>
+                {
+                    ctx.Pump(tokenSource.Token);
+                });
+
+                thread.Start();
+
+                await ctx.RunAsync(() =>
+                    {
+                        Assert.AreEqual(Thread.CurrentThread.ManagedThreadId, thread.ManagedThreadId);
+
+                        tokenSource.Cancel();
+                    })
+                    .ConfigureAwait(continueOnCapturedContext);
+
+                thread.Join();
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.Common/Google.Solutions.Common.csproj
+++ b/sources/Google.Solutions.Common/Google.Solutions.Common.csproj
@@ -100,6 +100,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Locator\ResourceLocator.cs" />
     <Compile Include="CommonTraceSources.cs" />
+    <Compile Include="Threading\SingleThreadSynchronizationContext.cs" />
+    <Compile Include="Threading\SynchronizationContextExtensions.cs" />
     <Compile Include="Util\CancellationTokenExtensions.cs" />
     <Compile Include="Util\DateTimeOffsetExtensions.cs" />
     <Compile Include="Util\EnumExtensions.cs" />

--- a/sources/Google.Solutions.Common/Threading/SingleThreadSynchronizationContext.cs
+++ b/sources/Google.Solutions.Common/Threading/SingleThreadSynchronizationContext.cs
@@ -1,0 +1,193 @@
+﻿//
+// Copyright 2022 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.Common.Threading
+{
+    /// <summary>
+    /// Execution context that invokes callbacks on a single,
+    /// designated thread.
+    /// </summary>
+    public class SingleThreadSynchronizationContext : SynchronizationContext
+    {
+        private Thread designatedThread;
+        private readonly Queue<QueuedCallback> backlog = new Queue<QueuedCallback>();
+
+        public SingleThreadSynchronizationContext()
+        {
+        }
+
+        //---------------------------------------------------------------------
+        // SynchronizationContext overrides.
+        //---------------------------------------------------------------------
+
+        public override SynchronizationContext CreateCopy()
+        {
+            throw new NotImplementedException(
+                "Context does not support copying");
+        }
+
+        public override void Send(SendOrPostCallback d, object state)
+        {
+            throw new NotImplementedException(
+                "Context does not support synchronous execution");
+        }
+
+        public override void Post(SendOrPostCallback callback, object state)
+        {
+            lock (this.backlog)
+            {
+                //
+                // Enqueue callback and signal the thread.
+                //
+                this.backlog.Enqueue(new QueuedCallback(
+                    ExecutionContext.Capture(),
+                    callback,
+                    state));
+                Monitor.Pulse(this.backlog);
+            }
+        }
+
+        /// <summary>
+        /// Pump and run callbacks until cancelled.
+        /// This method must be called on the designated thread.
+        /// </summary>
+        public void Pump(CancellationToken token)
+        {
+            if (this.designatedThread == null)
+            {
+                this.designatedThread = Thread.CurrentThread;
+            }
+            else if (Thread.CurrentThread.ManagedThreadId != 
+                this.designatedThread.ManagedThreadId)
+            {
+                throw new InvalidOperationException(
+                    "Only the designated thread can be used for pumping");
+            }
+
+            //
+            // Interrupt wait up on cancellation.
+            //
+            token.Register(() =>
+            {
+                lock (this.backlog)
+                {
+                    Monitor.PulseAll(this.backlog);
+                }
+            });
+
+            while (true)
+            {
+                QueuedCallback nextCallback;
+                lock (this.backlog)
+                {
+                    if (token.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    if (!this.backlog.Any())
+                    {
+                        Monitor.Wait(this.backlog);
+                    }
+
+                    Debug.Assert(this.backlog.Any());
+
+                    //
+                    // We might have been interrupted because of cancellation.
+                    //
+                    if (token.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
+                    //
+                    // Get next callback and leave lock so that new callbacks
+                    // can be enqueued while we're executing this one.
+                    //
+                    nextCallback = this.backlog.Dequeue();
+                }
+
+                try
+                {
+                    nextCallback.Invoke();
+                }
+                catch (Exception e)
+                {
+                    //
+                    // Callbacks shouldn't throw exceptions, but it
+                    // might happen anyway.
+                    //
+                    throw new TargetInvocationException(
+                        "Target threw exception, stopping pump",
+                        e);
+                }
+            }
+        }
+
+        //---------------------------------------------------------------------
+        // Inner clases.
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// A queued callback that is scheduled to be executed within
+        /// the synchronization context, on the single theread.
+        /// </summary>
+        private struct QueuedCallback
+        {
+            private readonly ExecutionContext executionContext;
+            private readonly SendOrPostCallback callback;
+            private readonly object state;
+
+            public QueuedCallback(
+                ExecutionContext executionContext,
+                SendOrPostCallback callback,
+                object state)
+            {
+                // TODO: check null
+                this.executionContext = executionContext;
+                this.callback = callback;
+                this.state = state;
+            }
+
+            internal void Invoke()
+            {
+                //
+                // Invoke callback on in the original
+                // execution context.
+                //
+                var cb = this.callback;
+                ExecutionContext.Run(
+                    this.executionContext,
+                    s => cb(s),
+                    this.state);
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.Common/Threading/SynchronizationContextExtensions.cs
+++ b/sources/Google.Solutions.Common/Threading/SynchronizationContextExtensions.cs
@@ -1,0 +1,77 @@
+﻿//
+// Copyright 2022 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.Common.Threading
+{
+    public static class SynchronizationContextExtensions
+    {
+        public static Task<T> RunAsync<T>(
+            this SynchronizationContext context,
+            Func<T> func)
+        {
+            //
+            // Force continuations to run on their execution
+            // context, not ours.
+            //
+            var completionSource = new TaskCompletionSource<T>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            //
+            // Execute the callback in the context, and signal the
+            // task when it's done.
+            //
+            context.Post(_ =>
+            {
+                try
+                {
+                    completionSource.SetResult(func());
+                }
+                catch (Exception e)
+                {
+                    completionSource.SetException(e);
+                }
+            },
+            null);
+
+            return completionSource.Task;
+        }
+
+        public static Task RunAsync(
+            this SynchronizationContext context,
+            Action func)
+        {
+            return RunAsync<object>(
+                context,
+                () =>
+                {
+                    func();
+                    return null;
+                });
+        }
+    }
+}


### PR DESCRIPTION
- Add SingleThreadSynchronizationContext, a context
  that executes callback on a designated thread
- Add SynchronizationContextExtensions to make
  SynchronizationContexts easier to use with async