### PR TITLE
b/253120524 Use NuGet package source mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -275,3 +275,4 @@ source/sponge_log.xml
 .tools/
 opencovertests.xml
 sponge_log.xml
+NuGet.config


### PR DESCRIPTION
Auto-generate nuget.config and configure source
mappings so that packages from the local dependency 
feed are always preferred over nuget.org packages.