### PR TITLE
b/227935260 Increase buffer for SFTP transfers

### DIFF
--- a/sources/Google.Solutions.Ssh/RemoteFileSystemChannel.cs
+++ b/sources/Google.Solutions.Ssh/RemoteFileSystemChannel.cs
@@ -38,12 +38,21 @@ namespace Google.Solutions.Ssh
     public class RemoteFileSystemChannel : RemoteChannelBase
     {
         //
-        // The buffer size determines the number of bytes written
-        // at once. IAP has a max write size of 16KB. Accounting
-        // for the overhead of SSH, this leaves a bit less than
-        // 16KB as a good write size.
+        // SFTP effectively limits the size of a packet to 32 KB, see
+        // <https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-13#section-4>
         //
-        internal const int CopyBufferSize = 15 * 1024;
+        // libssh2 uses a slightly smaller limit of 30000 bytes 
+        // (MAX_SFTP_OUTGOING_SIZE, MAX_SFTP_READ_SIZE).
+        // Using a buffer larger than 30000 bytes therefore doen't
+        // provide much value.
+        //
+        // Note that IAP/SSH Relay uses 16KB as maximum message size,
+        // so a 32000 byte packet will be split into 2 messages. 
+        // That's still more efficient than using a SFTP packet
+        // size below 16 KB as it at least limits the number of 
+        // SSH_FXP_STATUS packets that need to be exchanged.
+        //
+        internal const int CopyBufferSize = 30000;
 
         /// <summary>
         /// Channel handle, must only be accessed on worker thread.


### PR DESCRIPTION
Use 32000 byte buffers, corresponding to the maximum
size supported by libssh2.