### PR TITLE
b/240100649 Surface session commands in tab context menu

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/ObjectModel/Commands/TestCommandContainer.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/ObjectModel/Commands/TestCommandContainer.cs
@@ -38,14 +38,19 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
     [TestFixture]
     public class TestCommandContainer
     {
+        private class NonObservableCommandContextSource<TContext> : ICommandContextSource<TContext>
+        {
+            public TContext Context { get; set; }
+        }
+
         //---------------------------------------------------------------------
         // Context.
         //---------------------------------------------------------------------
 
         [Test]
-        public void WhenContextChanged_ThenQueryStateIsCalledOnTopLevelCommands()
+        public void WhenObservableContextChanged_ThenQueryStateIsCalledOnTopLevelCommands()
         {
-            var source = new CommandContextSource<string>()
+            var source = new ObservableCommandContextSource<string>()
             {
                 Context = "ctx-1"
             };
@@ -73,9 +78,9 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
         }
 
         [Test]
-        public void WhenContextChanged_ThenQueryStateIsCalledOnChildCommands()
+        public void WhenObservableContextChanged_ThenQueryStateIsCalledOnChildCommands()
         {
-            var source = new CommandContextSource<string>()
+            var source = new ObservableCommandContextSource<string>()
             {
                 Context = "ctx-1"
             };
@@ -109,9 +114,9 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
         }
 
         [Test]
-        public void WhenContextChanged_ThenExecuteUsesLatestContext()
+        public void WhenObservableContextChanged_ThenExecuteUsesLatestContext()
         {
-            var source = new CommandContextSource<string>()
+            var source = new ObservableCommandContextSource<string>()
             {
                 Context = "ctx-1"
             };
@@ -129,6 +134,27 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
             }
         }
 
+        [Test]
+        public void WhenNonObservableContextChanged_ThenExecuteUsesOldContext()
+        {
+            var source = new NonObservableCommandContextSource<string>()
+            {
+                Context = "ctx-1"
+            };
+
+            using (var container = new CommandContainer<string>(
+                ToolStripItemDisplayStyle.Text,
+                source))
+            {
+                container.AddCommand(
+                    "toplevel",
+                    ctx => CommandState.Enabled,
+                    ctx => Assert.AreEqual("ctx-1", ctx));
+
+                source.Context = "ctx-2";
+            }
+        }
+
         //---------------------------------------------------------------------
         // AddCommand.
         //---------------------------------------------------------------------
@@ -138,7 +164,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
         {
             using (var container = new CommandContainer<string>(
                 ToolStripItemDisplayStyle.Text,
-                new CommandContextSource<string>()))
+                new ObservableCommandContextSource<string>()))
             {
                 PropertyAssert.RaisesCollectionChangedNotification(
                     container.MenuItems,
@@ -155,7 +181,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
         {
             using (var container = new CommandContainer<string>(
                 ToolStripItemDisplayStyle.Text,
-                new CommandContextSource<string>()))
+                new ObservableCommandContextSource<string>()))
             {
                 PropertyAssert.RaisesCollectionChangedNotification(
                     container.MenuItems,
@@ -173,7 +199,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
         {
             using (var container = new CommandContainer<string>(
                 ToolStripItemDisplayStyle.Text,
-                new CommandContextSource<string>()))
+                new ObservableCommandContextSource<string>()))
             {
                 container.ExecuteCommandByKey(Keys.A);
             }
@@ -182,7 +208,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
         [Test]
         public void WhenKeyIsMappedAndCommandIsEnabled_ThenExecuteCommandInvokesHandler()
         {
-            var source = new CommandContextSource<string>()
+            var source = new ObservableCommandContextSource<string>()
             {
                 Context = "ctx-1"
             };
@@ -213,7 +239,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
         [Test]
         public void WhenKeyIsMappedAndCommandIsDisabled_ThenExecuteCommandByKeyDoesNothing()
         {
-            var source = new CommandContextSource<string>()
+            var source = new ObservableCommandContextSource<string>()
             {
                 Context = "ctx-1"
             };
@@ -245,7 +271,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
         [Test]
         public void WhenContainerDoesNotHaveDefaultCommand_ThenExecuteDefaultCommandDoesNothing()
         {
-            var source = new CommandContextSource<string>()
+            var source = new ObservableCommandContextSource<string>()
             {
                 Context = "ctx-1"
             };
@@ -269,7 +295,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
         [Test]
         public void WhenDefaultCommandIsDisabled_ThenExecuteDefaultCommandDoesNothing()
         {
-            var source = new CommandContextSource<string>()
+            var source = new ObservableCommandContextSource<string>()
             {
                 Context = "ctx-1"
             };
@@ -294,7 +320,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
         [Test]
         public void WhenDefaultCommandIsEnabled_ThenExecuteDefaultExecutesCommand()
         {
-            var source = new CommandContextSource<string>()
+            var source = new ObservableCommandContextSource<string>()
             {
                 Context = "ctx-1"
             };
@@ -330,7 +356,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
         {
             using (var container = new CommandContainer<string>(
                 ToolStripItemDisplayStyle.Text,
-                new CommandContextSource<string>()))
+                new ObservableCommandContextSource<string>()))
             {
                 Exception exception = null;
                 container.CommandFailed += (s, a) =>
@@ -359,7 +385,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel.Commands
         {
             using (var container = new CommandContainer<string>(
                 ToolStripItemDisplayStyle.Text,
-                new CommandContextSource<string>()))
+                new ObservableCommandContextSource<string>()))
             {
                 container.CommandFailed += (s, a) => Assert.Fail();
 

--- a/sources/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
+++ b/sources/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
@@ -171,7 +171,7 @@
     <Compile Include="Settings\RegistrySetting.cs" />
     <Compile Include="Settings\SettingBase.cs" />
     <Compile Include="ObjectModel\ToolStripMenuBindingExtensions.cs" />
-    <Compile Include="ObjectModel\Commands\CommandContextSource.cs" />
+    <Compile Include="ObjectModel\Commands\ObservableCommandContextSource.cs" />
     <Compile Include="ObjectModel\Commands\CommandContainer.cs" />
     <Compile Include="Util\AsyncLock.cs" />
     <Compile Include="Util\ByteSizeFormatter.cs" />

--- a/sources/Google.Solutions.IapDesktop.Application/ObjectModel/Commands/CommandContainer.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ObjectModel/Commands/CommandContainer.cs
@@ -54,6 +54,10 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel.Commands
         void ExecuteCommandByKey(Keys keys);
 
         void ExecuteDefaultCommand();
+
+        void BindTo(
+            ToolStripItemCollection view,
+            IContainer container = null);
     }
 
     public sealed class CommandContainer<TContext> : ICommandContainer<TContext>, IDisposable

--- a/sources/Google.Solutions.IapDesktop.Application/ObjectModel/Commands/CommandContainer.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ObjectModel/Commands/CommandContainer.cs
@@ -58,6 +58,8 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel.Commands
         void BindTo(
             ToolStripItemCollection view,
             IContainer container = null);
+
+        void ForceRefresh();
     }
 
     public sealed class CommandContainer<TContext> : ICommandContainer<TContext>, IDisposable

--- a/sources/Google.Solutions.IapDesktop.Application/ObjectModel/Commands/ObservableCommandContextSource.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ObjectModel/Commands/ObservableCommandContextSource.cs
@@ -40,7 +40,7 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel.Commands
     /// determines the availability of commands.
     /// </summary>
     /// <typeparam name="TContext"></typeparam>
-    public interface ICommandContextSource<TContext> : INotifyPropertyChanged
+    public interface ICommandContextSource<TContext>
     {
         TContext Context { get; }
     }
@@ -48,7 +48,8 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel.Commands
     /// <summary>
     /// Basic context source implementation.
     /// </summary>
-    public class CommandContextSource<TContext> : ViewModelBase, ICommandContextSource<TContext>
+    public class ObservableCommandContextSource<TContext> 
+        : ViewModelBase, ICommandContextSource<TContext>
     {
         private TContext context;
 

--- a/sources/Google.Solutions.IapDesktop.Application/Views/ProjectExplorer/ProjectExplorerWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/ProjectExplorer/ProjectExplorerWindow.cs
@@ -153,7 +153,7 @@ namespace Google.Solutions.IapDesktop.Application.Views.ProjectExplorer
             //
             // Menus.
             //
-            var contextSource = new CommandContextSource<IProjectModelNode>();
+            var contextSource = new ObservableCommandContextSource<IProjectModelNode>();
             this.viewModel.OnPropertyChange(
                 m => m.SelectedNode,
                 node =>

--- a/sources/Google.Solutions.IapDesktop.Application/Views/ToolWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/ToolWindow.cs
@@ -46,6 +46,12 @@ namespace Google.Solutions.IapDesktop.Application.Views
 
         public bool IsClosed { get; private set; } = false;
 
+        public bool ShowCloseMenuItemInContextMenu
+        {
+            get => this.closeMenuItem.Visible;
+            set => this.closeMenuItem.Visible = false;
+        }
+
         public ToolWindow()
         {
             this.InitializeComponent();

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Google.Solutions.IapDesktop.Extensions.Shell.Test.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Google.Solutions.IapDesktop.Extensions.Shell.Test.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Views\SshTerminal\TestSshTerminalPane.cs" />
     <Compile Include="Views\SshTerminal\TestSshTerminalSessionBroker.cs" />
     <Compile Include="Views\SshTerminal\TestSshTerminalPaneViewModel.cs" />
+    <Compile Include="Views\TestSessionPaneBase.cs" />
     <Compile Include="Views\TunnelsViewer\TestTunnelsViewModel.cs" />
     <Compile Include="Services\Tunnel\TestTunnelBrokerService.cs" />
     <Compile Include="Services\Tunnel\TestTunnelService.cs" />

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Rdp/TestRdpConnectionService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Rdp/TestRdpConnectionService.cs
@@ -107,17 +107,19 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Rdp
 
             var remoteDesktopService = new Mock<IRemoteDesktopSessionBroker>();
             remoteDesktopService.Setup(s => s.Connect(
-                It.IsAny<InstanceLocator>(),
-                "localhost",
-                It.IsAny<ushort>(),
-                It.IsAny<InstanceConnectionSettings>())).Returns<IRemoteDesktopSession>(null);
+                    It.IsAny<InstanceLocator>(),
+                    "localhost",
+                    It.IsAny<ushort>(),
+                    It.IsAny<InstanceConnectionSettings>()))
+                .Returns(new Mock<IRemoteDesktopSession>().Object);
 
             this.serviceRegistry.AddSingleton<IRemoteDesktopSessionBroker>(remoteDesktopService.Object);
 
             var service = new RdpConnectionService(this.serviceRegistry);
-            await service
+            var session = await service
                 .ActivateOrConnectInstanceAsync(vmNode.Object, false)
                 .ConfigureAwait(false);
+            Assert.IsNotNull(session);
 
             remoteDesktopService.Verify(s => s.Connect(
                 It.IsAny<InstanceLocator>(),
@@ -153,17 +155,19 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Rdp
 
             var remoteDesktopService = new Mock<IRemoteDesktopSessionBroker>();
             remoteDesktopService.Setup(s => s.Connect(
-                It.IsAny<InstanceLocator>(),
-                "localhost",
-                It.IsAny<ushort>(),
-                It.IsAny<InstanceConnectionSettings>())).Returns<IRemoteDesktopSession>(null);
+                    It.IsAny<InstanceLocator>(),
+                    "localhost",
+                    It.IsAny<ushort>(),
+                    It.IsAny<InstanceConnectionSettings>()))
+                .Returns(new Mock<IRemoteDesktopSession>().Object);
 
             this.serviceRegistry.AddSingleton<IRemoteDesktopSessionBroker>(remoteDesktopService.Object);
 
             var service = new RdpConnectionService(this.serviceRegistry);
-            await service
+            var session = await service
                 .ActivateOrConnectInstanceAsync(vmNode.Object, true)
                 .ConfigureAwait(false);
+            Assert.IsNotNull(session);
 
             remoteDesktopService.Verify(s => s.Connect(
                 It.IsAny<InstanceLocator>(),
@@ -198,18 +202,20 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Rdp
 
             var remoteDesktopService = new Mock<IRemoteDesktopSessionBroker>();
             remoteDesktopService.Setup(s => s.Connect(
-                It.IsAny<InstanceLocator>(),
-                "localhost",
-                It.IsAny<ushort>(),
-                It.IsAny<InstanceConnectionSettings>())).Returns<IRemoteDesktopSession>(null);
+                    It.IsAny<InstanceLocator>(),
+                    "localhost",
+                    It.IsAny<ushort>(),
+                    It.IsAny<InstanceConnectionSettings>()))
+                .Returns(new Mock<IRemoteDesktopSession>().Object);
 
             this.serviceRegistry.AddSingleton<IRemoteDesktopSessionBroker>(remoteDesktopService.Object);
 
             var service = new RdpConnectionService(this.serviceRegistry);
-            await service
+            var session = await service
                 .ActivateOrConnectInstanceAsync(
                     IapRdpUrl.FromString("iap-rdp:///project/us-central-1/instance"))
                 .ConfigureAwait(false);
+            Assert.IsNotNull(session);
 
             remoteDesktopService.Verify(s => s.Connect(
                 It.IsAny<InstanceLocator>(),
@@ -238,18 +244,20 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Rdp
 
             var remoteDesktopService = new Mock<IRemoteDesktopSessionBroker>();
             remoteDesktopService.Setup(s => s.Connect(
-                It.IsAny<InstanceLocator>(),
-                "localhost",
-                It.IsAny<ushort>(),
-                It.IsAny<InstanceConnectionSettings>())).Returns<IRemoteDesktopSession>(null);
+                    It.IsAny<InstanceLocator>(),
+                    "localhost",
+                    It.IsAny<ushort>(),
+                    It.IsAny<InstanceConnectionSettings>()))
+                .Returns(new Mock<IRemoteDesktopSession>().Object);
 
             this.serviceRegistry.AddSingleton<IRemoteDesktopSessionBroker>(remoteDesktopService.Object);
 
             var service = new RdpConnectionService(this.serviceRegistry);
-            await service
+            var session = await service
                 .ActivateOrConnectInstanceAsync(
                     IapRdpUrl.FromString("iap-rdp:///project/us-central-1/instance?username=john%20doe"))
                 .ConfigureAwait(false);
+            Assert.IsNotNull(session);
 
             remoteDesktopService.Verify(s => s.Connect(
                 It.IsAny<InstanceLocator>(),
@@ -291,18 +299,20 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Rdp
 
             var remoteDesktopService = new Mock<IRemoteDesktopSessionBroker>();
             remoteDesktopService.Setup(s => s.Connect(
-                It.IsAny<InstanceLocator>(),
-                "localhost",
-                It.IsAny<ushort>(),
-                It.IsAny<InstanceConnectionSettings>())).Returns<IRemoteDesktopSession>(null);
+                    It.IsAny<InstanceLocator>(),
+                    "localhost",
+                    It.IsAny<ushort>(),
+                    It.IsAny<InstanceConnectionSettings>()))
+                .Returns(new Mock<IRemoteDesktopSession>().Object);
 
             this.serviceRegistry.AddSingleton<IRemoteDesktopSessionBroker>(remoteDesktopService.Object);
 
             var service = new RdpConnectionService(this.serviceRegistry);
-            await service
+            var session = await service
                 .ActivateOrConnectInstanceAsync(
                     IapRdpUrl.FromString("iap-rdp:///project/us-central-1/instance-1?username=john%20doe"))
                 .ConfigureAwait(false);
+            Assert.IsNotNull(session);
 
             remoteDesktopService.Verify(s => s.Connect(
                 It.IsAny<InstanceLocator>(),

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/TestSessionPaneBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/TestSessionPaneBase.cs
@@ -67,20 +67,22 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views
                 s => { });
 
 
-            var window = new SessionPane()
+            using (var window = new SessionPane()
             {
                 ContextCommands = commands
-            };
+            })
+            {
 
-            Assert.IsNotNull(window.ContextCommands);
-            Assert.IsNotNull(window.TabPageContextMenuStrip);
+                Assert.IsNotNull(window.ContextCommands);
+                Assert.IsNotNull(window.TabPageContextMenuStrip);
 
-            CollectionAssert.Contains(
-                window.TabPageContextMenuStrip.Items
-                    .Cast<ToolStripMenuItem>()
-                    .Select(i => i.Text)
-                    .ToList(), 
-                "test-command");
+                CollectionAssert.Contains(
+                    window.TabPageContextMenuStrip.Items
+                        .Cast<ToolStripMenuItem>()
+                        .Select(i => i.Text)
+                        .ToList(),
+                    "test-command");
+            }
         }
 
         [Test]
@@ -94,13 +96,35 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views
                 s => CommandState.Enabled,
                 s => { });
 
-            var window = new SessionPane()
+            using (var window = new SessionPane()
             {
                 ContextCommands = commands
-            };
+            })
+            {
+                Assert.Throws<InvalidOperationException>(
+                    () => window.ContextCommands = commands);
+            }
+        }
 
-            Assert.Throws<InvalidOperationException>(
-                () => window.ContextCommands = commands);
+        [Test]
+        public void WhenContextCommandsSet_ThenDefaultCloseMenuIsReplaced()
+        {
+            using (var window = new SessionPane())
+            {
+                window.Show();
+
+                var commands = new CommandContainer<ISession>(
+                    ToolStripItemDisplayStyle.Text,
+                    new Mock<ICommandContextSource<ISession>>().Object);
+                commands.AddCommand(
+                    "test-command",
+                    s => CommandState.Enabled,
+                    s => { });
+                window.ContextCommands = commands;
+                Assert.IsFalse(window.ShowCloseMenuItemInContextMenu);
+
+                window.Close();
+            }
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/TestSessionPaneBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/TestSessionPaneBase.cs
@@ -75,12 +75,12 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views
             Assert.IsNotNull(window.ContextCommands);
             Assert.IsNotNull(window.TabPageContextMenuStrip);
 
-            var items = window.TabPageContextMenuStrip.Items
-                .Cast<ToolStripMenuItem>()
-                .Select(i => i.Text)
-                .ToList();
-
-            CollectionAssert.Contains(items, "test-command");
+            CollectionAssert.Contains(
+                window.TabPageContextMenuStrip.Items
+                    .Cast<ToolStripMenuItem>()
+                    .Select(i => i.Text)
+                    .ToList(), 
+                "test-command");
         }
 
         [Test]
@@ -93,7 +93,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views
                 "test-command",
                 s => CommandState.Enabled,
                 s => { });
-
 
             var window = new SessionPane()
             {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/TestSessionPaneBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/TestSessionPaneBase.cs
@@ -1,0 +1,107 @@
+﻿//
+// Copyright 2022 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.IapDesktop.Application.ObjectModel;
+using Google.Solutions.IapDesktop.Application.ObjectModel.Commands;
+using Google.Solutions.IapDesktop.Application.Services.Integration;
+using Google.Solutions.IapDesktop.Application.Services.Settings;
+using Google.Solutions.IapDesktop.Application.Views;
+using Google.Solutions.IapDesktop.Application.Views.Dialog;
+using Google.Solutions.IapDesktop.Extensions.Shell.Views;
+using Google.Solutions.Testing.Application.ObjectModel;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views
+{
+    [TestFixture]
+
+    [Apartment(ApartmentState.STA)]
+    public class TestSessionPaneBase : ShellFixtureBase
+    {
+        //---------------------------------------------------------------------
+        // Context menu.
+        //---------------------------------------------------------------------
+
+        private class SessionPane : SessionPaneBase
+        {
+            public SessionPane()
+            {
+            }
+        }
+
+        [Test]
+        public void WhenContextCommandsSet_ThenCommandsAreBoundToContextMenu()
+        {
+            var commands = new CommandContainer<ISession>(
+                ToolStripItemDisplayStyle.Text,
+                new Mock<ICommandContextSource<ISession>>().Object);
+            commands.AddCommand(
+                "test-command",
+                s => CommandState.Enabled,
+                s => { });
+
+
+            var window = new SessionPane()
+            {
+                ContextCommands = commands
+            };
+
+            Assert.IsNotNull(window.ContextCommands);
+            Assert.IsNotNull(window.TabPageContextMenuStrip);
+
+            var items = window.TabPageContextMenuStrip.Items
+                .Cast<ToolStripMenuItem>()
+                .Select(i => i.Text)
+                .ToList();
+
+            CollectionAssert.Contains(items, "test-command");
+        }
+
+        [Test]
+        public void WhenContextCommandsSet_ThenSettingCommandsAgainCausesException()
+        {
+            var commands = new CommandContainer<ISession>(
+                ToolStripItemDisplayStyle.Text,
+                new Mock<ICommandContextSource<ISession>>().Object);
+            commands.AddCommand(
+                "test-command",
+                s => CommandState.Enabled,
+                s => { });
+
+
+            var window = new SessionPane()
+            {
+                ContextCommands = commands
+            };
+
+            Assert.Throws<InvalidOperationException>(
+                () => window.ContextCommands = commands);
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Google.Solutions.IapDesktop.Extensions.Shell.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Google.Solutions.IapDesktop.Extensions.Shell.csproj
@@ -201,6 +201,7 @@
     <Compile Include="Views\RemoteDesktop\RemoteDesktopPane.Designer.cs">
       <DependentUpon>RemoteDesktopPane.cs</DependentUpon>
     </Compile>
+    <Compile Include="Views\SessionPaneBase.cs" />
     <Compile Include="Views\SshKeys\AuthorizedPublicKeysModel.cs" />
     <Compile Include="Views\SshKeys\AuthorizedPublicKeysViewModel.cs" />
     <Compile Include="Views\SshKeys\AuthorizedPublicKeysWindow.cs">

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ShellExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ShellExtension.cs
@@ -43,6 +43,7 @@ using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Google.Solutions.IapDesktop.Extensions.Shell.Views;
 
 namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
 {
@@ -54,6 +55,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
     {
         private readonly IServiceProvider serviceProvider;
         private readonly IWin32Window window;
+        private readonly ICommandContainer<ISession> sessionCommands;
 
         private static CommandState GetToolbarCommandStateWhenRunningInstanceRequired(
             IProjectModelNode node)
@@ -183,31 +185,47 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
         {
             try
             {
+                ISession session = null;
                 if (node is IProjectModelInstanceNode rdpNode && rdpNode.IsRdpSupported())
                 {
-                    await this.serviceProvider
+                    session = await this.serviceProvider
                         .GetService<IRdpConnectionService>()
                         .ActivateOrConnectInstanceAsync(
                             rdpNode,
                             allowPersistentCredentials)
                         .ConfigureAwait(true);
+
+                    Debug.Assert(session != null);
                 }
                 else if (node is IProjectModelInstanceNode sshNode && sshNode.IsSshSupported())
                 {
                     if (forceNewConnection)
                     {
-                        await this.serviceProvider
+                        session = await this.serviceProvider
                             .GetService<ISshConnectionService>()
                             .ConnectInstanceAsync(sshNode)
                             .ConfigureAwait(true);
                     }
                     else
                     {
-                        await this.serviceProvider
+                        session = await this.serviceProvider
                             .GetService<ISshConnectionService>()
                             .ActivateOrConnectInstanceAsync(sshNode)
                             .ConfigureAwait(true);
                     }
+
+                    Debug.Assert(session != null);
+                }
+
+                if (session is SessionPaneBase sessionPane)
+                {
+                    //
+                    // Use commands from Session menu as
+                    // context menu.
+                    //
+                    sessionPane.ContextCommands = this.sessionCommands;
+
+                    // TODO: Remove redundant commands.
                 }
             }
             catch (Exception e) when (e.IsCancellation())
@@ -400,13 +418,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
             //
             // On pop-up of the menu, query the active session and use it as context.
             //
-            var sessionMenu = mainForm.AddMenu(
+            this.sessionCommands = mainForm.AddMenu(
                 "&Session", 1,
                 () => this.serviceProvider
                     .GetService<IGlobalSessionBroker>()
                     .ActiveSession);
 
-            sessionMenu.AddCommand(
+            this.sessionCommands.AddCommand(
                 new Command<ISession>(
                     "&Full screen",
                     session => GetSessionMenuCommandState<IRemoteDesktopSession>(
@@ -417,7 +435,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
                     Image = Resources.Fullscreen_16,
                     ShortcutKeys = DocumentWindow.EnterFullScreenHotKey
                 });
-            sessionMenu.AddCommand(
+            this.sessionCommands.AddCommand(
                 new Command<ISession>(
                     "&Full screen (multiple displays)",
                     session => GetSessionMenuCommandState<IRemoteDesktopSession>(
@@ -428,7 +446,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
                     Image = Resources.Fullscreen_16,
                     ShortcutKeys = Keys.F11 | Keys.Shift
                 });
-            sessionMenu.AddCommand(
+            this.sessionCommands.AddCommand(
                 new Command<ISession>(
                     "&Disconnect",
                     session => GetSessionMenuCommandState<ISession>(
@@ -439,15 +457,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
                     Image = Resources.Disconnect_16,
                     ShortcutKeys = Keys.Control | Keys.F4
                 });
-            sessionMenu.AddSeparator();
-            sessionMenu.AddCommand(
+            this.sessionCommands.AddSeparator();
+            this.sessionCommands.AddCommand(
                 new Command<ISession>(
                     "Show &security screen (send Ctrl+Alt+Esc)",
                     session => GetSessionMenuCommandState<IRemoteDesktopSession>(
                         session,
                         rdpSession => rdpSession.IsConnected),
                     session => (session as IRemoteDesktopSession)?.ShowSecurityScreen()));
-            sessionMenu.AddCommand(
+            this.sessionCommands.AddCommand(
                 new Command<ISession>(
                     "Open &task manager (send Ctrl+Shift+Esc)",
                     session => GetSessionMenuCommandState<IRemoteDesktopSession>(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ShellExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ShellExtension.cs
@@ -224,8 +224,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
                     // context menu.
                     //
                     sessionPane.ContextCommands = this.sessionCommands;
-
-                    // TODO: Remove redundant commands.
                 }
             }
             catch (Exception e) when (e.IsCancellation())

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ShellExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ShellExtension.cs
@@ -217,7 +217,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
                     Debug.Assert(session != null);
                 }
 
-                if (session is SessionPaneBase sessionPane)
+                if (session is SessionPaneBase sessionPane && 
+                    sessionPane.ContextCommands == null)
                 {
                     //
                     // Use commands from Session menu as

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/RemoteDesktopPane.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/RemoteDesktopPane.cs
@@ -48,7 +48,7 @@ using System.Windows.Forms;
 namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.RemoteDesktop
 {
     [ComVisible(false)]
-    public partial class RemoteDesktopPane : DocumentWindow, IRemoteDesktopSession
+    public partial class RemoteDesktopPane : SessionPaneBase, IRemoteDesktopSession
     {
         private readonly IExceptionDialog exceptionDialog;
         private readonly IEventService eventService;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/RemoteDesktopPane.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/RemoteDesktopPane.cs
@@ -137,35 +137,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.RemoteDesktop
             this.exceptionDialog = serviceProvider.GetService<IExceptionDialog>();
             this.eventService = serviceProvider.GetService<IEventService>();
             this.Instance = vmInstance;
-
-            var singleScreenFullScreenMenuItem = new ToolStripMenuItem("&Full screen");
-            singleScreenFullScreenMenuItem.Click += (sender, _)
-                => TrySetFullscreen(FullScreenMode.SingleScreen);
-            this.TabPageContextMenuStrip.Items.Add(singleScreenFullScreenMenuItem);
-
-            var allScreensFullScreenMenuItem = new ToolStripMenuItem("&Full screen (multiple displays)");
-            allScreensFullScreenMenuItem.Click += (sender, _)
-                => TrySetFullscreen(FullScreenMode.AllScreens);
-            this.TabPageContextMenuStrip.Items.Add(allScreensFullScreenMenuItem);
-
-            this.TabPageContextMenuStrip.Opening += (sender, _) =>
-            {
-                foreach (var menuItem in this.TabPageContextMenuStrip.Items.Cast<ToolStripDropDownItem>())
-                {
-                    //
-                    // Disable all commands while connecting.
-                    //
-                    menuItem.Enabled = !this.IsConnecting;
-                }
-
-                //
-                // Disable full-screen if some other window is full-screen already.
-                //
-                singleScreenFullScreenMenuItem.Enabled &= this.CanEnterFullScreen;
-                allScreensFullScreenMenuItem.Enabled &= this.CanEnterFullScreen;
-            };
         }
-
 
         //---------------------------------------------------------------------
         // Publics.

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SessionPaneBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SessionPaneBase.cs
@@ -69,13 +69,14 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views
 
                 this.contextCommands = value;
                 this.contextCommands.BindTo(
-                    this.TabPageContextMenuStrip.Items,
+                    this.TabPageContextMenuStrip,
                     this.Container);
 
-                this.TabPageContextMenuStrip.Opening += (sender, args) =>
-                {
-                    this.contextCommands.ForceRefresh(); // TODO: Move to BindTo
-                };
+                //
+                // Hide the Close menu item since it's most
+                // likely redundant now.
+                //
+                this.ShowCloseMenuItemInContextMenu = false;
             }
         }
     }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SessionPaneBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SessionPaneBase.cs
@@ -67,10 +67,21 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views
                         "Context commands have already been set");
                 }
 
-                this.contextCommands = value;
-                this.contextCommands.BindTo(
-                    this.TabPageContextMenuStrip,
-                    this.Container);
+                if (this.TabPageContextMenuStrip == null)
+                {
+                    //
+                    // There's a rare chance that the context menu is
+                    // null because the window is being closed. In that
+                    // case, do nothing.
+                    //
+                }
+                else
+                {
+                    this.contextCommands = value;
+                    this.contextCommands.BindTo(
+                        this.TabPageContextMenuStrip,
+                        this.Container);
+                }
 
                 //
                 // Hide the Close menu item since it's most

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SessionPaneBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SessionPaneBase.cs
@@ -71,6 +71,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views
                 this.contextCommands.BindTo(
                     this.TabPageContextMenuStrip.Items,
                     this.Container);
+
+                this.TabPageContextMenuStrip.Opening += (sender, args) =>
+                {
+                    this.contextCommands.ForceRefresh(); // TODO: Move to BindTo
+                };
             }
         }
     }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SessionPaneBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SessionPaneBase.cs
@@ -1,0 +1,77 @@
+﻿//
+// Copyright 2022 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.IapDesktop.Application.ObjectModel.Commands;
+using Google.Solutions.IapDesktop.Application.Services.Integration;
+using Google.Solutions.IapDesktop.Application.Views;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.IapDesktop.Extensions.Shell.Views
+{
+    /// <summary>
+    /// Base class for sessions.
+    /// </summary>
+    public class SessionPaneBase : DocumentWindow
+    {
+        private ICommandContainer<ISession> contextCommands;
+
+        protected SessionPaneBase()
+        {
+            // Constructor is for designer only.
+        }
+
+        protected SessionPaneBase(IServiceProvider serviceProvider)
+            : base(serviceProvider)
+        {
+        }
+
+        //---------------------------------------------------------------------
+        // Context menu.
+        //---------------------------------------------------------------------
+
+        public ICommandContainer<ISession> ContextCommands
+        {
+            get => this.contextCommands;
+            set
+            {
+                if (this.contextCommands != null)
+                {
+                    //
+                    // Don't allow binding multiple command containers to
+                    // the smae menu (or binding the same container multiple
+                    // times) as that leads to duplication.
+                    //
+                    throw new InvalidOperationException(
+                        "Context commands have already been set");
+                }
+
+                this.contextCommands = value;
+                this.contextCommands.BindTo(
+                    this.TabPageContextMenuStrip.Items,
+                    this.Container);
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/TerminalPaneBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/TerminalPaneBase.cs
@@ -44,7 +44,7 @@ using WeifenLuo.WinFormsUI.Docking;
 
 namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
 {
-    public partial class TerminalPaneBase : DocumentWindow
+    public partial class TerminalPaneBase : SessionPaneBase
     {
         private readonly IExceptionDialog exceptionDialog;
 

--- a/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
+++ b/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
@@ -63,8 +63,8 @@ namespace Google.Solutions.IapDesktop.Windows
         private readonly IServiceProvider serviceProvider;
         private IIapUrlHandler urlHandler;
 
-        private readonly CommandContextSource<IMainForm> viewMenuContextSource;
-        private readonly CommandContextSource<ToolWindow> windowMenuContextSource;
+        private readonly ObservableCommandContextSource<IMainForm> viewMenuContextSource;
+        private readonly ObservableCommandContextSource<ToolWindow> windowMenuContextSource;
 
         private readonly CommandContainer<IMainForm> viewMenuCommands;
         private readonly CommandContainer<ToolWindow> windowMenuCommands;
@@ -117,7 +117,7 @@ namespace Google.Solutions.IapDesktop.Windows
             //
             // View menu.
             //
-            this.viewMenuContextSource = new CommandContextSource<IMainForm>()
+            this.viewMenuContextSource = new ObservableCommandContextSource<IMainForm>()
             {
                 Context = this // Pseudo-context, never changes
             };
@@ -126,12 +126,12 @@ namespace Google.Solutions.IapDesktop.Windows
                 ToolStripItemDisplayStyle.ImageAndText,
                 this.viewMenuContextSource);
             this.viewMenuCommands.CommandFailed += CommandContainer_CommandFailed;
-            this.viewMenuCommands.BindTo(this.viewToolStripMenuItem.DropDownItems);
+            this.viewMenuCommands.BindTo(this.viewToolStripMenuItem, this.Container);
 
             //
             // Window menu.
             //
-            this.windowMenuContextSource = new CommandContextSource<ToolWindow>();
+            this.windowMenuContextSource = new ObservableCommandContextSource<ToolWindow>();
 
             this.windowToolStripMenuItem.DropDownOpening += (sender, args) =>
             {
@@ -155,7 +155,7 @@ namespace Google.Solutions.IapDesktop.Windows
                 ToolStripItemDisplayStyle.ImageAndText,
                 this.windowMenuContextSource);
             this.windowMenuCommands.CommandFailed += CommandContainer_CommandFailed;
-            this.windowMenuCommands.BindTo(this.windowToolStripMenuItem.DropDownItems);
+            this.windowMenuCommands.BindTo(this.windowToolStripMenuItem, this.Container);
 
             //
             // Bind controls.
@@ -667,7 +667,7 @@ namespace Google.Solutions.IapDesktop.Windows
                 ToolStripItemDisplayStyle.ImageAndText,
                 new CallbackSource<TContext>(queryCurrentContextFunc));
             container.CommandFailed += CommandContainer_CommandFailed;
-            container.BindTo(menu.DropDownItems);
+            container.BindTo(menu, this.Container);
 
             menu.DropDownOpening += (sender, args) =>
             {
@@ -679,19 +679,6 @@ namespace Google.Solutions.IapDesktop.Windows
             };
 
             return container;
-        }
-
-        private class CallbackSource<TContext> : ICommandContextSource<TContext> // TODO: Move elsewhere
-        {
-            private readonly Func<TContext> queryCurrentContextFunc;
-
-            public CallbackSource(Func<TContext> queryCurrentContextFunc)
-            {
-                this.queryCurrentContextFunc = queryCurrentContextFunc;
-            }
-
-            public event PropertyChangedEventHandler PropertyChanged;
-            public TContext Context => this.queryCurrentContextFunc();
         }
 
         public void Minimize()
@@ -951,5 +938,21 @@ namespace Google.Solutions.IapDesktop.Windows
         public Task ReauthorizeAsync(CancellationToken token)
             => this.viewModel.ReauthorizeAsync(token);
 
+
+        //---------------------------------------------------------------------
+        // Helper classes.
+        //---------------------------------------------------------------------
+        
+        private class CallbackSource<TContext> : ICommandContextSource<TContext>
+        {
+            private readonly Func<TContext> queryCurrentContextFunc;
+
+            public CallbackSource(Func<TContext> queryCurrentContextFunc)
+            {
+                this.queryCurrentContextFunc = queryCurrentContextFunc;
+            }
+
+            public TContext Context => this.queryCurrentContextFunc();
+        }
     }
 }


### PR DESCRIPTION
* Change XxxConnectionService to return session objects
* Use the same command set for the Session (main) menu and the
  tab context menu
* Hide default 'Close' menu item when custom context commands set