### PR TITLE
b/232821184 Normalize casing for mutex and named pipe

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Util/TestSingletonApplicationBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Util/TestSingletonApplicationBase.cs
@@ -39,7 +39,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Util
             public string[] SubsequentInvocationArgs = null;
             public Exception SubsequentInvocationException = null;
 
-            public Singleton() : base(Guid.NewGuid().ToString())
+            public Singleton(string name) : base(name)
             {
             }
 
@@ -86,7 +86,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Util
                 new [] {"one two", "three"}
             )] string[] args)
         {
-            var app = new Singleton();
+            var app = new Singleton(Guid.NewGuid().ToString());
             Task.Factory.StartNew(() =>
             {
                 app.Run(args);
@@ -108,7 +108,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Util
                 new [] {"one two", "three"}
             )] string[] args)
         {
-            var app = new Singleton();
+            var app = new Singleton(Guid.NewGuid().ToString());
             Task.Factory.StartNew(() =>
             {
                 app.Run(new[] { "first", "app" });
@@ -131,9 +131,23 @@ namespace Google.Solutions.IapDesktop.Application.Test.Util
         }
 
         [Test]
-        public void WhenHandleSubsequentInvocationFailed_ThenHandleSubsequentInvocationExceptionIsCalled()
+        public void WhenNameOnlyDiffersInCasing_ThenArgumentsArePassedToHandleSubsequentInvocation()
         {
-            Assert.Inconclusive();
+            var guid = Guid.NewGuid().ToString();
+            var first = new Singleton("TEST_" + guid);
+            Task.Factory.StartNew(() => first.Run(new[] { "first" }));
+            first.WaitTillRunning();
+
+            var second = new Singleton("test_" + guid);
+            Task.Factory.StartNew(() => second.Run(new[] { "second" }));
+
+            first.WaitTillRunning();
+            Assert.AreEqual(
+                new[] { "second" },
+                first.SubsequentInvocationArgs);
+
+            first.Quit();
+            second.Quit();
         }
     }
 }


### PR DESCRIPTION
Mutex names are case-sensitive, but pipe names aren't.
Normalize casing to prevent a situation where a second
instance can claim the mutex (because it uses a different
casing) but then can't open another pipe server because
the pipe name is taken (with a different casing).

Remove retry-logic as it shouldn't be required anymore
with this fix in place.