### PR TITLE
b/244787438 Increase time between update checks

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Services/UpdateService.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/UpdateService.cs
@@ -53,7 +53,7 @@ namespace Google.Solutions.IapDesktop.Application.Services
         /// Determines how often update checks are performed. 
         /// A higher number implies a slower pace of updates.
         /// </summary>
-        public const int DaysBetweenUpdateChecks = 7;
+        public const int DaysBetweenUpdateChecks = 10;
 
         private readonly IGithubAdapter githubAdapter;
         private readonly ITaskDialog taskDialog;


### PR DESCRIPTION
Check every 10 (instead of 7) days to pace update rollouts.