### PR TITLE
b/249433546 Trim host name, URL for proxy settings

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Views/Options/TestNetworkOptionsViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Views/Options/TestNetworkOptionsViewModel.cs
@@ -518,11 +518,10 @@ namespace Google.Solutions.IapDesktop.Application.Test.Views.Options
                 settingsRepository,
                 this.proxyAdapterMock.Object)
             {
-
                 // Enable proxy with authentication.
                 IsCustomProxyServerEnabled = true,
-                ProxyServer = "prx",
-                ProxyPort = "123",
+                ProxyServer = " prx ", // Spaces should be ignored.
+                ProxyPort = " 123 ",   // Spaces should be ignored.
                 ProxyUsername = "user",
                 ProxyPassword = "pass"
             };
@@ -561,10 +560,9 @@ namespace Google.Solutions.IapDesktop.Application.Test.Views.Options
                 settingsRepository,
                 this.proxyAdapterMock.Object)
             {
-
                 // Enable proxy with authentication.
                 IsProxyAutoConfigurationEnabled = true,
-                ProxyAutoconfigurationAddress = "https://www/proxy.pac",
+                ProxyAutoconfigurationAddress = " https://www/proxy.pac ", // Spaces should be ignored.
                 ProxyUsername = "user",
                 ProxyPassword = "pass"
             };

--- a/sources/Google.Solutions.IapDesktop.Application/Views/Options/NetworkOptionsViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/Options/NetworkOptionsViewModel.cs
@@ -111,32 +111,32 @@ namespace Google.Solutions.IapDesktop.Application.Views.Options
             switch (this.Proxy)
             {
                 case ProxyType.Custom:
-                    if (!IsValidProxyHost(this.proxyServer))
+                    if (!IsValidProxyHost(this.proxyServer?.Trim()))
                     {
                         throw new ArgumentException(
                             $"'{this.proxyServer}' is not a valid host name");
                     }
 
-                    if (!IsValidProxyPort(this.proxyPort))
+                    if (!IsValidProxyPort(this.proxyPort?.Trim()))
                     {
                         throw new ArgumentException(
                             $"'{this.proxyPort}' is not a valid port number");
                     }
 
-                    settings.ProxyUrl.StringValue = $"http://{this.proxyServer}:{this.proxyPort}";
+                    settings.ProxyUrl.StringValue = $"http://{this.proxyServer?.Trim()}:{this.proxyPort?.Trim()}";
                     settings.ProxyPacUrl.Reset();
                     break;
 
                 case ProxyType.Autoconfig:
 
-                    if (!IsValidProxyAutoConfigurationAddress(this.proxyPacAddress))
+                    if (!IsValidProxyAutoConfigurationAddress(this.proxyPacAddress?.Trim()))
                     {
                         throw new ArgumentException(
-                            $"'{this.proxyPacAddress}' is not a valid proxy autoconfiguration URL");
+                            $"'{this.proxyPacAddress?.Trim()}' is not a valid proxy autoconfiguration URL");
                     }
 
                     settings.ProxyUrl.Reset();
-                    settings.ProxyPacUrl.StringValue = this.proxyPacAddress;
+                    settings.ProxyPacUrl.StringValue = this.proxyPacAddress?.Trim();
                     break;
 
                 case ProxyType.System:


### PR DESCRIPTION
Trim whitespace from host name and URL before applying changes so that accidentally copied whitespace doesn't cause issues.