### PR TITLE
b/264818000 Ensure clients use new token after reauth

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/Authorization/TestAuthorization.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/Authorization/TestAuthorization.cs
@@ -20,6 +20,7 @@
 //
 
 using Google.Apis.Auth.OAuth2;
+using Google.Apis.Auth.OAuth2.Flows;
 using Google.Solutions.IapDesktop.Application.Services.Adapters;
 using Google.Solutions.IapDesktop.Application.Services.Authorization;
 using Google.Solutions.Testing.Application.Test;
@@ -33,6 +34,14 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Authorization
     [TestFixture]
     public class TestAuthorization : ApplicationFixtureBase
     {
+        private static UserCredential CreateUserCredentialMock()
+        {
+            return new UserCredential(
+                new Mock<IAuthorizationCodeFlow>().Object,
+                "mock",
+                new Apis.Auth.OAuth2.Responses.TokenResponse());
+        }
+
         //---------------------------------------------------------------------
         // RevokeAsync.
         //---------------------------------------------------------------------
@@ -41,6 +50,10 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Authorization
         public async Task RevokeAsyncDeletesRefreshToken()
         {
             var adapter = new Mock<ISignInAdapter>();
+            adapter.Setup(a => a.SignInWithBrowserAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(CreateUserCredentialMock());
             var deviceEnrollment = new Mock<IDeviceEnrollment>();
 
             var authorization = await AppAuthorization.CreateAuthorizationAsync(
@@ -64,7 +77,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Authorization
             var adapter = new Mock<ISignInAdapter>();
             adapter.Setup(a => a.TrySignInWithRefreshTokenAsync(
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Mock<ICredential>().Object);
+                .ReturnsAsync(CreateUserCredentialMock());
             adapter.Setup(a => a.QueryUserInfoAsync(
                     It.IsAny<ICredential>(),
                     It.IsAny<CancellationToken>()))
@@ -90,7 +103,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Authorization
             var adapter = new Mock<ISignInAdapter>();
             adapter.Setup(a => a.TrySignInWithRefreshTokenAsync(
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync((ICredential)null);
+                .ReturnsAsync((UserCredential)null);
 
             var authorization = await AppAuthorization.TryLoadExistingAuthorizationAsync(
                     adapter.Object,
@@ -112,7 +125,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Authorization
             adapter.Setup(a => a.SignInWithBrowserAsync(
                     It.Is<string>(loginHint => loginHint == null),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Mock<ICredential>().Object);
+                .ReturnsAsync(CreateUserCredentialMock());
             adapter.Setup(a => a.QueryUserInfoAsync(
                     It.IsAny<ICredential>(),
                     It.IsAny<CancellationToken>()))
@@ -143,7 +156,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Authorization
             adapter.Setup(a => a.SignInWithBrowserAsync(
                     It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Mock<ICredential>().Object);
+                .ReturnsAsync(CreateUserCredentialMock());
             adapter.Setup(a => a.QueryUserInfoAsync(
                     It.IsAny<ICredential>(),
                     It.IsAny<CancellationToken>()))
@@ -184,7 +197,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Authorization
             adapter.Setup(a => a.SignInWithBrowserAsync(
                     It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Mock<ICredential>().Object);
+                .ReturnsAsync(CreateUserCredentialMock());
             adapter.Setup(a => a.QueryUserInfoAsync(
                     It.IsAny<ICredential>(),
                     It.IsAny<CancellationToken>()))

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/SignInAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/SignInAdapter.cs
@@ -43,10 +43,10 @@ namespace Google.Solutions.IapDesktop.Application.Services.Adapters
     {
         Task DeleteStoredRefreshToken();
 
-        Task<ICredential> TrySignInWithRefreshTokenAsync(
+        Task<UserCredential> TrySignInWithRefreshTokenAsync(
             CancellationToken token);
 
-        Task<ICredential> SignInWithBrowserAsync(
+        Task<UserCredential> SignInWithBrowserAsync(
             String loginHint,
             CancellationToken token);
 
@@ -153,7 +153,7 @@ namespace Google.Solutions.IapDesktop.Application.Services.Adapters
         // Authorize.
         //---------------------------------------------------------------------
 
-        public async Task<ICredential> TrySignInWithRefreshTokenAsync(
+        public async Task<UserCredential> TrySignInWithRefreshTokenAsync(
             CancellationToken token)
         {
             //
@@ -203,7 +203,7 @@ namespace Google.Solutions.IapDesktop.Application.Services.Adapters
             }
         }
 
-        public async Task<ICredential> SignInWithBrowserAsync(
+        public async Task<UserCredential> SignInWithBrowserAsync(
             string loginHint,
             CancellationToken token)
         {


### PR DESCRIPTION
Fix reauth credential swapping approach: Instead of wrapping the credential,
update the (User) credential in-place. This ensures that existing clients (which
hold on to UserCredential objects) use the updated credential after reauth.