### PR TITLE
Handle partial SFTP writes

### DIFF
--- a/sources/Google.Solutions.Ssh.Test/Native/TestSshSftpFileChannel.cs
+++ b/sources/Google.Solutions.Ssh.Test/Native/TestSshSftpFileChannel.cs
@@ -86,7 +86,12 @@ namespace Google.Solutions.Ssh.Test.Native
             using (var authSession = connection.Authenticate(authenticator))
             using (var channel = authSession.OpenSftpChannel())
             {
-                var sendData = "The quick brown fox jumps over the lazy dog";
+                var sendData = new StringBuilder();
+                for (int i = 0; i < 500; i++)
+                {
+                    sendData.Append(i);
+                    sendData.Append("The quick brown fox jumps over the lazy dog\n");
+                }
 
                 var fileName = Guid.NewGuid().ToString();
 
@@ -97,9 +102,8 @@ namespace Google.Solutions.Ssh.Test.Native
                         FilePermissions.OwnerRead |
                         FilePermissions.OtherWrite))
                 {
-                    var buffer = Encoding.ASCII.GetBytes(sendData);
-                    var bytesWritten = file.Write(buffer, buffer.Length);
-                    Assert.AreEqual(buffer.Length, bytesWritten);
+                    var buffer = Encoding.ASCII.GetBytes(sendData.ToString());
+                    file.Write(buffer, buffer.Length);
                 }
 
                 using (var file = channel.CreateFile(
@@ -112,13 +116,13 @@ namespace Google.Solutions.Ssh.Test.Native
                     var receiveData = new StringBuilder();
 
                     uint bytesRead = 0;
-                    var tinyBuffer = new byte[16];
+                    var tinyBuffer = new byte[128];
                     while ((bytesRead = file.Read(tinyBuffer)) > 0)
                     {
                         receiveData.Append(Encoding.ASCII.GetString(tinyBuffer, 0, (int)bytesRead));
                     }
 
-                    Assert.AreEqual(sendData, receiveData.ToString());
+                    Assert.AreEqual(sendData.ToString(), receiveData.ToString());
                 }
             }
         }

--- a/sources/Google.Solutions.Ssh/Native/UnsafeNativeMethods.cs
+++ b/sources/Google.Solutions.Ssh/Native/UnsafeNativeMethods.cs
@@ -530,7 +530,7 @@ namespace Google.Solutions.Ssh.Native
         [DllImport(Libssh2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern int libssh2_sftp_write(
             SshSftpFileHandle channel,
-            byte[] buffer,
+            IntPtr buffer,
             IntPtr bufferSize);
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.Ssh/RemoteFileSystemChannel.cs
+++ b/sources/Google.Solutions.Ssh/RemoteFileSystemChannel.cs
@@ -37,7 +37,13 @@ namespace Google.Solutions.Ssh
     /// </summary>
     public class RemoteFileSystemChannel : RemoteChannelBase
     {
-        internal const int CopyBufferSize = 16 * 1024;
+        //
+        // The buffer size determines the number of bytes written
+        // at once. IAP has a max write size of 16KB. Accounting
+        // for the overhead of SSH, this leaves a bit less than
+        // 16KB as a good write size.
+        //
+        internal const int CopyBufferSize = 15 * 1024;
 
         /// <summary>
         /// Channel handle, must only be accessed on worker thread.

--- a/sources/Google.Solutions.Ssh/RemoteFileSystemChannel.cs
+++ b/sources/Google.Solutions.Ssh/RemoteFileSystemChannel.cs
@@ -37,7 +37,7 @@ namespace Google.Solutions.Ssh
     /// </summary>
     public class RemoteFileSystemChannel : RemoteChannelBase
     {
-        private const int CopyBufferSize = 8 * 1024;
+        internal const int CopyBufferSize = 16 * 1024;
 
         /// <summary>
         /// Channel handle, must only be accessed on worker thread.
@@ -122,7 +122,7 @@ namespace Google.Solutions.Ssh
                     //
                     // Temporarily disable the timeout.
                     //
-                    using (c.Session.AsBlocking(TimeSpan.Zero))
+                    using (c.Session.AsBlocking())
                     using (var file = this.nativeChannel.CreateFile(
                             remotePath,
                             flags,
@@ -164,7 +164,7 @@ namespace Google.Solutions.Ssh
                     //
                     // Temporarily disable the timeout.
                     //
-                    using (c.Session.AsBlocking(TimeSpan.Zero))
+                    using (c.Session.AsBlocking())
                     using (var file = this.nativeChannel.CreateFile(
                             remotePath,
                             LIBSSH2_FXF_FLAGS.READ,


### PR DESCRIPTION
libssh_sftp_write doesn't guarantee that the entire
buffer is written. Therefore, repeat writes if
necessary.