### PR TITLE
b/263355375 Use pooled connections for API requests

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/ObjectModel/TestServiceAttribute.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/ObjectModel/TestServiceAttribute.cs
@@ -45,6 +45,60 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel
         {
         }
 
+        [Service(ServiceLifetime.Singleton)]
+        public class CounterService
+        {
+            public uint SingletonWithoutDelayCreationAttributeCount = 0;
+            public uint SingletonWithDelayCreationAttributeCount = 0;
+        }
+
+        [Service(ServiceLifetime.Singleton)]
+        public class SingletonWithoutDelayCreationAttribute 
+        {
+            public SingletonWithoutDelayCreationAttribute(CounterService counter)
+            {
+                counter.SingletonWithoutDelayCreationAttributeCount++;
+            }
+        }
+
+        [Service(ServiceLifetime.Singleton, DelayCreation=false)]
+        public class SingletonWithDelayCreationAttribute
+        {
+            public SingletonWithDelayCreationAttribute(CounterService counter)
+            {
+                counter.SingletonWithDelayCreationAttributeCount++;
+            }
+        }
+
+        [Test]
+        public void WhenDelayCreationNotSet_ThenServiceIsCreatedLazily()
+        {
+            var registry = new ServiceRegistry();
+            registry.AddExtensionAssembly(Assembly.GetExecutingAssembly());
+
+            Assert.AreEqual(
+                0, 
+                registry.GetService<CounterService>().SingletonWithoutDelayCreationAttributeCount);
+
+            registry.GetService<SingletonWithoutDelayCreationAttribute>();
+            registry.GetService<SingletonWithoutDelayCreationAttribute>();
+
+            Assert.AreEqual(
+                1,
+                registry.GetService<CounterService>().SingletonWithoutDelayCreationAttributeCount);
+        }
+
+        [Test]
+        public void WhenDelayCreationIsFalse_ThenServiceIsCreatedEagerly()
+        {
+            var registry = new ServiceRegistry();
+            registry.AddExtensionAssembly(Assembly.GetExecutingAssembly());
+
+            Assert.AreEqual(
+                1,
+                registry.GetService<CounterService>().SingletonWithDelayCreationAttributeCount);
+        }
+
         [Test]
         public void WhenClassAnnotatedAsSingletonServiceWithInterface_ThenServiceIsRegistered()
         {

--- a/sources/Google.Solutions.IapDesktop.Application.Test/ObjectModel/TestServiceRegistry.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/ObjectModel/TestServiceRegistry.cs
@@ -216,9 +216,10 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel
         public void WhenSingletonServiceOnlyHasRecursiveConstructor_ThenAddSingletonThrowsException()
         {
             var registry = new ServiceRegistry();
+            registry.AddSingleton<ServiceWithRecursiveConstructor>();
 
             Assert.Throws<UnknownServiceException>(
-                () => registry.AddSingleton<ServiceWithRecursiveConstructor>());
+                () => registry.GetService<ServiceWithRecursiveConstructor>());
         }
 
         [Test]

--- a/sources/Google.Solutions.IapDesktop.Application.Test/ObjectModel/TestServiceRegistry.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/ObjectModel/TestServiceRegistry.cs
@@ -156,8 +156,8 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel
 
             var service = registry.GetService<Service<ServiceWithDefaultConstructor>>();
             Assert.IsNotNull(service);
-            Assert.IsNotNull(service.CreateInstance());
-            Assert.AreNotSame(service.CreateInstance(), service.CreateInstance());
+            Assert.IsNotNull(service.GetInstance());
+            Assert.AreNotSame(service.GetInstance(), service.GetInstance());
         }
 
         [Test]
@@ -168,8 +168,8 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel
 
             var service = registry.GetService<Service<ServiceWithDefaultConstructor>>();
             Assert.IsNotNull(service);
-            Assert.IsNotNull(service.CreateInstance());
-            Assert.AreSame(service.CreateInstance(), service.CreateInstance());
+            Assert.IsNotNull(service.GetInstance());
+            Assert.AreSame(service.GetInstance(), service.GetInstance());
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestResourceManagerAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestResourceManagerAdapter.cs
@@ -40,16 +40,14 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         public async Task WhenUserInRole_ThenIsGrantedPermissionReturnsTrue(
             [Credential(Role = PredefinedRole.ComputeViewer)] ResourceTask<ICredential> credential)
         {
-            using (var adapter = new ResourceManagerAdapter(await credential))
-            {
-                var result = await adapter.IsGrantedPermissionAsync(
-                        TestProject.ProjectId,
-                        Permissions.ComputeInstancesGet,
-                        CancellationToken.None)
-                    .ConfigureAwait(false);
+            var adapter = new ResourceManagerAdapter(await credential);
+            var result = await adapter.IsGrantedPermissionAsync(
+                    TestProject.ProjectId,
+                    Permissions.ComputeInstancesGet,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
 
-                Assert.IsTrue(result);
-            }
+            Assert.IsTrue(result);
         }
 
         //---------------------------------------------------------------------
@@ -60,16 +58,14 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         public async Task WhenUserNotInRole_ThenIsGrantedPermissionReturnsFalse(
             [Credential(Role = PredefinedRole.ComputeViewer)] ResourceTask<ICredential> credential)
         {
-            using (var adapter = new ResourceManagerAdapter(await credential))
-            {
-                var result = await adapter.IsGrantedPermissionAsync(
-                        TestProject.ProjectId,
-                        "compute.disks.create",
-                        CancellationToken.None)
-                    .ConfigureAwait(false);
+            var adapter = new ResourceManagerAdapter(await credential);
+            var result = await adapter.IsGrantedPermissionAsync(
+                    TestProject.ProjectId,
+                    "compute.disks.create",
+                    CancellationToken.None)
+                .ConfigureAwait(false);
 
-                Assert.IsFalse(result);
-            }
+            Assert.IsFalse(result);
         }
 
         //---------------------------------------------------------------------
@@ -80,42 +76,36 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         public async Task WhenUserInViewerRole_ThenGetProjectReturnsProject(
             [Credential(Role = PredefinedRole.ComputeViewer)] ResourceTask<ICredential> credential)
         {
-            using (var adapter = new ResourceManagerAdapter(await credential))
-            {
-                var project = await adapter.GetProjectAsync(
-                        TestProject.ProjectId,
-                        CancellationToken.None)
-                    .ConfigureAwait(false);
+            var adapter = new ResourceManagerAdapter(await credential);
+            var project = await adapter.GetProjectAsync(
+                    TestProject.ProjectId,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
 
-                Assert.IsNotNull(project);
-                Assert.AreEqual(TestProject.ProjectId, project.ProjectId);
-            }
+            Assert.IsNotNull(project);
+            Assert.AreEqual(TestProject.ProjectId, project.ProjectId);
         }
 
         [Test]
         public async Task WhenUserNotInRole_ThenGetProjectThrowsResourceAccessDeniedException(
             [Credential(Role = PredefinedRole.IapTunnelUser)] ResourceTask<ICredential> credential)
         {
-            using (var adapter = new ResourceManagerAdapter(await credential))
-            {
-                ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
-                    () => adapter.GetProjectAsync(
-                        TestProject.ProjectId,
-                        CancellationToken.None).Wait());
-            }
+            var adapter = new ResourceManagerAdapter(await credential);
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
+                () => adapter.GetProjectAsync(
+                    TestProject.ProjectId,
+                    CancellationToken.None).Wait());
         }
 
         [Test]
         public async Task WhenProjectIdInvalid_ThenGetProjectThrowsResourceAccessDeniedException(
             [Credential(Role = PredefinedRole.IapTunnelUser)] ResourceTask<ICredential> credential)
         {
-            using (var adapter = new ResourceManagerAdapter(await credential))
-            {
-                ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
-                    () => adapter.GetProjectAsync(
-                        "invalid",
-                        CancellationToken.None).Wait());
-            }
+            var adapter = new ResourceManagerAdapter(await credential);
+            ExceptionAssert.ThrowsAggregateException<ResourceAccessDeniedException>(
+                () => adapter.GetProjectAsync(
+                    "invalid",
+                    CancellationToken.None).Wait());
         }
 
         //---------------------------------------------------------------------
@@ -126,42 +116,38 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
         public async Task WhenProjectIdExists_ThenQueryProjectsByIdReturnsProject(
             [Credential(Role = PredefinedRole.ComputeViewer)] ResourceTask<ICredential> credential)
         {
-            using (var adapter = new ResourceManagerAdapter(await credential))
-            {
-                var result = await adapter.ListProjectsAsync(
-                        ProjectFilter.ByProjectId(TestProject.ProjectId),
-                        null,
-                        CancellationToken.None)
-                    .ConfigureAwait(false);
+            var adapter = new ResourceManagerAdapter(await credential);
+            var result = await adapter.ListProjectsAsync(
+                    ProjectFilter.ByProjectId(TestProject.ProjectId),
+                    null,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
 
-                Assert.IsNotNull(result);
-                Assert.IsFalse(result.IsTruncated);
-                Assert.AreEqual(1, result.Projects.Count());
-                Assert.AreEqual(TestProject.ProjectId, result.Projects.First().ProjectId);
-            }
+            Assert.IsNotNull(result);
+            Assert.IsFalse(result.IsTruncated);
+            Assert.AreEqual(1, result.Projects.Count());
+            Assert.AreEqual(TestProject.ProjectId, result.Projects.First().ProjectId);
         }
 
         [Test]
         public async Task WhenProjectIdExists_ThenQueryProjectsByPrefixReturnsProject(
             [Credential(Role = PredefinedRole.ComputeViewer)] ResourceTask<ICredential> credential)
         {
-            using (var adapter = new ResourceManagerAdapter(await credential))
-            {
-                // Remove last character from project ID.
-                var prefix = TestProject.ProjectId.Substring(0, TestProject.ProjectId.Length - 1);
+            var adapter = new ResourceManagerAdapter(await credential);
+            // Remove last character from project ID.
+            var prefix = TestProject.ProjectId.Substring(0, TestProject.ProjectId.Length - 1);
 
-                var result = await adapter.ListProjectsAsync(
-                        ProjectFilter.ByPrefix(prefix),
-                        10,
-                        CancellationToken.None)
-                    .ConfigureAwait(false);
+            var result = await adapter.ListProjectsAsync(
+                    ProjectFilter.ByPrefix(prefix),
+                    10,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
 
-                Assert.IsNotNull(result);
-                Assert.IsTrue(result.Projects.Any());
-                CollectionAssert.Contains(
-                    result.Projects.Select(p => p.ProjectId),
-                    TestProject.ProjectId);
-            }
+            Assert.IsNotNull(result);
+            Assert.IsTrue(result.Projects.Any());
+            CollectionAssert.Contains(
+                result.Projects.Select(p => p.ProjectId),
+                TestProject.ProjectId);
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/Settings/TestApplicationSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/Settings/TestApplicationSettingsRepository.cs
@@ -426,6 +426,93 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Settings
             }
         }
 
+
+        //---------------------------------------------------------------------
+        // ConnectionLimit.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenConnectionLimitValid_ThenSettingWins()
+        {
+            using (var settingsKey = this.hkcu.CreateSubKey(TestKeyPath))
+            {
+                var repository = new ApplicationSettingsRepository(
+                    settingsKey,
+                    null,
+                    null);
+
+                settingsKey.SetValue("ConnectionLimit", 8);
+
+                var settings = repository.GetSettings();
+                Assert.AreEqual(8, settings.ConnectionLimit.IntValue);
+                Assert.IsFalse(settings.ConnectionLimit.IsDefault);
+            }
+        }
+
+        [Test]
+        public void WhenConnectionLimitValidAndUserPolicySet_ThenPolicyWins()
+        {
+            using (var settingsKey = this.hkcu.CreateSubKey(TestKeyPath))
+            using (var machinePolicyKey = this.hkcu.CreateSubKey(TestMachinePolicyKeyPath))
+            using (var userPolicyKey = this.hkcu.CreateSubKey(TestUserPolicyKeyPath))
+            {
+                var repository = new ApplicationSettingsRepository(
+                    settingsKey,
+                    machinePolicyKey,
+                    userPolicyKey);
+
+                settingsKey.SetValue("ConnectionLimit", 8);
+                userPolicyKey.SetValue("ConnectionLimit", 9);
+
+                var settings = repository.GetSettings();
+                Assert.AreEqual(9, settings.ConnectionLimit.IntValue);
+                Assert.IsFalse(settings.ConnectionLimit.IsDefault);
+            }
+        }
+
+        [Test]
+        public void WhenConnectionLimitValidAndMachinePolicySet_ThenPolicyWins()
+        {
+            using (var settingsKey = this.hkcu.CreateSubKey(TestKeyPath))
+            using (var machinePolicyKey = this.hkcu.CreateSubKey(TestMachinePolicyKeyPath))
+            using (var userPolicyKey = this.hkcu.CreateSubKey(TestUserPolicyKeyPath))
+            {
+                var repository = new ApplicationSettingsRepository(
+                    settingsKey,
+                    machinePolicyKey,
+                    userPolicyKey);
+
+                settingsKey.SetValue("ConnectionLimit", 8);
+                machinePolicyKey.SetValue("ConnectionLimit", 9);
+
+                var settings = repository.GetSettings();
+                Assert.AreEqual(9, settings.ConnectionLimit.IntValue);
+                Assert.IsFalse(settings.ConnectionLimit.IsDefault);
+            }
+        }
+
+        [Test]
+        public void WhenConnectionLimitValidAndUserAndMachinePolicySet_ThenMachinePolicyWins()
+        {
+            using (var settingsKey = this.hkcu.CreateSubKey(TestKeyPath))
+            using (var machinePolicyKey = this.hkcu.CreateSubKey(TestMachinePolicyKeyPath))
+            using (var userPolicyKey = this.hkcu.CreateSubKey(TestUserPolicyKeyPath))
+            {
+                var repository = new ApplicationSettingsRepository(
+                    settingsKey,
+                    machinePolicyKey,
+                    userPolicyKey);
+
+                settingsKey.SetValue("ConnectionLimit", 8);
+                userPolicyKey.SetValue("ConnectionLimit", 9);
+                machinePolicyKey.SetValue("ConnectionLimit", 10);
+
+                var settings = repository.GetSettings();
+                Assert.AreEqual(10, settings.ConnectionLimit.IntValue);
+                Assert.IsFalse(settings.ConnectionLimit.IsDefault);
+            }
+        }
+
         //---------------------------------------------------------------------
         // IsPolicyPresent.
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Application/ObjectModel/Service.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ObjectModel/Service.cs
@@ -33,7 +33,7 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel
             this.serviceProvider = serviceProvider.ThrowIfNull(nameof(serviceProvider));
         }
 
-        public TService CreateInstance() // TODO: Rename to GetInstance
+        public TService GetInstance()
         {
             return (TService)this.serviceProvider.GetService(typeof(TService));
         }

--- a/sources/Google.Solutions.IapDesktop.Application/ObjectModel/Service.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ObjectModel/Service.cs
@@ -33,7 +33,7 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel
             this.serviceProvider = serviceProvider.ThrowIfNull(nameof(serviceProvider));
         }
 
-        public TService CreateInstance()
+        public TService CreateInstance() // TODO: Rename to GetInstance
         {
             return (TService)this.serviceProvider.GetService(typeof(TService));
         }

--- a/sources/Google.Solutions.IapDesktop.Application/ObjectModel/ServiceAttribute.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ObjectModel/ServiceAttribute.cs
@@ -30,10 +30,26 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel
     [AttributeUsage(AttributeTargets.Class)]
     public sealed class ServiceAttribute : Attribute
     {
+        /// <summary>
+        /// Interface by which the service can be looked up.
+        /// </summary>
         public Type ServiceInterface { get; }
+
+        /// <summary>
+        /// Instance lifetime of the service object.
+        /// </summary>
         public ServiceLifetime Lifetime { get; }
 
+        /// <summary>
+        /// Restrict visibility to other services.
+        /// </summary>
         public ServiceVisibility Visibility { get; } = ServiceVisibility.Scoped;
+
+        /// <summary>
+        /// Delay instance creation until first use. Ignored
+        /// for transient services.
+        /// </summary>
+        public bool DelayCreation { get; set; } = true;
 
         public ServiceAttribute(
             Type serviceInterface,

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/IComputeEngineAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/IComputeEngineAdapter.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 
 namespace Google.Solutions.IapDesktop.Application.Services.Adapters
 {
-    public interface IComputeEngineAdapter : IDisposable
+    public interface IComputeEngineAdapter
     {
         //---------------------------------------------------------------------
         // Projects.

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/ResourceManagerAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/ResourceManagerAdapter.cs
@@ -38,7 +38,7 @@ using System.Threading.Tasks;
 
 namespace Google.Solutions.IapDesktop.Application.Services.Adapters
 {
-    public interface IResourceManagerAdapter : IDisposable
+    public interface IResourceManagerAdapter
     {
         Task<Project> GetProjectAsync(
             string projectId,

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Management/InstanceControlService.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Management/InstanceControlService.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 
 namespace Google.Solutions.IapDesktop.Application.Services.Management
 {
-    public interface IInstanceControlService : IDisposable
+    public interface IInstanceControlService
     {
         /// <summary>
         /// Start, stop, or otherwise control the lifecycle of an instance
@@ -79,15 +79,6 @@ namespace Google.Solutions.IapDesktop.Application.Services.Management
                             command == InstanceControlCommand.Resume))
                     .ConfigureAwait(false);
             }
-        }
-
-        //---------------------------------------------------------------------
-        // InstanceControlService.
-        //---------------------------------------------------------------------
-
-        public void Dispose()
-        {
-            this.computeEngineAdapter.Dispose();
         }
     }
 

--- a/sources/Google.Solutions.IapDesktop.Application/Services/ProjectModel/ProjectModelService.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/ProjectModel/ProjectModelService.cs
@@ -144,7 +144,7 @@ namespace Google.Solutions.IapDesktop.Application.Services.ProjectModel
                     tasks.Add(
                         new ProjectLocator(project.ProjectId),
                         this.resourceManagerAdapter
-                            .CreateInstance()
+                            .GetInstance()
                             .GetProjectAsync(project.ProjectId, token));
                 }
 
@@ -201,7 +201,7 @@ namespace Google.Solutions.IapDesktop.Application.Services.ProjectModel
             using (ApplicationTraceSources.Default.TraceMethod().WithoutParameters())
             {
                 var instances = await this.computeEngineAdapter
-                    .CreateInstance()
+                    .GetInstance()
                     .ListInstancesAsync(project.ProjectId, token)
                     .ConfigureAwait(false);
 

--- a/sources/Google.Solutions.IapDesktop.Application/Services/ProjectModel/ProjectModelService.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/ProjectModel/ProjectModelService.cs
@@ -127,7 +127,6 @@ namespace Google.Solutions.IapDesktop.Application.Services.ProjectModel
             CancellationToken token)
         {
             using (ApplicationTraceSources.Default.TraceMethod().WithoutParameters())
-            using (var computeEngineAdapter = this.computeEngineAdapter.CreateInstance())
             {
                 var accessibleProjects = new List<ProjectNode>();
 
@@ -200,9 +199,9 @@ namespace Google.Solutions.IapDesktop.Application.Services.ProjectModel
             CancellationToken token)
         {
             using (ApplicationTraceSources.Default.TraceMethod().WithoutParameters())
-            using (var computeEngineAdapter = this.computeEngineAdapter.CreateInstance())
             {
-                var instances = await computeEngineAdapter
+                var instances = await this.computeEngineAdapter
+                    .CreateInstance()
                     .ListInstancesAsync(project.ProjectId, token)
                     .ConfigureAwait(false);
 

--- a/sources/Google.Solutions.IapDesktop.Application/Services/ProjectModel/ProjectModelService.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/ProjectModel/ProjectModelService.cs
@@ -128,7 +128,6 @@ namespace Google.Solutions.IapDesktop.Application.Services.ProjectModel
         {
             using (ApplicationTraceSources.Default.TraceMethod().WithoutParameters())
             using (var computeEngineAdapter = this.computeEngineAdapter.CreateInstance())
-            using (var resourceManagerAdapter = this.resourceManagerAdapter.CreateInstance())
             {
                 var accessibleProjects = new List<ProjectNode>();
 
@@ -145,9 +144,9 @@ namespace Google.Solutions.IapDesktop.Application.Services.ProjectModel
                 {
                     tasks.Add(
                         new ProjectLocator(project.ProjectId),
-                        resourceManagerAdapter.GetProjectAsync(
-                            project.ProjectId,
-                            token));
+                        this.resourceManagerAdapter
+                            .CreateInstance()
+                            .GetProjectAsync(project.ProjectId, token));
                 }
 
                 foreach (var task in tasks)

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Settings/ApplicationSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Settings/ApplicationSettingsRepository.cs
@@ -85,6 +85,8 @@ namespace Google.Solutions.IapDesktop.Application.Services.Settings
 
         public RegistryStringSetting CollapsedProjects { get; private set; }
 
+        public RegistryDwordSetting ConnectionLimit { get; private set; }
+
         public IEnumerable<ISetting> Settings => new ISetting[]
         {
             this.IsMainWindowMaximized,
@@ -101,7 +103,8 @@ namespace Google.Solutions.IapDesktop.Application.Services.Settings
             this.FullScreenDevices,
             this.IncludeOperatingSystems,
             this.DeviceCertificateSelector,
-            this.CollapsedProjects
+            this.CollapsedProjects,
+            this.ConnectionLimit
         };
 
         private ApplicationSettings()
@@ -177,6 +180,17 @@ namespace Google.Solutions.IapDesktop.Application.Services.Settings
                         SecureConnectEnrollment.DefaultDeviceCertificateSelector,
                         settingsKey,
                         selector => selector == null || ChromeCertificateSelector.TryParse(selector, out var _))
+                    .ApplyPolicy(userPolicyKey)
+                    .ApplyPolicy(machinePolicyKey),
+                ConnectionLimit = RegistryDwordSetting.FromKey(
+                        "ConnectionLimit",
+                        "ConnectionLimit",
+                        null,
+                        null,
+                        16,
+                        settingsKey,
+                        1,
+                        32)
                     .ApplyPolicy(userPolicyKey)
                     .ApplyPolicy(machinePolicyKey),
 

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Windows/WindowsCredentialService.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Windows/WindowsCredentialService.cs
@@ -38,7 +38,7 @@ using System.Threading.Tasks;
 
 namespace Google.Solutions.IapDesktop.Application.Services.Windows
 {
-    public interface IWindowsCredentialService : IDisposable
+    public interface IWindowsCredentialService
     {
         Task<bool> IsGrantedPermissionToCreateWindowsCredentialsAsync(
             InstanceLocator instanceRef);
@@ -311,15 +311,6 @@ namespace Google.Solutions.IapDesktop.Application.Services.Windows
             return this.computeEngineAdapter.IsGrantedPermission(
                 instanceRef,
                 Permissions.ComputeInstancesSetMetadata);
-        }
-
-        //---------------------------------------------------------------------
-        // IDisposable.
-        //---------------------------------------------------------------------
-
-        public void Dispose()
-        {
-            this.computeEngineAdapter.Dispose();
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Application/Views/ProjectExplorer/ProjectExplorerWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/ProjectExplorer/ProjectExplorerWindow.cs
@@ -289,7 +289,7 @@ namespace Google.Solutions.IapDesktop.Application.Views.ProjectExplorer
                     .SelectCloudProjects(
                         this,
                         "Add projects",
-                        this.resourceManagerAdapter.CreateInstance(),
+                        this.resourceManagerAdapter.GetInstance(),
                         this.exceptionDialog,
                         out var projects) == DialogResult.OK)
                 {

--- a/sources/Google.Solutions.IapDesktop.Application/Views/ProjectExplorer/ProjectExplorerWindow.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/ProjectExplorer/ProjectExplorerWindow.cs
@@ -285,26 +285,23 @@ namespace Google.Solutions.IapDesktop.Application.Views.ProjectExplorer
                 //
                 // Show project picker
                 //
-                using (var resourceManager = this.resourceManagerAdapter.CreateInstance())
+                if (this.projectPickerDialog
+                    .SelectCloudProjects(
+                        this,
+                        "Add projects",
+                        this.resourceManagerAdapter.CreateInstance(),
+                        this.exceptionDialog,
+                        out var projects) == DialogResult.OK)
                 {
-                    if (this.projectPickerDialog
-                        .SelectCloudProjects(
-                            this,
-                            "Add projects",
-                            resourceManager,
-                            this.exceptionDialog,
-                            out var projects) == DialogResult.OK)
-                    {
-                        await this.viewModel
-                            .AddProjectsAsync(projects.ToArray())
-                            .ConfigureAwait(true);
+                    await this.viewModel
+                        .AddProjectsAsync(projects.ToArray())
+                        .ConfigureAwait(true);
 
-                        return true;
-                    }
-                    else
-                    {
-                        return false;
-                    }
+                    return true;
+                }
+                else
+                {
+                    return false;
                 }
             }
             catch (Exception e) when (e.IsCancellation())

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/Services/ActiveDirectory/TestDomainJoinServiceStartupScript.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/Services/ActiveDirectory/TestDomainJoinServiceStartupScript.cs
@@ -51,13 +51,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Test.Services.Active
             [DomainJoinWindowsInstance] ResourceTask<InstanceLocator> instanceTask,
             [Credential(Role = PredefinedRole.ComputeInstanceAdminV1)] ResourceTask<ICredential> credentialTask)
         {
-            using (var computeEngineAdapter = new ComputeEngineAdapter(await credentialTask))
             using (var cts = new CancellationTokenSource())
             {
                 var instance = await instanceTask;
 
                 cts.CancelAfter(TimeSpan.FromSeconds(30));
 
+                var computeEngineAdapter = new ComputeEngineAdapter(await credentialTask);
                 using (var operation = new StartupScriptOperation(
                     Guid.Empty,
                     instance,
@@ -89,13 +89,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Test.Services.Active
             [DomainJoinWindowsInstance] ResourceTask<InstanceLocator> instanceTask,
             [Credential(Role = PredefinedRole.ComputeInstanceAdminV1)] ResourceTask<ICredential> credentialTask)
         {
-            using (var computeEngineAdapter = new ComputeEngineAdapter(await credentialTask))
             using (var cts = new CancellationTokenSource())
             {
                 var instance = await instanceTask;
 
                 cts.CancelAfter(TimeSpan.FromSeconds(30));
 
+                var computeEngineAdapter = new ComputeEngineAdapter(await credentialTask);
                 using (var operation = new StartupScriptOperation(
                     Guid.Empty,
                     instance,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/ActiveDirectory/DomainJoinService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/ActiveDirectory/DomainJoinService.cs
@@ -261,7 +261,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Services.ActiveDirec
                 using (var operation = new StartupScriptOperation(
                     instance,
                     MetadataKeys.JoinDomainGuard,
-                    this.computeEngineAdapter.CreateInstance()))
+                    this.computeEngineAdapter.GetInstance()))
                 {
                     await JoinDomainAsync(
                             operation,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/ActiveDirectory/StartupScriptOperation.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/ActiveDirectory/StartupScriptOperation.cs
@@ -273,7 +273,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Services.ActiveDirec
         {
             Debug.Assert(!this.itemsToRestore.EnsureNotNull().Any());
             Debug.Assert(!this.itemsToCleanup.EnsureNotNull().Any());
-            this.ComputeEngineAdapter.Dispose();
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/Adapters/AuditLogAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/Adapters/AuditLogAdapter.cs
@@ -44,7 +44,7 @@ using System.Threading.Tasks;
 
 namespace Google.Solutions.IapDesktop.Extensions.Management.Services.Adapters
 {
-    public interface IAuditLogAdapter : IDisposable
+    public interface IAuditLogAdapter
     {
         Task ProcessInstanceEventsAsync(
             IEnumerable<string> projectIds,
@@ -55,7 +55,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Services.Adapters
             CancellationToken cancellationToken);
     }
 
-    [Service(typeof(IAuditLogAdapter), ServiceLifetime.Transient)]
+    [Service(typeof(IAuditLogAdapter), ServiceLifetime.Singleton)]
     public class AuditLogAdapter : IAuditLogAdapter
     {
         private const string MtlsBaseUri = "https://logging.mtls.googleapis.com/";
@@ -227,15 +227,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Services.Adapters
                     new ExponentialBackOff(initialBackOff, MaxRetries),
                     cancellationToken).ConfigureAwait(false);
             }
-        }
-
-        //---------------------------------------------------------------------
-        // IDisposable.
-        //---------------------------------------------------------------------
-
-        public void Dispose()
-        {
-            this.service.Dispose();
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/Inventory/InventoryService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/Inventory/InventoryService.cs
@@ -35,7 +35,7 @@ using System.Threading.Tasks;
 
 namespace Google.Solutions.IapDesktop.Extensions.Management.Services.Inventory
 {
-    public interface IInventoryService : IDisposable
+    public interface IInventoryService
     {
         /// <summary>
         /// Get OS inventory data for instance.
@@ -159,15 +159,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Services.Inventory
                         .Select(i => i.GetInstanceLocator()),
                     token)
                 .ConfigureAwait(false);
-        }
-
-        //---------------------------------------------------------------------
-        // IDisposable.
-        //---------------------------------------------------------------------
-
-        public void Dispose()
-        {
-            this.computeEngineAdapter.Dispose();
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/ManagementExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/ManagementExtension.cs
@@ -46,7 +46,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Services
     /// <summary>
     /// Main class of the extension, instantiated on load.
     /// </summary>
-    [Service(ServiceLifetime.Singleton)]
+    [Service(ServiceLifetime.Singleton, DelayCreation = false)]
     public class ManagementExtension
     {
         private readonly IServiceProvider serviceProvider;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/ManagementExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/ManagementExtension.cs
@@ -81,15 +81,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Services
                         JobUserFeedbackType.BackgroundFeedback),
                     async jobToken =>
                     {
-                        using (var service = this.serviceProvider
-                            .GetService<IInstanceControlService>())
-                        {
-                            await service.ControlInstanceAsync(
+                        await this.serviceProvider
+                            .GetService<IInstanceControlService>()
+                            .ControlInstanceAsync(
                                     instance,
                                     command,
                                     jobToken)
                             .ConfigureAwait(false);
-                        }
 
                         return null;
                     })

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/EventLog/EventLogViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/EventLog/EventLogViewModel.cs
@@ -294,7 +294,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Views.EventLog
                             JobUserFeedbackType.BackgroundFeedback),
                         async jobToken =>
                         {
-                            using (var auditLogAdapter = this.auditLogAdapter.CreateInstance())
+                            using (var auditLogAdapter = this.auditLogAdapter.GetInstance())
                             using (var combinedTokenSource = jobToken.Combine(token))
                             {
                                 var model = new EventLogModel(displayName);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/EventLog/EventLogViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/EventLog/EventLogViewModel.cs
@@ -294,17 +294,20 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Views.EventLog
                             JobUserFeedbackType.BackgroundFeedback),
                         async jobToken =>
                         {
-                            using (var auditLogAdapter = this.auditLogAdapter.GetInstance())
                             using (var combinedTokenSource = jobToken.Combine(token))
                             {
                                 var model = new EventLogModel(displayName);
-                                await auditLogAdapter.ProcessInstanceEventsAsync(
-                                    new[] { projectIdFilter },
-                                    zonesFilter,
-                                    instanceIdFilter,
-                                    DateTime.UtcNow.Subtract(this.SelectedTimeframe.Duration),
-                                    model,
-                                    combinedTokenSource.Token).ConfigureAwait(false);
+                                await this.auditLogAdapter
+                                    .GetInstance()
+                                    .ProcessInstanceEventsAsync(
+                                        new[] { projectIdFilter },
+                                        zonesFilter,
+                                        instanceIdFilter,
+                                        DateTime.UtcNow.Subtract(this.SelectedTimeframe.Duration),
+                                        model,
+                                        combinedTokenSource.Token)
+                                    .ConfigureAwait(false);
+
                                 return model;
                             }
                         }).ConfigureAwait(true);  // Back to original (UI) thread.

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/InstanceProperties/InstancePropertiesInspectorViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/InstanceProperties/InstancePropertiesInspectorViewModel.cs
@@ -144,8 +144,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Views.InstanceProper
                             {
                                 return await InstancePropertiesInspectorModel.LoadAsync(
                                         vmNode.Instance,
-                                        this.computeEngineAdapter.CreateInstance(),
-                                        this.inventoryService.CreateInstance(),
+                                        this.computeEngineAdapter.GetInstance(),
+                                        this.inventoryService.GetInstance(),
                                         combinedTokenSource.Token)
                                     .ConfigureAwait(false);
                             }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/InstanceProperties/InstancePropertiesInspectorViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/InstanceProperties/InstancePropertiesInspectorViewModel.cs
@@ -141,14 +141,12 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Views.InstanceProper
                         async jobToken =>
                         {
                             using (var combinedTokenSource = jobToken.Combine(token))
-                            using (var gceAdapter = this.computeEngineAdapter.CreateInstance())
-                            using (var inventoryService = this.inventoryService.CreateInstance())
                             {
                                 return await InstancePropertiesInspectorModel.LoadAsync(
-                                    vmNode.Instance,
-                                    gceAdapter,
-                                    inventoryService,
-                                    combinedTokenSource.Token)
+                                        vmNode.Instance,
+                                        this.computeEngineAdapter.CreateInstance(),
+                                        this.inventoryService.CreateInstance(),
+                                        combinedTokenSource.Token)
                                     .ConfigureAwait(false);
                             }
                         }).ConfigureAwait(true);  // Back to original (UI) thread.

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/PackageInventory/PackageInventoryViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/PackageInventory/PackageInventoryViewModel.cs
@@ -227,7 +227,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Views.PackageInvento
                         async jobToken =>
                         {
                             return await PackageInventoryModel.LoadAsync(
-                                    this.inventoryService.CreateInstance(),
+                                    this.inventoryService.GetInstance(),
                                     this.inventoryType,
                                     node,
                                     jobToken)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/PackageInventory/PackageInventoryViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/PackageInventory/PackageInventoryViewModel.cs
@@ -226,15 +226,12 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Views.PackageInvento
                             JobUserFeedbackType.BackgroundFeedback),
                         async jobToken =>
                         {
-                            using (var inventoryService = this.inventoryService.CreateInstance())
-                            {
-                                return await PackageInventoryModel.LoadAsync(
-                                        inventoryService,
-                                        this.inventoryType,
-                                        node,
-                                        jobToken)
-                                    .ConfigureAwait(false);
-                            }
+                            return await PackageInventoryModel.LoadAsync(
+                                    this.inventoryService.CreateInstance(),
+                                    this.inventoryType,
+                                    node,
+                                    jobToken)
+                                .ConfigureAwait(false);
                         }).ConfigureAwait(true);  // Back to original (UI) thread.
                 }
                 finally

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/SerialOutput/SerialOutputViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Views/SerialOutput/SerialOutputViewModel.cs
@@ -225,7 +225,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Views.SerialOutput
                             {
                                 return await SerialOutputModel.LoadAsync(
                                     vmNode.Instance.Name,
-                                    this.computeEngineAdapter.CreateInstance(),
+                                    this.computeEngineAdapter.GetInstance(),
                                     vmNode.Instance,
                                     this.serialPortNumber,
                                     combinedTokenSource.Token)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/RemoteDesktop/TestRemoteDesktopPane.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/RemoteDesktop/TestRemoteDesktopPane.cs
@@ -178,9 +178,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
             using (var tunnel = IapTunnel.ForRdp(
                 locator,
                 await credential))
-            using (var credentialAdapter = new WindowsCredentialService(
-                new ComputeEngineAdapter(this.ServiceProvider.GetService<IAuthorizationSource>())))
             {
+                var credentialAdapter = new WindowsCredentialService(
+                    new ComputeEngineAdapter(this.ServiceProvider.GetService<IAuthorizationSource>()));
                 var credentials = await credentialAdapter.CreateWindowsCredentialsAsync(
                         locator,
                         CreateRandomUsername(),
@@ -238,9 +238,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
             using (var tunnel = IapTunnel.ForRdp(
                 locator,
                 await credential))
-            using (var credentialAdapter = new WindowsCredentialService(
-                new ComputeEngineAdapter(this.ServiceProvider.GetService<IAuthorizationSource>())))
             {
+                var credentialAdapter = new WindowsCredentialService(
+                    new ComputeEngineAdapter(this.ServiceProvider.GetService<IAuthorizationSource>()));
                 var credentials = await credentialAdapter.CreateWindowsCredentialsAsync(
                         locator,
                         CreateRandomUsername(),
@@ -297,9 +297,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
             using (var tunnel = IapTunnel.ForRdp(
                 locator,
                 await credential))
-            using (var credentialAdapter = new WindowsCredentialService(
-                new ComputeEngineAdapter(this.ServiceProvider.GetService<IAuthorizationSource>())))
             {
+                var credentialAdapter = new WindowsCredentialService(
+                    new ComputeEngineAdapter(this.ServiceProvider.GetService<IAuthorizationSource>()));
                 var credentials = await credentialAdapter.CreateWindowsCredentialsAsync(
                        locator,
                        CreateRandomUsername(),

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/RemoteDesktop/TestRemoteDesktopPaneWithGroupPolicies.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/RemoteDesktop/TestRemoteDesktopPaneWithGroupPolicies.cs
@@ -44,32 +44,31 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
         private async Task<InstanceConnectionSettings> CreateSettingsAsync(
             InstanceLocator instanceLocator)
         {
-            using (var credentialAdapter = new WindowsCredentialService(
-                new ComputeEngineAdapter(this.ServiceProvider.GetService<IAuthorizationSource>())))
-            {
-                var credentials = await credentialAdapter.CreateWindowsCredentialsAsync(
-                    instanceLocator,
-                    CreateRandomUsername(),
-                    UserFlags.AddToAdministrators,
-                    TimeSpan.FromSeconds(60),
-                    CancellationToken.None)
-                .ConfigureAwait(true);
+            var credentialAdapter = new WindowsCredentialService(
+                new ComputeEngineAdapter(this.ServiceProvider.GetService<IAuthorizationSource>()));
+            
+            var credentials = await credentialAdapter.CreateWindowsCredentialsAsync(
+                instanceLocator,
+                CreateRandomUsername(),
+                UserFlags.AddToAdministrators,
+                TimeSpan.FromSeconds(60),
+                CancellationToken.None)
+            .ConfigureAwait(true);
 
-                var settings = InstanceConnectionSettings.CreateNew(instanceLocator);
-                settings.RdpUsername.Value = credentials.UserName;
-                settings.RdpPassword.Value = credentials.SecurePassword;
-                settings.RdpAuthenticationLevel.Value = RdpAuthenticationLevel.NoServerAuthentication;
-                settings.RdpBitmapPersistence.Value = RdpBitmapPersistence.Disabled;
-                settings.RdpDesktopSize.Value = RdpDesktopSize.ClientSize;
-                settings.RdpRedirectClipboard.Value = RdpRedirectClipboard.Enabled;
-                settings.RdpRedirectPrinter.Value = RdpRedirectPrinter.Enabled;
-                settings.RdpRedirectPort.Value = RdpRedirectPort.Enabled;
-                settings.RdpRedirectSmartCard.Value = RdpRedirectSmartCard.Enabled;
-                settings.RdpRedirectDrive.Value = RdpRedirectDrive.Enabled;
-                settings.RdpRedirectDevice.Value = RdpRedirectDevice.Enabled;
+            var settings = InstanceConnectionSettings.CreateNew(instanceLocator);
+            settings.RdpUsername.Value = credentials.UserName;
+            settings.RdpPassword.Value = credentials.SecurePassword;
+            settings.RdpAuthenticationLevel.Value = RdpAuthenticationLevel.NoServerAuthentication;
+            settings.RdpBitmapPersistence.Value = RdpBitmapPersistence.Disabled;
+            settings.RdpDesktopSize.Value = RdpDesktopSize.ClientSize;
+            settings.RdpRedirectClipboard.Value = RdpRedirectClipboard.Enabled;
+            settings.RdpRedirectPrinter.Value = RdpRedirectPrinter.Enabled;
+            settings.RdpRedirectPort.Value = RdpRedirectPort.Enabled;
+            settings.RdpRedirectSmartCard.Value = RdpRedirectSmartCard.Enabled;
+            settings.RdpRedirectDrive.Value = RdpRedirectDrive.Enabled;
+            settings.RdpRedirectDevice.Value = RdpRedirectDevice.Enabled;
 
-                return settings;
-            }
+            return settings;
         }
 
         private async Task<IRemoteDesktopSession> ConnectAsync(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/RemoteDesktop/TestRemoteDesktopSessionBroker.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/RemoteDesktop/TestRemoteDesktopSessionBroker.cs
@@ -68,9 +68,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
             using (var tunnel = IapTunnel.ForRdp(
                 locator,
                 await credential))
-            using (var credentialAdapter = new WindowsCredentialService(
-                new ComputeEngineAdapter(this.ServiceProvider.GetService<IAuthorizationSource>())))
             {
+                var credentialAdapter = new WindowsCredentialService(
+                    new ComputeEngineAdapter(this.ServiceProvider.GetService<IAuthorizationSource>()));
                 var credentials = await credentialAdapter.CreateWindowsCredentialsAsync(
                         locator,
                         CreateRandomUsername(),

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshTerminalPane.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshTerminalPane.cs
@@ -99,45 +99,44 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
                 .Setup(a => a.Authorization)
                 .Returns(authorization.Object);
 
-            using (var keyAdapter = new KeyAuthorizationService(
+            var keyAdapter = new KeyAuthorizationService(
                 authorizationSource.Object,
                 new ComputeEngineAdapter(credential),
                 new ResourceManagerAdapter(credential),
-                new Mock<IOsLoginService>().Object))
-            {
-                var authorizedKey = await keyAdapter.AuthorizeKeyAsync(
-                        instanceLocator,
-                        SshKeyPair.NewEphemeralKeyPair(keyType),
-                        TimeSpan.FromMinutes(10),
-                        null,
-                        KeyAuthorizationMethods.InstanceMetadata,
-                        CancellationToken.None)
-                    .ConfigureAwait(true);
+                new Mock<IOsLoginService>().Object);
+            
+            var authorizedKey = await keyAdapter.AuthorizeKeyAsync(
+                    instanceLocator,
+                    SshKeyPair.NewEphemeralKeyPair(keyType),
+                    TimeSpan.FromMinutes(10),
+                    null,
+                    KeyAuthorizationMethods.InstanceMetadata,
+                    CancellationToken.None)
+                .ConfigureAwait(true);
 
-                var broker = new SshTerminalSessionBroker(
-                    this.ServiceProvider);
+            var broker = new SshTerminalSessionBroker(
+                this.ServiceProvider);
 
-                var address = await PublicAddressFromLocator(instanceLocator)
-                    .ConfigureAwait(true);
+            var address = await PublicAddressFromLocator(instanceLocator)
+                .ConfigureAwait(true);
 
-                SshTerminalPane pane = null;
-                await AssertRaisesEventAsync<SessionStartedEvent>(
-                    async () =>
-                    {
-                        pane = (SshTerminalPane)await broker.ConnectAsync(
-                                instanceLocator,
-                                new IPEndPoint(address, 22),
-                                authorizedKey,
-                                language,
-                                TimeSpan.FromSeconds(10))
-                            .ConfigureAwait(true);
-                    })
-                    .ConfigureAwait(true);
+            SshTerminalPane pane = null;
+            await AssertRaisesEventAsync<SessionStartedEvent>(
+                async () =>
+                {
+                    pane = (SshTerminalPane)await broker.ConnectAsync(
+                            instanceLocator,
+                            new IPEndPoint(address, 22),
+                            authorizedKey,
+                            language,
+                            TimeSpan.FromSeconds(10))
+                        .ConfigureAwait(true);
+                })
+                .ConfigureAwait(true);
 
-                PumpWindowMessages();
+            PumpWindowMessages();
 
-                return (SshTerminalPane)pane;
-            }
+            return (SshTerminalPane)pane;
         }
 
         [SetUp]

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshTerminalPaneViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshTerminalPaneViewModel.cs
@@ -91,21 +91,20 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
         {
             var authorizationSource = CreateAuthorizationSource();
 
-            using (var keyAdapter = new KeyAuthorizationService(
+            var keyAdapter = new KeyAuthorizationService(
                 authorizationSource.Object,
                 new ComputeEngineAdapter(credential),
                 new ResourceManagerAdapter(credential),
-                new Mock<IOsLoginService>().Object))
-            {
-                return await keyAdapter.AuthorizeKeyAsync(
-                        instance,
-                        SshKeyPair.NewEphemeralKeyPair(keyType),
-                        TimeSpan.FromMinutes(10),
-                        null,
-                        KeyAuthorizationMethods.InstanceMetadata,
-                        CancellationToken.None)
-                    .ConfigureAwait(true);
-            }
+                new Mock<IOsLoginService>().Object);
+            
+            return await keyAdapter.AuthorizeKeyAsync(
+                    instance,
+                    SshKeyPair.NewEphemeralKeyPair(keyType),
+                    TimeSpan.FromMinutes(10),
+                    null,
+                    KeyAuthorizationMethods.InstanceMetadata,
+                    CancellationToken.None)
+                .ConfigureAwait(true);
         }
 
         private async Task<SshTerminalPaneViewModel> CreateViewModelAsync(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Adapter/OsLoginAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Adapter/OsLoginAdapter.cs
@@ -40,7 +40,7 @@ using System.Threading.Tasks;
 
 namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Adapter
 {
-    public interface IOsLoginAdapter : IDisposable
+    public interface IOsLoginAdapter
     {
         /// <summary>
         /// Import user's public key to OS Login.
@@ -225,11 +225,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Adapter
                         e);
                 }
             }
-        }
-
-        public void Dispose()
-        {
-            this.service?.Dispose();
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ShellExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ShellExtension.cs
@@ -48,7 +48,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
     /// <summary>
     /// Main class of the extension, instantiated on load.
     /// </summary>
-    [Service(ServiceLifetime.Singleton)]
+    [Service(ServiceLifetime.Singleton, DelayCreation = false)]
     public class ShellExtension
     {
         private readonly IServiceProvider serviceProvider;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Ssh/IKeyAuthorizationService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Ssh/IKeyAuthorizationService.cs
@@ -27,7 +27,7 @@ using System.Threading.Tasks;
 
 namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Ssh
 {
-    public interface IKeyAuthorizationService : IDisposable
+    public interface IKeyAuthorizationService
     {
         Task<AuthorizedKeyPair> AuthorizeKeyAsync(
             InstanceLocator instance,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Ssh/KeyAuthorizationService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Ssh/KeyAuthorizationService.cs
@@ -139,23 +139,5 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Ssh
                 }
             }
         }
-
-        //---------------------------------------------------------------------
-        // IDisposable.
-        //---------------------------------------------------------------------
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                this.computeEngineAdapter.Dispose();
-            }
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Ssh/OsLoginService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Ssh/OsLoginService.cs
@@ -39,7 +39,7 @@ using System.Threading.Tasks;
 
 namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Ssh
 {
-    public interface IOsLoginService : IDisposable
+    public interface IOsLoginService
     {
         /// <summary>
         /// Upload an a public key to authorize it.
@@ -197,11 +197,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Ssh
                         cancellationToken)
                     .ConfigureAwait(false);
             }
-        }
-
-        public void Dispose()
-        {
-            this.adapter?.Dispose();
         }
 
         internal class AuthorizedPublicKey : IAuthorizedPublicKey

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshKeys/AuthorizedPublicKeysViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshKeys/AuthorizedPublicKeysViewModel.cs
@@ -221,16 +221,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshKeys
                     }
                     else
                     {
-                        using (var computeEngineAdapter = this.computeEngineAdapter.CreateInstance())
-                        {
-                            await AuthorizedPublicKeysModel.DeleteFromMetadataAsync(
-                                    computeEngineAdapter,
-                                    this.resourceManagerAdapter.CreateInstance(),
-                                    this.ModelKey,
-                                    this.selectedItem,
-                                    cancellationToken)
-                                .ConfigureAwait(true);
-                        }
+                        await AuthorizedPublicKeysModel.DeleteFromMetadataAsync(
+                                this.computeEngineAdapter.CreateInstance(),
+                                this.resourceManagerAdapter.CreateInstance(),
+                                this.ModelKey,
+                                this.selectedItem,
+                                cancellationToken)
+                            .ConfigureAwait(true);
                     }
 
                     return null;
@@ -273,11 +270,10 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshKeys
                             JobUserFeedbackType.BackgroundFeedback),
                         async jobToken =>
                         {
-                            using (var computeEngineAdapter = this.computeEngineAdapter.CreateInstance())
                             using (var osLoginService = this.osLoginService.CreateInstance())
                             {
                                 return await AuthorizedPublicKeysModel.LoadAsync(
-                                        computeEngineAdapter,
+                                        this.computeEngineAdapter.CreateInstance(),
                                         this.resourceManagerAdapter.CreateInstance(),
                                         osLoginService,
                                         node,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshKeys/AuthorizedPublicKeysViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshKeys/AuthorizedPublicKeysViewModel.cs
@@ -210,7 +210,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshKeys
                 {
                     if (this.selectedItem.AuthorizationMethod == KeyAuthorizationMethods.Oslogin)
                     {
-                        using (var osLoginService = this.osLoginService.CreateInstance())
+                        using (var osLoginService = this.osLoginService.GetInstance())
                         {
                             await AuthorizedPublicKeysModel.DeleteFromOsLoginAsync(
                                     osLoginService,
@@ -222,8 +222,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshKeys
                     else
                     {
                         await AuthorizedPublicKeysModel.DeleteFromMetadataAsync(
-                                this.computeEngineAdapter.CreateInstance(),
-                                this.resourceManagerAdapter.CreateInstance(),
+                                this.computeEngineAdapter.GetInstance(),
+                                this.resourceManagerAdapter.GetInstance(),
                                 this.ModelKey,
                                 this.selectedItem,
                                 cancellationToken)
@@ -270,11 +270,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshKeys
                             JobUserFeedbackType.BackgroundFeedback),
                         async jobToken =>
                         {
-                            using (var osLoginService = this.osLoginService.CreateInstance())
+                            using (var osLoginService = this.osLoginService.GetInstance())
                             {
                                 return await AuthorizedPublicKeysModel.LoadAsync(
-                                        this.computeEngineAdapter.CreateInstance(),
-                                        this.resourceManagerAdapter.CreateInstance(),
+                                        this.computeEngineAdapter.GetInstance(),
+                                        this.resourceManagerAdapter.GetInstance(),
                                         osLoginService,
                                         node,
                                         jobToken)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshKeys/AuthorizedPublicKeysViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshKeys/AuthorizedPublicKeysViewModel.cs
@@ -222,11 +222,10 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshKeys
                     else
                     {
                         using (var computeEngineAdapter = this.computeEngineAdapter.CreateInstance())
-                        using (var resourceManagerAdapter = this.resourceManagerAdapter.CreateInstance())
                         {
                             await AuthorizedPublicKeysModel.DeleteFromMetadataAsync(
                                     computeEngineAdapter,
-                                    resourceManagerAdapter,
+                                    this.resourceManagerAdapter.CreateInstance(),
                                     this.ModelKey,
                                     this.selectedItem,
                                     cancellationToken)
@@ -275,12 +274,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshKeys
                         async jobToken =>
                         {
                             using (var computeEngineAdapter = this.computeEngineAdapter.CreateInstance())
-                            using (var resourceManagerAdapter = this.resourceManagerAdapter.CreateInstance())
                             using (var osLoginService = this.osLoginService.CreateInstance())
                             {
                                 return await AuthorizedPublicKeysModel.LoadAsync(
                                         computeEngineAdapter,
-                                        resourceManagerAdapter,
+                                        this.resourceManagerAdapter.CreateInstance(),
                                         osLoginService,
                                         node,
                                         jobToken)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshKeys/AuthorizedPublicKeysViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/SshKeys/AuthorizedPublicKeysViewModel.cs
@@ -210,14 +210,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshKeys
                 {
                     if (this.selectedItem.AuthorizationMethod == KeyAuthorizationMethods.Oslogin)
                     {
-                        using (var osLoginService = this.osLoginService.GetInstance())
-                        {
-                            await AuthorizedPublicKeysModel.DeleteFromOsLoginAsync(
-                                    osLoginService,
-                                    this.selectedItem,
-                                    cancellationToken)
-                                .ConfigureAwait(true);
-                        }
+                        await AuthorizedPublicKeysModel.DeleteFromOsLoginAsync(
+                                this.osLoginService.GetInstance(),
+                                this.selectedItem,
+                                cancellationToken)
+                            .ConfigureAwait(true);
                     }
                     else
                     {
@@ -270,16 +267,14 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.SshKeys
                             JobUserFeedbackType.BackgroundFeedback),
                         async jobToken =>
                         {
-                            using (var osLoginService = this.osLoginService.GetInstance())
-                            {
-                                return await AuthorizedPublicKeysModel.LoadAsync(
-                                        this.computeEngineAdapter.GetInstance(),
-                                        this.resourceManagerAdapter.GetInstance(),
-                                        osLoginService,
-                                        node,
-                                        jobToken)
-                                    .ConfigureAwait(false);
-                            }
+                            return await AuthorizedPublicKeysModel
+                                .LoadAsync(
+                                    this.computeEngineAdapter.GetInstance(),
+                                    this.resourceManagerAdapter.GetInstance(),
+                                    this.osLoginService.GetInstance(),
+                                    node,
+                                    jobToken)
+                                .ConfigureAwait(false);
                         }).ConfigureAwait(true);  // Back to original (UI) thread.
                 }
                 finally

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -267,7 +267,7 @@ namespace Google.Solutions.IapDesktop
 
                 // TODO: Use singletons for other adapters
                 baseLayer.AddSingleton<IResourceManagerAdapter, ResourceManagerAdapter>();
-                baseLayer.AddTransient<IComputeEngineAdapter, ComputeEngineAdapter>();
+                baseLayer.AddSingleton<IComputeEngineAdapter, ComputeEngineAdapter>();
                 baseLayer.AddTransient<IHttpProxyAdapter, HttpProxyAdapter>();
 
                 baseLayer.AddSingleton<IThemeService, ThemeService>();

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -219,8 +219,7 @@ namespace Google.Solutions.IapDesktop
             }
 
             //
-            // Lift limit on concurrent HTTP connections to same endpoint,
-            // relevant for GCS downloads.
+            // Lift limit on concurrent HTTP connections to same endpoint.
             //
             ServicePointManager.DefaultConnectionLimit = 16;
 
@@ -264,11 +263,13 @@ namespace Google.Solutions.IapDesktop
                 baseLayer.AddTransient<IGithubAdapter, GithubAdapter>();
                 baseLayer.AddTransient<BuganizerAdapter>();
                 baseLayer.AddTransient<ICloudConsoleAdapter, CloudConsoleAdapter>();
+                baseLayer.AddTransient<IHttpProxyAdapter, HttpProxyAdapter>();
 
-                // TODO: Use singletons for other adapters
+                //
+                // Register adapters as singletons to ensure connection resuse.
+                //
                 baseLayer.AddSingleton<IResourceManagerAdapter, ResourceManagerAdapter>();
                 baseLayer.AddSingleton<IComputeEngineAdapter, ComputeEngineAdapter>();
-                baseLayer.AddTransient<IHttpProxyAdapter, HttpProxyAdapter>();
 
                 baseLayer.AddSingleton<IThemeService, ThemeService>();
 

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -265,7 +265,8 @@ namespace Google.Solutions.IapDesktop
                 baseLayer.AddTransient<BuganizerAdapter>();
                 baseLayer.AddTransient<ICloudConsoleAdapter, CloudConsoleAdapter>();
 
-                baseLayer.AddTransient<IResourceManagerAdapter, ResourceManagerAdapter>();
+                // TODO: Use singletons for other adapters
+                baseLayer.AddSingleton<IResourceManagerAdapter, ResourceManagerAdapter>();
                 baseLayer.AddTransient<IComputeEngineAdapter, ComputeEngineAdapter>();
                 baseLayer.AddTransient<IHttpProxyAdapter, HttpProxyAdapter>();
 

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -218,11 +218,6 @@ namespace Google.Solutions.IapDesktop
                     SecurityProtocolType.Tls11;
             }
 
-            //
-            // Lift limit on concurrent HTTP connections to same endpoint.
-            //
-            ServicePointManager.DefaultConnectionLimit = 16;
-
             // Allow custom User-Agent headers.
             try
             {
@@ -295,14 +290,26 @@ namespace Google.Solutions.IapDesktop
                     SignInAdapter.StoreUserId));
 
                 //
-                // Load proxy settings and main form.
+                // Configure networking settings.
                 //
-
+                // NB. Until now, no network connections have been made.
+                //
                 try
                 {
+                    var settings = baseLayer
+                        .GetService<ApplicationSettingsRepository>()
+                        .GetSettings();
+
+                    //
+                    // Set connection pool limit. This limit applies per endpoint,
+                    // and GCE, RM, OS Login, etc are all separate endpoints.
+                    //
+                    ServicePointManager.DefaultConnectionLimit = settings.ConnectionLimit.IntValue;
+
+                    //
                     // Activate proxy settings based on app settings.
-                    baseLayer.GetService<IHttpProxyAdapter>().ActivateSettings(
-                        baseLayer.GetService<ApplicationSettingsRepository>().GetSettings());
+                    //
+                    baseLayer.GetService<IHttpProxyAdapter>().ActivateSettings(settings);
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
Maintain a single adapter per API throughout the lifetime of the process

* Change adapter services to be singletons
* Change ServiceRegistry to create singletons lazily (to support singletons that require access to credentials)

Previously, a separate ServicePoint was used for each (transient) adapter instance, effectively disabling connection pooling.