### PR TITLE
Use Debian 11 for test VMs

### DIFF
--- a/sources/Google.Solutions.Ssh.Test/Native/TestSshShellChannel.cs
+++ b/sources/Google.Solutions.Ssh.Test/Native/TestSshShellChannel.cs
@@ -140,9 +140,9 @@ namespace Google.Solutions.Ssh.Test.Native
                 new[]
                 {
                     new EnvironmentVariable(
-                        "LANG",
                         "LC_ALL",
-                        true) // LANG is whitelisted by sshd by default.
+                        "en_AU",
+                        true) // LC_* is whitelisted by sshd by default.
                 }))
             {
                 var bytesWritten = channel.Write(Encoding.ASCII.GetBytes("echo $LANG;exit\n"));
@@ -151,8 +151,13 @@ namespace Google.Solutions.Ssh.Test.Native
                 var output = ReadToEnd(channel, Encoding.ASCII);
                 channel.Close();
 
+                //
+                // The locale might be unknown, but then there'll be an error by
+                // setlocale. In either case, we should find "en_AU" somewhere in
+                // the output, confirming that it has been passed to the VM.
+                //
                 StringAssert.Contains(
-                    "en_US.UTF-8",
+                    "en_AU",
                     output);
 
                 Assert.AreEqual(0, channel.ExitCode);

--- a/sources/Google.Solutions.Testing.Common/Integration/InstanceAttribute.cs
+++ b/sources/Google.Solutions.Testing.Common/Integration/InstanceAttribute.cs
@@ -174,7 +174,7 @@ namespace Google.Solutions.Testing.Common.Integration
     public sealed class LinuxInstanceAttribute : InstanceAttribute
     {
         public const string DefaultMachineType = "f1-micro";
-        public const string Debian9 = "projects/debian-cloud/global/images/family/debian-9";
+        public const string Debian9 = "projects/debian-cloud/global/images/family/debian-11";
 
         protected override string InstanceNamePrefix => "u";
 


### PR DESCRIPTION
The debian-9 image family has been deprecated,
so use debian-11 instead.