### PR TITLE
b/229769118 Ignore copy/paste if clipboard is busy

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Controls/ListViewExtensions.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Controls/ListViewExtensions.cs
@@ -110,7 +110,7 @@ namespace Google.Solutions.IapDesktop.Application.Controls
                 DataFormats.Html,
                 HtmlClipboardFormat.Format(listView.ToHtml(selectedItemsOnly)));
 
-            Clipboard.SetDataObject(dataObject);
+            ClipboardUtil.SetDataObject(dataObject);
         }
 
         public static void AddCopyCommands(this ListView listView)

--- a/sources/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
+++ b/sources/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
@@ -170,6 +170,7 @@
     <Compile Include="Settings\SettingBase.cs" />
     <Compile Include="Util\AsyncLock.cs" />
     <Compile Include="Util\ByteSizeFormatter.cs" />
+    <Compile Include="Util\ClipboardUtil.cs" />
     <Compile Include="Util\Disposable.cs" />
     <Compile Include="Util\EventArgs.cs" />
     <Compile Include="Util\StringExtensions.cs" />

--- a/sources/Google.Solutions.IapDesktop.Application/Util/ClipboardUtil.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Util/ClipboardUtil.cs
@@ -1,0 +1,76 @@
+﻿//
+// Copyright 2020 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Google.Solutions.IapDesktop.Application.Util
+{
+    public class ClipboardUtil
+    {
+        public static string GetText()
+        {
+            try
+            {
+                return Clipboard.GetText();
+            }
+            catch (ExternalException)
+            {
+                //
+                // Clipboard busy, ignore.
+                //
+                return string.Empty;
+            }
+        }
+        public static void SetText(string text)
+        {
+            try
+            {
+                Clipboard.SetText(text);
+            }
+            catch (ExternalException)
+            {
+                //
+                // Clipboard busy, ignore.
+                //
+            }
+        }
+
+        public static void SetDataObject(object data)
+        {
+            try
+            {
+                Clipboard.SetDataObject(data);
+            }
+            catch (ExternalException)
+            {
+                //
+                // Clipboard busy, ignore.
+                //
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminal.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminal.cs
@@ -20,6 +20,7 @@
 //
 
 using Google.Solutions.IapDesktop.Application.Test;
+using Google.Solutions.IapDesktop.Application.Util;
 using Google.Solutions.IapDesktop.Extensions.Shell.Controls;
 using NUnit.Framework;
 using System.Collections.Generic;
@@ -108,7 +109,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         [Test]
         public void WhenPastingClipboardContentWithCrlf_ThenTerminalSendsClipboardContentWithNewline()
         {
-            Clipboard.SetText("sample\r\ntext");
+            ClipboardUtil.SetText("sample\r\ntext");
 
             this.terminal.PasteClipboard();
 
@@ -123,7 +124,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             // you're probably using an unpatched version.
             //
 
-            Clipboard.SetText("text");
+            ClipboardUtil.SetText("text");
 
             this.terminal.ReceiveData($"{Esc}[?2004h"); // Set bracketed paste mode.
             this.terminal.PasteClipboard();
@@ -140,7 +141,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         [Test]
         public void WhenCtrlVIsEnabled_ThenTypingCtrlVSendsClipboardContent()
         {
-            Clipboard.SetText("sample\r\ntext");
+            ClipboardUtil.SetText("sample\r\ntext");
 
             this.terminal.EnableCtrlV = true;
             this.terminal.SimulateKey(Keys.Control | Keys.V);
@@ -151,7 +152,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         [Test]
         public void WhenCtrlVIsDisabled_ThenTypingCtrlVSendsKeystroke()
         {
-            Clipboard.SetText("sample\r\ntext");
+            ClipboardUtil.SetText("sample\r\ntext");
 
             this.terminal.EnableCtrlV = false;
             this.terminal.SimulateKey(Keys.Control | Keys.V);
@@ -166,7 +167,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         [Test]
         public void WhenShiftInsertIsEnabled_ThenTypingShiftInsertSendsClipboardContent()
         {
-            Clipboard.SetText("sample\r\ntext");
+            ClipboardUtil.SetText("sample\r\ntext");
 
             this.terminal.EnableShiftInsert = true;
             this.terminal.SimulateKey(Keys.Shift | Keys.Insert);
@@ -177,7 +178,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
         [Test]
         public void WhenShiftInsertIsDisabled_ThenTypingShiftInsertSendsKeystroke()
         {
-            Clipboard.SetText("sample\r\ntext");
+            ClipboardUtil.SetText("sample\r\ntext");
 
             this.terminal.EnableShiftInsert = false;
             this.terminal.SimulateKey(Keys.Shift | Keys.Insert);
@@ -201,7 +202,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlC = true;
             this.terminal.SimulateKey(Keys.Control | Keys.C);
 
-            Assert.AreEqual("rst line\nsecond l", Clipboard.GetText());
+            Assert.AreEqual("rst line\nsecond l", ClipboardUtil.GetText());
             Assert.AreEqual(string.Empty, this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
@@ -218,7 +219,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlC = true;
             this.terminal.SimulateKey(Keys.Control | Keys.C);
 
-            Assert.AreEqual("", Clipboard.GetText());
+            Assert.AreEqual("", ClipboardUtil.GetText());
             Assert.AreEqual("\u0003", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
@@ -235,7 +236,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlC = false;
             this.terminal.SimulateKey(Keys.Control | Keys.C);
 
-            Assert.AreEqual("", Clipboard.GetText());
+            Assert.AreEqual("", ClipboardUtil.GetText());
             Assert.AreEqual("", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
@@ -252,7 +253,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlC = false;
             this.terminal.SimulateKey(Keys.Control | Keys.C);
 
-            Assert.AreEqual("", Clipboard.GetText());
+            Assert.AreEqual("", ClipboardUtil.GetText());
             Assert.AreEqual("\u0003", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
@@ -273,7 +274,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlInsert = true;
             this.terminal.SimulateKey(Keys.Control | Keys.Insert);
 
-            Assert.AreEqual("rst line\nsecond l", Clipboard.GetText());
+            Assert.AreEqual("rst line\nsecond l", ClipboardUtil.GetText());
             Assert.AreEqual(string.Empty, this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
@@ -290,7 +291,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlInsert = true;
             this.terminal.SimulateKey(Keys.Control | Keys.Insert);
 
-            Assert.AreEqual("", Clipboard.GetText());
+            Assert.AreEqual("", ClipboardUtil.GetText());
             Assert.AreEqual($"{Esc}[2;5~", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
@@ -307,7 +308,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlInsert = false;
             this.terminal.SimulateKey(Keys.Control | Keys.Insert);
 
-            Assert.AreEqual("", Clipboard.GetText());
+            Assert.AreEqual("", ClipboardUtil.GetText());
             Assert.AreEqual("", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
@@ -324,7 +325,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlInsert = false;
             this.terminal.SimulateKey(Keys.Control | Keys.Insert);
 
-            Assert.AreEqual("", Clipboard.GetText());
+            Assert.AreEqual("", ClipboardUtil.GetText());
             Assert.AreEqual($"{Esc}[2;5~", this.sendData.ToString());
             Assert.IsFalse(this.terminal.IsTextSelected);
         }
@@ -401,7 +402,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             Assert.IsFalse(this.terminal.IsTextSelected);
             Assert.AreEqual(
                 textSmallerThanViewPort.Replace("\r\n", "\n"),
-                Clipboard.GetText());
+                ClipboardUtil.GetText());
         }
 
         [Test]

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshTerminalPane.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshTerminalPane.cs
@@ -27,6 +27,7 @@ using Google.Solutions.IapDesktop.Application.Services.Adapters;
 using Google.Solutions.IapDesktop.Application.Services.Authorization;
 using Google.Solutions.IapDesktop.Application.Services.Integration;
 using Google.Solutions.IapDesktop.Application.Test.Views;
+using Google.Solutions.IapDesktop.Application.Util;
 using Google.Solutions.IapDesktop.Extensions.Shell.Services.Settings;
 using Google.Solutions.IapDesktop.Extensions.Shell.Services.Ssh;
 using Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal;
@@ -368,7 +369,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
                 await AssertRaisesEventAsync<SessionEndedEvent>(() =>
                     {
                         // Copy command with a line continuation.
-                        Clipboard.SetText("whoami \\\r\n--help;exit\n\n");
+                        ClipboardUtil.SetText("whoami \\\r\n--help;exit\n\n");
                         pane.Terminal.PasteClipboard();
 
                         return Task.CompletedTask;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminal.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminal.cs
@@ -543,14 +543,14 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
                 // Trim end since we might be copying empty rows
                 // instead (if we have not reached the bottom row
                 // yet).
-                Clipboard.SetText(captured.TrimEnd());
+                ClipboardUtil.SetText(captured.TrimEnd());
             }
         }
 
         internal void PasteClipboard()
         {
             // Paste clipboard.
-            var text = Clipboard.GetText();
+            var text = ClipboardUtil.GetText();
             if (!string.IsNullOrEmpty(text))
             {
                 //

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Credentials/ShowCredentialsDialog.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Credentials/ShowCredentialsDialog.cs
@@ -21,6 +21,7 @@
 
 using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.IapDesktop.Application.ObjectModel;
+using Google.Solutions.IapDesktop.Application.Util;
 using Google.Solutions.IapDesktop.Application.Views;
 using Google.Solutions.IapDesktop.Extensions.Shell.Properties;
 using System;
@@ -56,7 +57,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Credentials
             copyPasswordButton.Location = new Point(passwordText.ClientSize.Width - copyPasswordButton.Width, -1);
             copyPasswordButton.Image = Resources.Copy_16x;
             copyPasswordButton.Cursor = Cursors.Default;
-            copyPasswordButton.Click += (s, a) => { Clipboard.SetText(passwordText.Text); };
+            copyPasswordButton.Click += (s, a) => { ClipboardUtil.SetText(passwordText.Text); };
             passwordText.Controls.Add(copyPasswordButton);
 
             // Send EM_SETMARGINS to prevent text from disappearing underneath the button

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshTerminalPaneViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshTerminalPaneViewModel.cs
@@ -26,6 +26,7 @@ using Google.Solutions.IapDesktop.Application;
 using Google.Solutions.IapDesktop.Application.Controls;
 using Google.Solutions.IapDesktop.Application.ObjectModel;
 using Google.Solutions.IapDesktop.Application.Services.Integration;
+using Google.Solutions.IapDesktop.Application.Util;
 using Google.Solutions.IapDesktop.Application.Views;
 using Google.Solutions.IapDesktop.Application.Views.Dialog;
 using Google.Solutions.IapDesktop.Extensions.Shell.Services.Ssh;
@@ -415,7 +416,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
         {
             if (this.sentData.Length > 0)
             {
-                Clipboard.SetText(this.sentData.ToString());
+                ClipboardUtil.SetText(this.sentData.ToString());
             }
         }
 
@@ -423,7 +424,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
         {
             if (this.receivedData.Length > 0)
             {
-                Clipboard.SetText(this.receivedData.ToString());
+                ClipboardUtil.SetText(this.receivedData.ToString());
             }
         }
 


### PR DESCRIPTION
If the clipboard is busy, silently ignore the copy/
paste operation. This is in line with how most Windows
applications handle such errors.