### PR TITLE
b/253777656 Fix line endings when pasting text

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminal.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Controls/TestVirtualTerminal.cs
@@ -112,7 +112,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
 
             this.terminal.PasteClipboard();
 
-            Assert.AreEqual("sample\ntext", this.sendData.ToString());
+            Assert.AreEqual("sample\rtext", this.sendData.ToString());
         }
 
         [Test]
@@ -145,7 +145,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableCtrlV = true;
             this.terminal.SimulateKey(Keys.Control | Keys.V);
 
-            Assert.AreEqual("sample\ntext", this.sendData.ToString());
+            Assert.AreEqual("sample\rtext", this.sendData.ToString());
         }
 
         [Test]
@@ -171,7 +171,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Controls
             this.terminal.EnableShiftInsert = true;
             this.terminal.SimulateKey(Keys.Shift | Keys.Insert);
 
-            Assert.AreEqual("sample\ntext", this.sendData.ToString());
+            Assert.AreEqual("sample\rtext", this.sendData.ToString());
         }
 
         [Test]

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminal.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Controls/VirtualTerminal.cs
@@ -598,20 +598,25 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Controls
             if (!string.IsNullOrEmpty(text))
             {
                 //
-                // Convert to Unix line endings, otherwise pasting a multi-
-                // line command will be interpreted as a sequence of
-                // commands.
+                // Avoid pasting CRLF line endings as causes line
+                // endings to be duplicated.
                 //
-                text = text.Replace("\r\n", "\n");
+                // Converting CRLF => NL works for most applications,
+                // but not for older versions of nano. The correct
+                // behavior is to only send a CR.
+                //
+                text = text.Replace("\r\n", "\r");
 
                 if (this.EnableTypographicQuoteConversionOnPaste)
                 {
+                    //
                     // Copied code snippets might contain typographic 
                     // quotes (thanks to Word and Docs) - convert them
                     // to plain ASCII single/double quotes.
+                    //
                     text = TypographicQuotes.ToAsciiQuotes(text);
                 }
-
+                
                 this.controller.Paste(Encoding.UTF8.GetBytes(text));
             }
         }


### PR DESCRIPTION
CRLF line endings were previously converted to NL. That works in most terminals and editors (incl. vim), not in others (like older nano versions).

Convert line endings to CR instead to comply with
how other terminals behave and to be compatible with nano.