### PR TITLE
b/248097454 Improve error when SSH authentication fails

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshTerminalPane.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshTerminalPane.cs
@@ -255,10 +255,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
                     TimeSpan.FromSeconds(10)))
                 .ConfigureAwait(true);
 
-            Assert.IsInstanceOf(typeof(SshNativeException), this.ExceptionShown);
-            Assert.AreEqual(
-                LIBSSH2_ERROR.AUTHENTICATION_FAILED,
-                ((SshNativeException)this.ExceptionShown).ErrorCode);
+            Assert.IsInstanceOf(typeof(MetadataKeyAuthenticationFailedException), this.ExceptionShown);
 
             await CompleteBackgroundWorkAsync().ConfigureAwait(true);
         }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshTerminalPaneViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshTerminalPaneViewModel.cs
@@ -345,7 +345,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
                     .ConnectAsync(new TerminalSize(80, 24))
                     .ConfigureAwait(true);
 
-                Assert.IsInstanceOf<SshNativeException>(argsReceived.Error);
+                Assert.IsInstanceOf<MetadataKeyAuthenticationFailedException>(argsReceived.Error);
                 eventService.Verify(s => s.FireAsync(
                     It.IsAny<SessionAbortedEvent>()), Times.Once());
 


### PR DESCRIPTION
Extend error message to indicate that the authentication error might be caused by rsa-ssh being disallowed. Only show the extended error messagen when the user is actually using RSA.