### PR TITLE
Unwrap nested AggregateExceptions, InvocationTargetExceptions

### DIFF
--- a/sources/Google.Solutions.Common.Test/Util/TestExceptionExtensions.cs
+++ b/sources/Google.Solutions.Common.Test/Util/TestExceptionExtensions.cs
@@ -29,8 +29,12 @@ namespace Google.Solutions.Common.Test.Util
     [TestFixture]
     public class TestExceptionExtensions : CommonFixtureBase
     {
+        //---------------------------------------------------------------------
+        // Unwrap.
+        //---------------------------------------------------------------------
+
         [Test]
-        public void WhenRegularException_UnwrapDoesNothing()
+        public void WhenRegularException_ThenUnwrapDoesNothing()
         {
             var ex = new ApplicationException();
 
@@ -40,7 +44,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void WhenAggregateException_UnwrapReturnsFirstInnerException()
+        public void WhenAggregateException_ThenUnwrapReturnsFirstInnerException()
         {
             var inner1 = new ApplicationException();
             var inner2 = new ApplicationException();
@@ -52,7 +56,30 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void WhenTargetInvocationException_UnwrapReturnsInnerException()
+        public void WhenAggregateExceptionContainsAggregateException_ThenUnwrapReturnsFirstInnerException()
+        {
+            var inner1 = new ApplicationException();
+            var inner2 = new ApplicationException();
+            var aggregate = new AggregateException(
+                new AggregateException(
+                    new TargetInvocationException(inner1)), inner2);
+
+            var unwrapped = aggregate.Unwrap();
+
+            Assert.AreSame(inner1, unwrapped);
+        }
+
+        [Test]
+        public void WhenAggregateExceptionWithoutInnerException_ThenUnwrapDoesNothing()
+        {
+            var aggregate = new AggregateException();
+            var unwrapped = aggregate.Unwrap();
+
+            Assert.AreSame(aggregate, unwrapped);
+        }
+
+        [Test]
+        public void WhenTargetInvocationException_ThenUnwrapReturnsInnerException()
         {
             var inner = new ApplicationException();
             var target = new TargetInvocationException("", inner);
@@ -61,6 +88,10 @@ namespace Google.Solutions.Common.Test.Util
 
             Assert.AreSame(inner, unwrapped);
         }
+
+        //---------------------------------------------------------------------
+        // FillMessage.
+        //---------------------------------------------------------------------
 
         [Test]
         public void WhenExceptionHasNoInnerException_ThenFullMessageIsSameAsMessage()

--- a/sources/Google.Solutions.Common/Util/ExceptionExtensions.cs
+++ b/sources/Google.Solutions.Common/Util/ExceptionExtensions.cs
@@ -31,17 +31,20 @@ namespace Google.Solutions.Common.Util
     {
         public static Exception Unwrap(this Exception e)
         {
-            if (e is AggregateException aggregate)
+            if (e is AggregateException aggregate &&
+                aggregate.InnerException != null)
             {
-                e = aggregate.InnerException;
+                return aggregate.InnerException.Unwrap();
             }
-
-            if (e is TargetInvocationException target)
+            else if (e is TargetInvocationException target &&
+                target.InnerException != null)
             {
-                e = target.InnerException;
+                return target.InnerException.Unwrap();
             }
-
-            return e;
+            else
+            {
+                return e;
+            }
         }
 
         public static bool Is<T>(this Exception e) where T : Exception


### PR DESCRIPTION
Unwrap nested exceptions to avoid showing error messages like
"One or more errors have occured".