### PR TITLE
b/260624119 Use quarter-1080p as minimum size

### DIFF
--- a/sources/Google.Solutions.IapDesktop/Windows/MainForm.Designer.cs
+++ b/sources/Google.Solutions.IapDesktop/Windows/MainForm.Designer.cs
@@ -396,7 +396,6 @@ namespace Google.Solutions.IapDesktop.Windows
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.IsMdiContainer = true;
             this.MainMenuStrip = this.mainMenu;
-            this.MinimumSize = new System.Drawing.Size(1000, 700);
             this.Name = "MainForm";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.MainForm_FormClosing);
             this.Load += new System.EventHandler(this.MainForm_Load);

--- a/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
+++ b/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
@@ -57,6 +57,14 @@ namespace Google.Solutions.IapDesktop.Windows
 {
     public partial class MainForm : Form, IJobHost, IMainForm, IAuthorizationSource
     {
+        //
+        // Calculate minimum size so that it's a quarter of a 1080p screen,
+        // leaving some room for the taskbar (typically <= 50px).
+        //
+        private static readonly Size MinimumWindowSize = new Size(
+            1920 / 2,
+            (1080 - 50) / 2);
+
         private readonly MainFormViewModel viewModel;
 
         private readonly IThemeService themeService;
@@ -110,6 +118,8 @@ namespace Google.Solutions.IapDesktop.Windows
             this.themeService.ApplyTheme(this.statusStrip);
 
             ResumeLayout();
+
+            this.MinimumSize = MinimumWindowSize;
 
             // Set fixed size for the left/right panels (in pixels).
             this.dockPanel.DockLeftPortion =


### PR DESCRIPTION
Decrease minimum window size so that it's a
quarter of 1080p (half height, half width, minus
taskbar).

Cf. #841