### PR TITLE
b/227935260 Disable timeout for file upload/download operations

### DIFF
--- a/sources/Google.Solutions.Ssh/Native/SshSession.cs
+++ b/sources/Google.Solutions.Ssh/Native/SshSession.cs
@@ -130,6 +130,19 @@ namespace Google.Solutions.Ssh.Native
             return Disposable.For(() => this.IsBlocking = false);
         }
 
+        public IDisposable AsBlocking(TimeSpan timeout)
+        {
+            this.IsBlocking = true;
+            var previousTimeout = this.Timeout;
+
+            this.Timeout = timeout;
+            return Disposable.For(() =>
+            {
+                this.IsBlocking = false;
+                this.Timeout = previousTimeout;
+            });
+        }
+
         public IDisposable AsNonBlocking()
         {
             this.IsBlocking = false;

--- a/sources/Google.Solutions.Ssh/Native/SshSftpFileChannel.cs
+++ b/sources/Google.Solutions.Ssh/Native/SshSftpFileChannel.cs
@@ -99,7 +99,7 @@ namespace Google.Solutions.Ssh.Native
 
             Debug.Assert(length <= buffer.Length);
 
-            using (SshTraceSources.Default.TraceMethod().WithoutParameters())
+            using (SshTraceSources.Default.TraceMethod().WithParameters(length))
             {
                 var bytesWritten = UnsafeNativeMethods.libssh2_sftp_write(
                     this.fileHandle,

--- a/sources/Google.Solutions.Ssh/RemoteConnection.cs
+++ b/sources/Google.Solutions.Ssh/RemoteConnection.cs
@@ -239,6 +239,7 @@ namespace Google.Solutions.Ssh
 
             if (exception != null)
             {
+                SshTraceSources.Default.TraceError(exception);
                 throw exception;
             }
             else

--- a/sources/Google.Solutions.Ssh/RemoteFileSystemChannel.cs
+++ b/sources/Google.Solutions.Ssh/RemoteFileSystemChannel.cs
@@ -120,8 +120,9 @@ namespace Google.Solutions.Ssh
                     // Upload the entire file as one operation, possibly
                     // blocking other channels.
                     //
-
-                    using (c.Session.AsBlocking())
+                    // Temporarily disable the timeout.
+                    //
+                    using (c.Session.AsBlocking(TimeSpan.Zero))
                     using (var file = this.nativeChannel.CreateFile(
                             remotePath,
                             flags,
@@ -161,8 +162,9 @@ namespace Google.Solutions.Ssh
                     // Upload the entire file as one operation, possibly
                     // blocking other channels.
                     //
-
-                    using (c.Session.AsBlocking())
+                    // Temporarily disable the timeout.
+                    //
+                    using (c.Session.AsBlocking(TimeSpan.Zero))
                     using (var file = this.nativeChannel.CreateFile(
                             remotePath,
                             LIBSSH2_FXF_FLAGS.READ,


### PR DESCRIPTION
Although the operstions are done as blocking, they
could might time out if the connection speed is low.

Disable timeout during upload/download and restore
afterwards.