### PR TITLE
b/248087823 Avoid resizing virtual terminal when window minimized

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminal.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminal.cs
@@ -249,6 +249,16 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
 
         protected override void OnLayout(LayoutEventArgs e)
         {
+            if (this.Width == 0 && this.Height == 0)
+            {
+                //
+                // Window is probably being minimized. Don't layout
+                // and don't update dimensions as that might screw up
+                // the screen buffer.
+                //
+                return;
+            }
+
             UpdateDimensions();
             base.OnLayout(e);
         }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/TerminalPaneViewModelBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/TerminalPaneViewModelBase.cs
@@ -20,6 +20,7 @@
 //
 
 using Google.Solutions.Common.Locator;
+using Google.Solutions.IapDesktop.Application;
 using Google.Solutions.IapDesktop.Application.Services.Integration;
 using Google.Solutions.Mvvm.Binding;
 using Google.Solutions.Mvvm.Controls;


### PR DESCRIPTION
Avoid resizing the virtual terminal when the window size changes to (0,0). This ensures that the terminal buffer is properly maintained when the window is later restored/maximized.