### PR TITLE
b/231083798 Use TaskDialog for confirmation

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Views/Dialog/TaskDialog.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/Dialog/TaskDialog.cs
@@ -44,6 +44,7 @@ namespace Google.Solutions.IapDesktop.Application.Views.Dialog
 
     public static class TaskDialogIcons
     {
+        public static readonly IntPtr TD_WARNING_ICON = new IntPtr(65535);
         public static readonly IntPtr TD_ERROR_ICON = new IntPtr(65534);
         public static readonly IntPtr TD_INFORMATION_ICON = new IntPtr(65533);
         public static readonly IntPtr TD_SHIELD_ICON = new IntPtr(65532);

--- a/sources/Google.Solutions.IapDesktop.Application/Views/Dialog/UnsafeNativeMethods.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/Dialog/UnsafeNativeMethods.cs
@@ -79,6 +79,11 @@ namespace Google.Solutions.IapDesktop.Application.Views.Dialog
 
         public const int IDOK = 1;
         public const int IDCANCEL = 2;
+        public const int IDABORT = 3;
+        public const int IDRETRY = 4;
+        public const int IDIGNORE = 5;
+        public const int IDYES = 6;
+        public const int IDNO = 7;
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode, Pack = 1)]
         internal struct TASKDIALOGCONFIG

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshTerminalPaneViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshTerminalPaneViewModel.cs
@@ -341,16 +341,19 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
                     var conflicts = existingFileNames.Intersect(fileNamesToUpload);
 
                     var message = "Are you sure you want to upload the following " +
-                        $"file(s) to {this.Instance.Name}?\n\n - " +
-                        string.Join("\n - ", fileNamesToUpload);
+                        $"file(s) to your home directory on {this.Instance.Name}?\n\n - " +
+                        string.Join("\n - ", fileNamesToUpload.Select(s => s.Truncate(30)));
                     if (conflicts.Any())
                     {
                         message +=
                             "\n\nThe following files already exist on the server and will be replaced:\n\n - " +
-                            string.Join("\n - ", conflicts);
+                            string.Join("\n - ", conflicts.Select(s => s.Truncate(30)));
                     }
 
-                    if (this.confirmationDialog.Confirm(this.View, message, "Upload") != DialogResult.Yes)
+                    if (this.confirmationDialog.Confirm(
+                        this.View, 
+                        message,
+                        $"Upload file(s) to {this.Instance.Name}") != DialogResult.Yes)
                     {
                         return false;
                     }


### PR DESCRIPTION
- Use TaskDialog instead if MessageBox
- Truncate overly long file names in SFTP
  confirmation message