### PR TITLE
b/249900045 Ignore non-profile keys when listing profiles

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Host/TestProfile.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Host/TestProfile.cs
@@ -21,8 +21,10 @@
 
 using Google.Solutions.IapDesktop.Application.Host;
 using Google.Solutions.Testing.Application.Test;
+using Microsoft.Win32;
 using NUnit.Framework;
 using System;
+using System.Linq;
 
 namespace Google.Solutions.IapDesktop.Application.Test.Host
 {
@@ -198,6 +200,23 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
 
             Assert.IsNotNull(list);
             CollectionAssert.Contains(list, "Default");
+        }
+
+        [Test]
+        public void WhenNonProfileKeysPresent_ThenListProfilesIgnoresKeys()
+        {
+            using (var hive = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default))
+            {
+                hive.CreateSubKey($"{Profile.ProfilesKeyPath}\\________Notaprofile", true);
+            }
+
+            using (Profile.OpenProfile(null))
+            { }
+
+            var list = Profile.ListProfiles();
+
+            Assert.IsNotNull(list);
+            Assert.IsFalse(list.Any(p => p.EndsWith("Notaprofile", StringComparison.OrdinalIgnoreCase)));
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Application/Host/Profile.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Host/Profile.cs
@@ -51,7 +51,7 @@ namespace Google.Solutions.IapDesktop.Application.Host
         /// <summary>
         /// Path containing profiles.
         /// </summary>
-        private const string ProfilesKeyPath = @"Software\Google\IapDesktop";
+        internal const string ProfilesKeyPath = @"Software\Google\IapDesktop";
 
         /// <summary>
         /// Path to policies. This path is independent of the profile.
@@ -205,6 +205,7 @@ namespace Google.Solutions.IapDesktop.Application.Host
                 {
                     return profiles.GetSubKeyNames()
                         .EnsureNotNull()
+                        .Where(n => n == DefaultProfileKey || n.StartsWith(ProfileKeyPrefix))
                         .Select(n => n == DefaultProfileKey
                             ? DefaultProfileName
                             : n.Substring(ProfileKeyPrefix.Length));


### PR DESCRIPTION
Check prefix of key name to ignore other keys, including the "Installer" key created by the installer package.