### PR TITLE
b/257378836 Handle Win32-incompliant filenames

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Google.Solutions.IapDesktop.Application.Test.csproj
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Google.Solutions.IapDesktop.Application.Test.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Services\SecureConnect\TestSecureConnectEnrollment.cs" />
     <Compile Include="Services\Integration\TestJobService.cs" />
     <Compile Include="ObjectModel\TestServiceRegistry.cs" />
+    <Compile Include="Util\TestFilename.cs" />
     <Compile Include="Util\TestIapRdpUrl.cs" />
     <Compile Include="Util\TestStringExtensions.cs" />
     <Compile Include="Util\TestTypographicQuotes.cs" />

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Util/TestFilename.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Util/TestFilename.cs
@@ -1,0 +1,105 @@
+﻿//
+// Copyright 2022 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.IapDesktop.Application.Util;
+using NUnit.Framework;
+
+namespace Google.Solutions.IapDesktop.Application.Test.Util
+{
+    [TestFixture]
+    public class TestFilename
+    {
+        //---------------------------------------------------------------------
+        // StripExtension.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenFileHasExtension_ThenStripExtensionRemovesExtension()
+        {
+            Assert.AreEqual("file", Filename.StripExtension("file.txt"));
+            Assert.AreEqual(".txt", Filename.StripExtension(".txt.tmp"));
+            Assert.AreEqual("file.txt", Filename.StripExtension("file.txt.tmp"));
+        }
+
+        [Test]
+        public void WhenFileHasNoExtension_ThenStripExtensionRetainsName()
+        {
+            Assert.AreEqual(".file", Filename.StripExtension(".file"));
+            Assert.AreEqual("file", Filename.StripExtension("file"));
+        }
+
+        //---------------------------------------------------------------------
+        // IsValidFilename.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenFilenameIsDosDevice_ThenIsValidFilenameReturnsFalse(
+            [Values("con", "Prn", "AUX", "NUL", "COM1", "COM9", "LPT1", "lpt9.txt")] string name)
+        {
+            Assert.IsFalse(Filename.IsValidFilename(name));
+        }
+
+        [Test]
+        public void WhenFilenameContainsInvalidCharacters_ThenIsValidFilenameReturnsFalse(
+            [Values("f<.txt", ":.txt", "\"file\".txt", "\\f", "?.txt", "*.*")] string name)
+        {
+            Assert.IsFalse(Filename.IsValidFilename(name));
+        }
+
+        [Test]
+        public void WhenFilenameHasTrailingDot_ThenIsValidFilenameReturnsFalse(
+            [Values("file.txt.")] string name)
+        {
+            Assert.IsFalse(Filename.IsValidFilename(name));
+        }
+
+        [Test]
+        public void WhenFilenameIsWin32Compliant_ThenIsValidFilenameReturnsTrue(
+            [Values(".file.txt", "f", "null.txt")] string name)
+        {
+            Assert.IsTrue(Filename.IsValidFilename(name));
+        }
+
+        //---------------------------------------------------------------------
+        // EscapeFilename.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenFilenameIsWin32Compliant_ThenEscapeFilenameRetainsName()
+        {
+            Assert.AreEqual("File.txt", Filename.EscapeFilename("File.txt"));
+            Assert.AreEqual("File with spaces", Filename.EscapeFilename("File with spaces"));
+            Assert.AreEqual(".dotfile", Filename.EscapeFilename(".dotfile"));
+            Assert.AreEqual("NULl.AUX", Filename.EscapeFilename("NULl.AUX"));
+        }
+
+        [Test]
+        public void WhenFilenameNotWin32Compliant_ThenEscapeFilenameReturnsCompliantName()
+        {
+            Assert.IsTrue(Filename.IsValidFilename(Filename.EscapeFilename(".")));
+            Assert.IsTrue(Filename.IsValidFilename(Filename.EscapeFilename("file.")));
+            Assert.IsTrue(Filename.IsValidFilename(Filename.EscapeFilename("NUL")));
+            Assert.IsTrue(Filename.IsValidFilename(Filename.EscapeFilename("NUL.")));
+            Assert.IsTrue(Filename.IsValidFilename(Filename.EscapeFilename("AUX.txt")));
+            Assert.IsTrue(Filename.IsValidFilename(Filename.EscapeFilename("\"file\"")));
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
+++ b/sources/Google.Solutions.IapDesktop.Application/Google.Solutions.IapDesktop.Application.csproj
@@ -153,6 +153,7 @@
     <Compile Include="Data\IHelpTopic.cs" />
     <Compile Include="Util\StringExtensions.cs" />
     <Compile Include="Util\TypographicQuotes.cs" />
+    <Compile Include="Util\Filename.cs" />
     <Compile Include="Util\WindowMessage.cs" />
     <Compile Include="Views\Authorization\DeviceFlyoutViewModel.cs" />
     <Compile Include="Views\Authorization\NewProfileDialog.cs">

--- a/sources/Google.Solutions.IapDesktop.Application/Util/Filename.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Util/Filename.cs
@@ -1,0 +1,93 @@
+﻿//
+// Copyright 2022 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System.IO;
+using System.Linq;
+
+namespace Google.Solutions.IapDesktop.Application.Util
+{
+    public static class Filename
+    {
+        private static readonly string[] DosDevices =
+        {
+            "CON", "PRN", "AUX", "NUL", 
+            "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", 
+            "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9"
+        };
+
+        internal static string StripExtension(string name)
+        {
+            var dotIndex = name.LastIndexOf('.');
+            return dotIndex <= 0
+                ? name
+                : name.Substring(0, dotIndex);
+        }
+
+        /// <summary>
+        /// Check if a file name is a valid Windows file name.
+        /// </summary>
+        public static bool IsValidFilename(string name)
+        {
+            //
+            // Cf. https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+            //
+            if (name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            {
+                return false;
+            }
+            else if (DosDevices.Any(n => n == StripExtension(name).ToUpper()))
+            {
+                return false;
+            }
+            else if (name.EndsWith("."))
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        /// <summary>
+        /// Escape a file name so that it becomes a valid Windows file name.
+        /// </summary>
+        public static string EscapeFilename(string name)
+        {
+            if (DosDevices.Any(n => n == StripExtension(name).ToUpper()))
+            {
+                name = "_" + name;
+            }
+            
+            if (name.EndsWith("."))
+            {
+                name = name + "_";
+            }
+
+            foreach (var c in Path.GetInvalidFileNameChars())
+            {
+                name = name.Replace(c, '_');
+            }
+
+            return name;
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSftpFileSystem.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSftpFileSystem.cs
@@ -208,7 +208,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
         }
 
         [Test]
-        public void WheFileIsConfigFile_ThenFileTypeIsIsSpecial()
+        public void WheFileIsConfigFile_ThenFileTypeIsSpecial()
         {
             using (var fs = CreateFileSystem())
             {
@@ -237,6 +237,26 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
                         FilePermissions.Directory));
 
                 Assert.IsTrue(!dirType.IsFile);
+            }
+        }
+
+        [Test]
+        public void WheFileNameContainsInvalidCharacters_ThenFileTypeIsPlain(
+            [Values("file?", "<file", "COM1", "file.")] string fileName)
+        {
+            using (var fs = CreateFileSystem())
+            {
+                var regularType = fs.TranslateFileType(
+                    CreateFile(
+                        fileName,
+                        FilePermissions.OtherRead));
+                var iniType = fs.TranslateFileType(
+                    CreateFile(
+                        "file",
+                        FilePermissions.OtherRead | FilePermissions.OwnerExecute));
+
+                Assert.IsTrue(iniType.IsFile);
+                Assert.AreNotEqual(regularType.TypeName, iniType.TypeName);
             }
         }
     }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SftpFileSystem.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SftpFileSystem.cs
@@ -20,6 +20,7 @@
 //
 
 using Google.Apis.Util;
+using Google.Solutions.IapDesktop.Application.Util;
 using Google.Solutions.Mvvm.Controls;
 using Google.Solutions.Mvvm.Shell;
 using Google.Solutions.Ssh;
@@ -90,8 +91,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
             }
             else
             {
+                //
+                // Lookup file type using Shell.
+                //
                 return this.fileTypeCache.Lookup(
-                    sftpFile.Name,
+                    Filename.IsValidFilename(sftpFile.Name) ? sftpFile.Name : "file",
                     FileAttributes.Normal,
                     FileType.IconFlags.None);
             }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshTerminalPaneViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshTerminal/SshTerminalPaneViewModel.cs
@@ -417,7 +417,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal
                         {
                             foreach (var file in selectedFiles)
                             {
-                                var targetFile = new FileInfo(Path.Combine(targetDirectory.FullName, file.Name));
+                                //
+                                // NB. The remote file name might not be Win32-compliant,
+                                // so we need to escape it.
+                                //
+                                var targetFile = new FileInfo(Path.Combine(
+                                    targetDirectory.FullName, 
+                                    Filename.EscapeFilename(file.Name)));
                                 using (var fileStream = targetFile.OpenWrite())
                                 {
                                     await fsChannel.DownloadFileAsync(


### PR DESCRIPTION
* Avoid passing incompliant filenames to Shell API
* Use escaped filename for creating local file

Addresses #828