### PR TITLE
b/229066583 Show error page when OAuth flow was cancelled

### DIFF
--- a/sources/Google.Solutions.IapDesktop/Windows/Resources.resx
+++ b/sources/Google.Solutions.IapDesktop/Windows/Resources.resx
@@ -182,14 +182,31 @@
     &lt;body&gt;
         &lt;div class="container-outer"&gt;
             &lt;div class="container-middle"&gt;
-                &lt;div class="container-content"&gt;
+                &lt;div class="container-content" id="success"&gt;
                     &lt;h1&gt;&lt;span class='product'&gt;IAP Desktop&lt;/span&gt; is ready to use&lt;/h1&gt;
                     &lt;p&gt;
                         You can now use IAP Desktop to access your VMs.
                     &lt;/p&gt;
                 &lt;/div&gt;
+                &lt;div class="container-content" id="error"&gt;
+                    &lt;h1&gt;Something went wrong&lt;/h1&gt;
+                    &lt;p&gt;
+                         Authentication failed: &lt;code id="error-code"&gt;&lt;/code&gt;.
+                    &lt;/p&gt;
+                &lt;/div&gt;
             &lt;/div&gt;
         &lt;/div&gt;
+        
+        &lt;script language="javascript"&gt;
+            const params = new URLSearchParams(location.search);
+            if (params.has('error')) {
+                document.getElementById('success').style.display = 'none';
+                document.getElementById('error-code').textContent = params.get('error');
+            }
+            else {
+                document.getElementById('error').style.display = 'none';
+            }
+        &lt;/script&gt;
     &lt;/body&gt;
 &lt;/html&gt;</value>
   </data>

--- a/sources/Google.Solutions.Ssh.Test/TestSshShellConnection.cs
+++ b/sources/Google.Solutions.Ssh.Test/TestSshShellConnection.cs
@@ -1,5 +1,5 @@
 ﻿//
-// Copyright 2020 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
Display an error messagen when the redirect URI
contains an 'error' parameter, indicating that the
authorization failed or has been cancelled.