### PR TITLE
b/274025818 RDP credential callback

### DIFF
--- a/sources/Google.Solutions.Common.Test/Diagnostics/TestDumpObjectExtensions.cs
+++ b/sources/Google.Solutions.Common.Test/Diagnostics/TestDumpObjectExtensions.cs
@@ -1,0 +1,48 @@
+﻿
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Diagnostics;
+using NUnit.Framework;
+
+namespace Google.Solutions.Common.Test.Diagnostics
+{
+    [TestFixture]
+    public class TestDumpObjectExtensions
+    {
+        [Test]
+        public void WhenObjectIsNull_ThenDumpPropertiesReturnsEmptyString()
+        {
+            Assert.AreEqual(string.Empty, ((object)null).DumpProperties());
+        }
+
+        [Test]
+        public void WhenObjectIsNotNull_ThenDumpPropertiesReturnsString()
+        {
+            Assert.AreEqual(
+                "Foo: 1\nBar: test\nQuux: System.Object\n", 
+                new {
+                    Foo = 1,
+                    Bar = "test",
+                    Quux = new object()
+                }.DumpProperties());
+        }
+    }
+}

--- a/sources/Google.Solutions.Common.Test/Google.Solutions.Common.Test.csproj
+++ b/sources/Google.Solutions.Common.Test/Google.Solutions.Common.Test.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Diagnostics\TestBugReport.cs" />
     <Compile Include="Diagnostics\TestClrVersion.cs" />
     <Compile Include="CommonFixtureBase.cs" />
+    <Compile Include="Diagnostics\TestDumpObjectExtensions.cs" />
     <Compile Include="Diagnostics\TestTraceSourceExtensions.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Interop\TestCoTaskMemAllocSafeHandle.cs" />

--- a/sources/Google.Solutions.Common/Diagnostics/DumpObjectExtensions.cs
+++ b/sources/Google.Solutions.Common/Diagnostics/DumpObjectExtensions.cs
@@ -1,0 +1,46 @@
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System.ComponentModel;
+using System.Text;
+
+namespace Google.Solutions.Common.Diagnostics
+{
+    public static class DumpObjectExtensions
+    {
+        public static string DumpProperties(this object obj)
+        {
+            var buffer = new StringBuilder();
+
+            if (obj != null)
+            {
+                foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(obj))
+                {
+                    string name = descriptor.Name;
+                    object value = descriptor.GetValue(obj);
+                    buffer.Append($"{name}: {value}\n");
+                }
+            }
+
+            return buffer.ToString();
+        }
+    }
+}

--- a/sources/Google.Solutions.Common/Google.Solutions.Common.csproj
+++ b/sources/Google.Solutions.Common/Google.Solutions.Common.csproj
@@ -71,6 +71,7 @@
     <Compile Include="ApiExtensions\RequestExtensions.cs" />
     <Compile Include="Diagnostics\BugReport.cs" />
     <Compile Include="Diagnostics\ClrVersion.cs" />
+    <Compile Include="Diagnostics\DumpObjectExtensions.cs" />
     <Compile Include="Diagnostics\SkipCodeCoverageAttribute.cs" />
     <Compile Include="Diagnostics\TraceCallScope.cs" />
     <Compile Include="Diagnostics\TraceSourceExtensions.cs" />

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestGithubAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Services/Adapters/TestGithubAdapter.cs
@@ -44,7 +44,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
             var restAdapter = new Mock<IExternalRestAdapter>();
             restAdapter
                 .Setup(a => a.GetAsync<GithubAdapter.Release>(
-                    It.IsNotNull<string>(),
+                    It.IsNotNull<Uri>(),
                     It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new HttpRequestException("mock"));
 
@@ -62,7 +62,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
             var restAdapter = new Mock<IExternalRestAdapter>();
             restAdapter
                 .Setup(a => a.GetAsync<GithubAdapter.Release>(
-                    It.IsNotNull<string>(),
+                    It.IsNotNull<Uri>(),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync((GithubAdapter.Release)null);
 
@@ -83,7 +83,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
             var restAdapter = new Mock<IExternalRestAdapter>();
             restAdapter
                 .Setup(a => a.GetAsync<GithubAdapter.Release>(
-                    It.IsNotNull<string>(),
+                    It.IsNotNull<Uri>(),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new GithubAdapter.Release("1.2.3.4", null, null));
 
@@ -102,7 +102,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
             var restAdapter = new Mock<IExternalRestAdapter>();
             restAdapter
                 .Setup(a => a.GetAsync<GithubAdapter.Release>(
-                    It.IsNotNull<string>(),
+                    It.IsNotNull<Uri>(),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new GithubAdapter.Release("not a version", null, null));
 
@@ -125,7 +125,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
             var restAdapter = new Mock<IExternalRestAdapter>();
             restAdapter
                 .Setup(a => a.GetAsync<GithubAdapter.Release>(
-                    It.IsNotNull<string>(),
+                    It.IsNotNull<Uri>(),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new GithubAdapter.Release(
                     "1.2.3.4",
@@ -150,7 +150,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Services.Adapters
             var restAdapter = new Mock<IExternalRestAdapter>();
             restAdapter
                 .Setup(a => a.GetAsync<GithubAdapter.Release>(
-                    It.IsNotNull<string>(),
+                    It.IsNotNull<Uri>(),
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new GithubAdapter.Release(
                     "1.2.3.4",

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/ExternalRestAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/ExternalRestAdapter.cs
@@ -38,7 +38,7 @@ namespace Google.Solutions.IapDesktop.Application.Services.Adapters
         /// </summary>
         /// <returns>null if not found or empty</returns>
         Task<TModel> GetAsync<TModel>(
-            string url,
+            Uri url,
             CancellationToken cancellationToken);
     }
 
@@ -51,12 +51,12 @@ namespace Google.Solutions.IapDesktop.Application.Services.Adapters
         private readonly RestClient client = new RestClient(Install.UserAgent);
 
 
-        public async Task<TModel> GetAsync<TModel>(string url, CancellationToken cancellationToken)
+        public async Task<TModel> GetAsync<TModel>(Uri url, CancellationToken cancellationToken)
         {
             using (ApplicationTraceSources.Default.TraceMethod().WithParameters(url))
             {
                 return await this.client
-                    .GetAsync<TModel>(url, null, cancellationToken)
+                    .GetAsync<TModel>(url.ToString(), null, cancellationToken)
                     .ConfigureAwait(false);
             }
         }

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/GithubAdapter.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Adapters/GithubAdapter.cs
@@ -63,7 +63,7 @@ namespace Google.Solutions.IapDesktop.Application.Services.Adapters
             {
                 var latestRelease = await this.restAdapter
                     .GetAsync<Release>(
-                        $"https://api.github.com/repos/{RepositoryName}/releases/latest",
+                        new Uri($"https://api.github.com/repos/{RepositoryName}/releases/latest"),
                         cancellationToken)
                     .ConfigureAwait(false);
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Google.Solutions.IapDesktop.Extensions.Shell.Test.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Google.Solutions.IapDesktop.Extensions.Shell.Test.csproj
@@ -130,6 +130,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="IapTunnel.cs" />
     <Compile Include="Services\Adapter\TestKeyStoreAdapter.cs" />
+    <Compile Include="Services\Connection\TestRdpCredentialCallbackService.cs" />
     <Compile Include="Services\Ssh\TestMetadataAuthorizedPublicKeyProcessor.cs" />
     <Compile Include="Services\Ssh\TestProjectMetadataAuthorizedPublicKeyProcessor.cs" />
     <Compile Include="Services\Ssh\TestMetadataAuthorizedPublicKey.cs" />

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Connection/TestRdpConnectionService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Connection/TestRdpConnectionService.cs
@@ -32,6 +32,7 @@ using Google.Solutions.IapDesktop.Extensions.Shell.Services.Tunnel;
 using Google.Solutions.IapDesktop.Extensions.Shell.Views.Credentials;
 using Google.Solutions.IapTunneling.Iap;
 using Google.Solutions.Testing.Application.Mocks;
+using Google.Solutions.Testing.Common;
 using Moq;
 using NUnit.Framework;
 using System;
@@ -100,7 +101,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
                 CreateTunnelBrokerServiceMock().Object,
                 new SynchronousJobService(),
                 settingsService.Object,
-                new Mock<ISelectCredentialsWorkflow>().Object);
+                new Mock<ISelectCredentialsWorkflow>().Object,
+                new Mock<IRdpCredentialCallbackService>().Object);
 
             var template = await service
                 .PrepareConnectionAsync(vmNode.Object, false)
@@ -141,7 +143,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
                 CreateTunnelBrokerServiceMock().Object,
                 new SynchronousJobService(),
                 settingsService.Object,
-                new Mock<ISelectCredentialsWorkflow>().Object);
+                new Mock<ISelectCredentialsWorkflow>().Object,
+                new Mock<IRdpCredentialCallbackService>().Object);
 
             var template = await service
                 .PrepareConnectionAsync(vmNode.Object, true)
@@ -179,13 +182,16 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync((IProjectModelNode)null); // Not found
 
+            var callbackService = new Mock<IRdpCredentialCallbackService>();
+
             var service = new RdpConnectionService(
                 new Mock<IMainWindow>().Object,
                 modelService.Object,
                 CreateTunnelBrokerServiceMock().Object,
                 new SynchronousJobService(),
                 settingsService.Object,
-                credentialPrompt.Object);
+                credentialPrompt.Object,
+                callbackService.Object);
 
             var template = await service
                 .PrepareConnectionAsync(
@@ -198,6 +204,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
 
             settingsService.Verify(s => s.GetConnectionSettings(
                 It.IsAny<IProjectModelNode>()), Times.Never);
+            callbackService.Verify(s => s.GetCredentialsAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Test]
@@ -221,13 +230,16 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync((IProjectModelNode)null); // Not found
 
+            var callbackService = new Mock<IRdpCredentialCallbackService>();
+
             var service = new RdpConnectionService(
                 new Mock<IMainWindow>().Object,
                 modelService.Object,
                 CreateTunnelBrokerServiceMock().Object,
                 new SynchronousJobService(),
                 settingsService.Object,
-                credentialPrompt.Object);
+                credentialPrompt.Object,
+                callbackService.Object);
 
             var template = await service
                 .PrepareConnectionAsync(
@@ -240,6 +252,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
 
             settingsService.Verify(s => s.GetConnectionSettings(
                 It.IsAny<IProjectModelNode>()), Times.Never);
+            callbackService.Verify(s => s.GetCredentialsAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Test]
@@ -274,13 +289,16 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(vmNode.Object);
 
+            var callbackService = new Mock<IRdpCredentialCallbackService>();
+
             var service = new RdpConnectionService(
                 new Mock<IMainWindow>().Object,
                 modelService.Object,
                 CreateTunnelBrokerServiceMock().Object,
                 new SynchronousJobService(),
                 settingsService.Object,
-                credentialPrompt.Object);
+                credentialPrompt.Object,
+                callbackService.Object);
 
             var template = await service
                 .PrepareConnectionAsync(
@@ -293,6 +311,79 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
 
             settingsService.Verify(s => s.GetConnectionSettings(
                 It.IsAny<IProjectModelNode>()), Times.Once);
+            callbackService.Verify(s => s.GetCredentialsAsync(
+                It.IsAny<Uri>(),
+                It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        //---------------------------------------------------------------------
+        // Connect by URL (with credential callback).
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenConnectingByUrlAndCredentialCallbackFails_ThenPrepareConnectionThrowsException()
+        {
+            var callbackService = new Mock<IRdpCredentialCallbackService>();
+            callbackService.Setup(
+                s => s.GetCredentialsAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new ArgumentException("mock"));
+
+            var service = new RdpConnectionService(
+                new Mock<IMainWindow>().Object,
+                new Mock<IProjectModelService>().Object,
+                CreateTunnelBrokerServiceMock().Object,
+                new SynchronousJobService(),
+                new Mock<IConnectionSettingsService>().Object,
+                new Mock<ISelectCredentialsWorkflow>().Object,
+                callbackService.Object);
+
+            var url = IapRdpUrl.FromString("iap-rdp:///project/us-central-1/instance-1?CredentialCallbackUrl=http://mock");
+
+            ExceptionAssert.ThrowsAggregateException<ArgumentException>(
+                () => service.PrepareConnectionAsync(url).Wait());
+
+            callbackService.Verify(s => s.GetCredentialsAsync(
+                new Uri("http://mock"),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public async Task WhenConnectingByUrlAndCredentialCallbackSucceeds_ThenConnectionIsMadeWithCallbackCredentials()
+        {
+            var callbackService = new Mock<IRdpCredentialCallbackService>();
+            callbackService.Setup(
+                s => s.GetCredentialsAsync(
+                    It.IsAny<Uri>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new RdpCredentials(
+                    "user",
+                    "domain",
+                    SecureStringExtensions.FromClearText("password")));
+
+            var service = new RdpConnectionService(
+                new Mock<IMainWindow>().Object,
+                new Mock<IProjectModelService>().Object,
+                CreateTunnelBrokerServiceMock().Object,
+                new SynchronousJobService(),
+                new Mock<IConnectionSettingsService>().Object,
+                new Mock<ISelectCredentialsWorkflow>().Object,
+                callbackService.Object);
+
+            var url = IapRdpUrl.FromString("iap-rdp:///project/us-central-1/instance-1?username=john%20doe&CredentialCallbackUrl=http://mock");
+
+            var template = await service
+                .PrepareConnectionAsync(url)
+                .ConfigureAwait(false);
+            Assert.IsNotNull(template);
+            Assert.AreEqual("user", template.Session.Credentials.User);
+            Assert.AreEqual("domain", template.Session.Credentials.Domain);
+            Assert.AreEqual("password", template.Session.Credentials.Password.AsClearText());
+
+            callbackService.Verify(s => s.GetCredentialsAsync(
+                new Uri("http://mock"),
+                It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Connection/TestRdpConnectionService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Connection/TestRdpConnectionService.cs
@@ -25,6 +25,7 @@ using Google.Solutions.IapDesktop.Application.Data;
 using Google.Solutions.IapDesktop.Application.Services.ProjectModel;
 using Google.Solutions.IapDesktop.Application.Settings;
 using Google.Solutions.IapDesktop.Application.Views;
+using Google.Solutions.IapDesktop.Extensions.Shell.Data;
 using Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection;
 using Google.Solutions.IapDesktop.Extensions.Shell.Services.ConnectionSettings;
 using Google.Solutions.IapDesktop.Extensions.Shell.Services.Tunnel;
@@ -168,6 +169,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
                     It.IsAny<IWin32Window>(),
                     It.IsAny<InstanceLocator>(),
                     It.IsAny<ConnectionSettingsBase>(),
+                    RdpCredentialGenerationBehavior._Default,
                     It.IsAny<bool>())); // Nop -> Connect without configuring credentials.
 
             var modelService = new Mock<IProjectModelService>();
@@ -209,6 +211,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
                     It.IsAny<IWin32Window>(),
                     It.IsAny<InstanceLocator>(),
                     It.IsAny<ConnectionSettingsBase>(),
+                    RdpCredentialGenerationBehavior._Default,
                     It.IsAny<bool>())); // Nop -> Connect without configuring credentials.
 
             var modelService = new Mock<IProjectModelService>();
@@ -261,6 +264,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
                     It.IsAny<IWin32Window>(),
                     It.IsAny<InstanceLocator>(),
                     It.IsAny<ConnectionSettingsBase>(),
+                    RdpCredentialGenerationBehavior._Default,
                     It.IsAny<bool>()));
 
             var modelService = new Mock<IProjectModelService>();

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Connection/TestRdpCredentialCallbackService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Connection/TestRdpCredentialCallbackService.cs
@@ -1,0 +1,101 @@
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Security;
+using Google.Solutions.IapDesktop.Application.Services.Adapters;
+using Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection;
+using Google.Solutions.Testing.Common;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
+{
+    [TestFixture]
+    public class TestRdpCredentialCallbackService
+    {
+        private static readonly Uri SampleCallbackUrl = new Uri("http://example.com/callback");
+
+        [Test]
+        public async Task WhenServerReturnsEmptyResult_ThenGetCredentialsReturnsEmptyCredentials()
+        {
+            var adapter = new Mock<IExternalRestAdapter>();
+            adapter
+                .Setup(a => a.GetAsync<RdpCredentialCallbackService.CredentialCallbackResponse>(
+                    SampleCallbackUrl,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync((RdpCredentialCallbackService.CredentialCallbackResponse)null);
+
+            var service = new RdpCredentialCallbackService(adapter.Object);
+            var credentials = await service
+                .GetCredentialsAsync(SampleCallbackUrl, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.IsNull(credentials.User);
+            Assert.IsNull(credentials.Domain);
+            Assert.IsNull(credentials.Password);
+        }
+
+        [Test]
+        public void WhenServerRequestFails_ThenGetCredentialsThrowsException()
+        {
+            var adapter = new Mock<IExternalRestAdapter>();
+            adapter
+                .Setup(a => a.GetAsync<RdpCredentialCallbackService.CredentialCallbackResponse>(
+                    SampleCallbackUrl,
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new HttpRequestException());
+
+            var service = new RdpCredentialCallbackService(adapter.Object);
+
+            ExceptionAssert.ThrowsAggregateException<CredentialCallbackException>(
+                () => service.GetCredentialsAsync(SampleCallbackUrl, CancellationToken.None).Wait());
+        }
+
+        [Test]
+        public async Task WhenServerReturnsResult_ThenGetCredentialsReturnsCredentials()
+        {
+            var adapter = new Mock<IExternalRestAdapter>();
+            adapter
+                .Setup(a => a.GetAsync<RdpCredentialCallbackService.CredentialCallbackResponse>(
+                    SampleCallbackUrl,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new RdpCredentialCallbackService.CredentialCallbackResponse()
+                {
+                    User = "user",
+                    Domain = "domain",
+                    Password = "password"
+                });
+
+            var service = new RdpCredentialCallbackService(adapter.Object);
+            var credentials = await service
+                .GetCredentialsAsync(SampleCallbackUrl, CancellationToken.None)
+                .ConfigureAwait(false);
+
+            Assert.AreEqual("user", credentials.User);
+            Assert.AreEqual("domain", credentials.Domain);
+            Assert.AreEqual("password", credentials.Password.AsClearText());
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Connection/TestRdpCredentialCallbackService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Connection/TestRdpCredentialCallbackService.cs
@@ -24,6 +24,7 @@ using Google.Solutions.IapDesktop.Application.Services.Adapters;
 using Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection;
 using Google.Solutions.Testing.Common;
 using Moq;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
 using System.Net.Http;
@@ -66,6 +67,22 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
                     SampleCallbackUrl,
                     It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new HttpRequestException());
+
+            var service = new RdpCredentialCallbackService(adapter.Object);
+
+            ExceptionAssert.ThrowsAggregateException<CredentialCallbackException>(
+                () => service.GetCredentialsAsync(SampleCallbackUrl, CancellationToken.None).Wait());
+        }
+
+        [Test]
+        public void WhenServerReturnsInvalidResponse_ThenGetCredentialsThrowsException()
+        {
+            var adapter = new Mock<IExternalRestAdapter>();
+            adapter
+                .Setup(a => a.GetAsync<RdpCredentialCallbackService.CredentialCallbackResponse>(
+                    SampleCallbackUrl,
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new JsonReaderException());
 
             var service = new RdpCredentialCallbackService(adapter.Object);
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/ConnectionSettings/TestConnectionSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/ConnectionSettings/TestConnectionSettingsRepository.cs
@@ -86,7 +86,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.ConnectionS
             Assert.IsTrue(settings.RdpUserAuthenticationBehavior.IsDefault);
             Assert.IsTrue(settings.RdpBitmapPersistence.IsDefault);
             Assert.IsTrue(settings.RdpConnectionTimeout.IsDefault);
-            Assert.IsTrue(settings.RdpCredentialGenerationBehavior.IsDefault);
         }
 
         [Test]
@@ -171,7 +170,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.ConnectionS
             Assert.IsTrue(settings.RdpUserAuthenticationBehavior.IsDefault);
             Assert.IsTrue(settings.RdpBitmapPersistence.IsDefault);
             Assert.IsTrue(settings.RdpConnectionTimeout.IsDefault);
-            Assert.IsTrue(settings.RdpCredentialGenerationBehavior.IsDefault);
         }
 
         [Test]
@@ -234,7 +232,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.ConnectionS
             Assert.IsTrue(settings.RdpUserAuthenticationBehavior.IsDefault);
             Assert.IsTrue(settings.RdpBitmapPersistence.IsDefault);
             Assert.IsTrue(settings.RdpConnectionTimeout.IsDefault);
-            Assert.IsTrue(settings.RdpCredentialGenerationBehavior.IsDefault);
             Assert.IsTrue(settings.RdpRedirectClipboard.IsDefault);
             Assert.IsTrue(settings.RdpRedirectPrinter.IsDefault);
             Assert.IsTrue(settings.RdpRedirectSmartCard.IsDefault);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/ConnectionSettings/TestIapRdpUrlConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/ConnectionSettings/TestIapRdpUrlConnectionSettings.cs
@@ -93,7 +93,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.ConnectionS
             settings.RdpColorDepth.Value = RdpColorDepth.TrueColor;
             settings.RdpAudioMode.Value = RdpAudioMode.PlayOnServer;
             settings.RdpRedirectClipboard.Value = RdpRedirectClipboard.Disabled;
-            settings.RdpCredentialGenerationBehavior.Value = RdpCredentialGenerationBehavior.Disallow;
 
             var url = new IapRdpUrl(
                 new InstanceLocator("project-1", "us-central1-a", "instance-1"),
@@ -109,7 +108,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.ConnectionS
             Assert.AreEqual(RdpColorDepth.TrueColor, copy.RdpColorDepth.Value);
             Assert.AreEqual(RdpAudioMode.PlayOnServer, copy.RdpAudioMode.Value);
             Assert.AreEqual(RdpRedirectClipboard.Disabled, copy.RdpRedirectClipboard.Value);
-            Assert.AreEqual(RdpCredentialGenerationBehavior.Disallow, copy.RdpCredentialGenerationBehavior.Value);
         }
 
         //---------------------------------------------------------------------
@@ -131,7 +129,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.ConnectionS
             Assert.AreEqual(RdpColorDepth._Default, settings.RdpColorDepth.Value);
             Assert.AreEqual(RdpAudioMode._Default, settings.RdpAudioMode.Value);
             Assert.AreEqual(RdpRedirectClipboard._Default, settings.RdpRedirectClipboard.Value);
-            Assert.AreEqual(RdpCredentialGenerationBehavior._Default, settings.RdpCredentialGenerationBehavior.Value);
         }
 
         [Test]
@@ -149,7 +146,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.ConnectionS
             Assert.AreEqual(RdpColorDepth._Default, settings.RdpColorDepth.Value);
             Assert.AreEqual(RdpAudioMode._Default, settings.RdpAudioMode.Value);
             Assert.AreEqual(RdpRedirectClipboard._Default, settings.RdpRedirectClipboard.Value);
-            Assert.AreEqual(RdpCredentialGenerationBehavior._Default, settings.RdpCredentialGenerationBehavior.Value);
         }
 
         [Test]
@@ -170,7 +166,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.ConnectionS
             Assert.AreEqual(RdpColorDepth._Default, settings.RdpColorDepth.Value);
             Assert.AreEqual(RdpAudioMode._Default, settings.RdpAudioMode.Value);
             Assert.AreEqual(RdpRedirectClipboard._Default, settings.RdpRedirectClipboard.Value);
-            Assert.AreEqual(RdpCredentialGenerationBehavior._Default, settings.RdpCredentialGenerationBehavior.Value);
         }
 
         [Test]
@@ -199,7 +194,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.ConnectionS
             Assert.AreEqual(RdpColorDepth.DeepColor, settings.RdpColorDepth.Value);
             Assert.AreEqual(RdpAudioMode.DoNotPlay, settings.RdpAudioMode.Value);
             Assert.AreEqual(RdpRedirectClipboard.Disabled, settings.RdpRedirectClipboard.Value);
-            Assert.AreEqual(RdpCredentialGenerationBehavior.Allow, settings.RdpCredentialGenerationBehavior.Value);
             Assert.AreEqual(13389, settings.RdpPort.Value);
         }
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Credentials/TestSelectCredentialsWorkflow.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Credentials/TestSelectCredentialsWorkflow.cs
@@ -104,13 +104,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
                 taskDialog);
 
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
-            settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.Allow;
 
             await credentialPrompt
                 .SelectCredentialsAsync(
                     null,
                     SampleInstance,
                     settings,
+                    RdpCredentialGenerationBehavior.Allow,
                     true)
                 .ConfigureAwait(true);
 
@@ -151,7 +151,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
                 false,
                 taskDialog);
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
-            settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.Allow;
             settings.RdpUsername.StringValue = "alice";
             settings.RdpPassword.ClearTextValue = "alicespassword";
 
@@ -160,6 +159,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
                     null,
                     SampleInstance,
                     settings,
+                     RdpCredentialGenerationBehavior.Allow,
                     true)
                 .ConfigureAwait(true);
 
@@ -201,13 +201,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             var credentialPrompt = CreateCredentialsWorkflow(true, false, taskDialog);
 
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
-            settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.AllowIfNoCredentialsFound;
 
             await credentialPrompt
                 .SelectCredentialsAsync(
                     null,
                     SampleInstance,
                     settings,
+                    RdpCredentialGenerationBehavior.AllowIfNoCredentialsFound,
                     true)
                 .ConfigureAwait(true);
 
@@ -246,13 +246,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             var window = this.serviceRegistry.AddMock<IConfigureCredentialsWorkflow>();
 
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
-            settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.AllowIfNoCredentialsFound;
 
             ExceptionAssert.ThrowsAggregateException<TaskCanceledException>(
                 () => credentialPrompt.SelectCredentialsAsync(
                 null,
                 SampleInstance,
                 settings,
+                RdpCredentialGenerationBehavior.AllowIfNoCredentialsFound,
                 true).Wait());
 
             window.Verify(w => w.ShowCredentialsDialog(), Times.Once);
@@ -290,7 +290,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
                 taskDialog);
 
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
-            settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.AllowIfNoCredentialsFound;
             settings.RdpUsername.StringValue = "alice";
             settings.RdpPassword.ClearTextValue = "alicespassword";
 
@@ -299,6 +298,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
                     null,
                     SampleInstance,
                     settings,
+                    RdpCredentialGenerationBehavior.AllowIfNoCredentialsFound,
                     true)
                 .ConfigureAwait(true);
 
@@ -341,13 +341,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             var window = this.serviceRegistry.AddMock<IConfigureCredentialsWorkflow>();
 
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
-            settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.Disallow;
 
             ExceptionAssert.ThrowsAggregateException<TaskCanceledException>(
                 () => credentialPrompt.SelectCredentialsAsync(
                 null,
                 SampleInstance,
                 settings,
+                RdpCredentialGenerationBehavior.Disallow,
                 true).Wait());
 
             window.Verify(w => w.ShowCredentialsDialog(), Times.Once);
@@ -381,13 +381,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             var credentialPrompt = CreateCredentialsWorkflow(true, false, taskDialog);
 
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
-            settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.Disallow;
 
             await credentialPrompt
                 .SelectCredentialsAsync(
                     null,
                     SampleInstance,
                     settings,
+                    RdpCredentialGenerationBehavior.Disallow,
                     false)
                 .ConfigureAwait(true);
 
@@ -425,7 +425,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             var credentialPrompt = CreateCredentialsWorkflow(true, false, taskDialog);
 
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
-            settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.Disallow;
             settings.RdpUsername.StringValue = "alice";
             settings.RdpPassword.ClearTextValue = "alicespassword";
 
@@ -434,6 +433,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
                     null,
                     SampleInstance,
                     settings,
+                    RdpCredentialGenerationBehavior.Disallow,
                     true)
                 .ConfigureAwait(true);
 
@@ -465,13 +465,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             var credentialPrompt = CreateCredentialsWorkflow(true, true, taskDialog);
 
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
-            settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.Force;
 
             await credentialPrompt
                 .SelectCredentialsAsync(
                     null,
                     SampleInstance,
                     settings,
+                    RdpCredentialGenerationBehavior.Force,
                     true)
                 .ConfigureAwait(true);
 
@@ -511,13 +511,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Credentials
             var window = this.serviceRegistry.AddMock<IConfigureCredentialsWorkflow>();
 
             var settings = InstanceConnectionSettings.CreateNew(SampleInstance);
-            settings.RdpCredentialGenerationBehavior.EnumValue = RdpCredentialGenerationBehavior.Force;
 
             ExceptionAssert.ThrowsAggregateException<TaskCanceledException>(
                 () => credentialPrompt.SelectCredentialsAsync(
                 null,
                 SampleInstance,
                 settings,
+                RdpCredentialGenerationBehavior.Force,
                 true).Wait());
 
             window.Verify(w => w.ShowCredentialsDialog(), Times.Once);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Data/RdpSessionParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Data/RdpSessionParameters.cs
@@ -33,7 +33,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Data
     {
         internal static readonly int DefaultTimeoutInSeconds = 30;
 
-        public RdpCredentials Credentials { get; }
+        public RdpCredentials Credentials { get; set; }
 
         public TimeSpan ConnectionTimeout { get; set;  } = TimeSpan.FromSeconds(DefaultTimeoutInSeconds);
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Data/RdpSessionParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Data/RdpSessionParameters.cs
@@ -77,6 +77,22 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Data
             this.Password = password;
             this.Domain = domain;
         }
+
+        public override string ToString()
+        {
+            if (!string.IsNullOrEmpty(this.Domain) && !string.IsNullOrEmpty(this.User))
+            {
+                return $"{this.Domain}\\{this.User}";
+            }
+            else if (!string.IsNullOrEmpty(this.User))
+            {
+                return this.User;
+            }
+            else
+            {
+                return "(empty)";
+            }
+        }
     }
 
     //-------------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Data/RdpSessionParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Data/RdpSessionParameters.cs
@@ -53,7 +53,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Data
         public RdpHookWindowsKeys HookWindowsKeys { get; set; } = RdpHookWindowsKeys._Default;
 
         public RdpUserAuthenticationBehavior UserAuthenticationBehavior { get; set; } = RdpUserAuthenticationBehavior._Default;
-        public RdpCredentialGenerationBehavior CredentialGenerationBehavior { get; set; } = RdpCredentialGenerationBehavior._Default;
 
         public RdpSessionParameters(RdpCredentials credentials)
         {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Google.Solutions.IapDesktop.Extensions.Shell.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Google.Solutions.IapDesktop.Extensions.Shell.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Services\Connection\ConnectionTemplate.cs" />
     <Compile Include="Data\RdpSessionParameters.cs" />
     <Compile Include="Data\SshSessionParameters.cs" />
+    <Compile Include="Services\Connection\RdpCredentialCallbackService.cs" />
     <Compile Include="Services\Ssh\IAuthorizedPublicKey.cs" />
     <Compile Include="Services\Ssh\MetadataAuthorizedPublicKey.cs" />
     <Compile Include="Services\Ssh\MetadataAuthorizedPublicKeySet.cs" />

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/RdpConnectionService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/RdpConnectionService.cs
@@ -104,7 +104,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection
                 NetworkLevelAuthentication = settings.RdpNetworkLevelAuthentication.EnumValue,
 
                 UserAuthenticationBehavior = settings.RdpUserAuthenticationBehavior.EnumValue,
-                CredentialGenerationBehavior = settings.RdpCredentialGenerationBehavior.EnumValue,
                 
                 RedirectClipboard = settings.RdpRedirectClipboard.EnumValue,
                 RedirectPrinter = settings.RdpRedirectPrinter.EnumValue,
@@ -146,6 +145,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection
                         this.window,
                         vmNode.Instance,
                         settings.TypedCollection,
+                        RdpCredentialGenerationBehavior.AllowIfNoCredentialsFound,
                         true)
                     .ConfigureAwait(true);
 
@@ -203,6 +203,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection
             }
             else
             {
+                if (!url.TryGetParameter<RdpCredentialGenerationBehavior>(
+                    "CredentialGenerationBehavior", 
+                    out var allowedBehavior))
+                {
+                    allowedBehavior = RdpCredentialGenerationBehavior._Default;
+                }
+
                 //
                 // Show prompt, but don't persist any generated credentials.
                 //
@@ -210,6 +217,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection
                         this.window,
                         url.Instance,
                         settings,
+                        allowedBehavior,
                         false)
                     .ConfigureAwait(true);
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/RdpConnectionService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/RdpConnectionService.cs
@@ -130,7 +130,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection
         {
             Debug.Assert(vmNode.IsRdpSupported());
 
+            //
             // Select node so that tracking windows are updated.
+            //
             await this.projectModelService.SetActiveNodeAsync(
                     vmNode,
                     CancellationToken.None)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/RdpCredentialCallbackService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/RdpCredentialCallbackService.cs
@@ -1,13 +1,31 @@
-﻿using Google.Solutions.Common.Security;
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Security;
 using Google.Solutions.IapDesktop.Application.ObjectModel;
 using Google.Solutions.IapDesktop.Application.Services.Adapters;
 using Google.Solutions.IapDesktop.Extensions.Shell.Data;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/RdpCredentialCallbackService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/RdpCredentialCallbackService.cs
@@ -1,0 +1,89 @@
+﻿using Google.Solutions.Common.Security;
+using Google.Solutions.IapDesktop.Application.ObjectModel;
+using Google.Solutions.IapDesktop.Application.Services.Adapters;
+using Google.Solutions.IapDesktop.Extensions.Shell.Data;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection
+{
+    public interface IRdpCredentialCallbackService
+    {
+        Task<RdpCredentials> GetCredentialsAsync(
+            Uri callbackUrl,
+            CancellationToken cancellationToken);
+    }
+
+    [Service(typeof(IRdpCredentialCallbackService))]
+    public class RdpCredentialCallbackService : IRdpCredentialCallbackService
+    {
+        private readonly IExternalRestAdapter restAdapter;
+
+        public RdpCredentialCallbackService(IExternalRestAdapter restAdapter)
+        {
+            this.restAdapter = restAdapter;
+        }
+
+        public async Task<RdpCredentials> GetCredentialsAsync( // TODO: Test
+            Uri callbackUrl, 
+            CancellationToken cancellationToken)
+        {
+            try
+            {
+                var response = await this.restAdapter
+                    .GetAsync<CredentialCallbackResponse>(callbackUrl, cancellationToken)
+                    .ConfigureAwait(false);
+
+                if (response != null)
+                {
+                    return new RdpCredentials(
+                        response.User,
+                        response.Domain,
+                        SecureStringExtensions.FromClearText(response.Password));
+                }
+                else
+                {
+                    return RdpCredentials.Empty;
+                }
+            }
+            catch (HttpRequestException e)
+            {
+                throw new CredentialCallbackException(
+                    $"Invoking the credential callback endpoint at {callbackUrl} failed " +
+                    $"and no credentials were obtained",
+                    e);
+            }
+        }
+
+        //---------------------------------------------------------------------
+        // Response entity. 
+        //---------------------------------------------------------------------
+
+        public class CredentialCallbackResponse
+        {
+            [JsonProperty("User")]
+            public string User { get; set; }
+
+            [JsonProperty("Domain")]
+            public string Domain { get; set; }
+
+            [JsonProperty("Password")]
+            public string Password { get; set; }
+        }
+    }
+
+    public class CredentialCallbackException : Exception
+    {
+        public CredentialCallbackException(
+            string message, 
+            Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/RdpCredentialCallbackService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/RdpCredentialCallbackService.cs
@@ -59,6 +59,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection
                     $"and no credentials were obtained",
                     e);
             }
+            catch (JsonException e)
+            {
+                throw new CredentialCallbackException(
+                    $"The credential callback endpoint at {callbackUrl} returned " +
+                    $"an invalid result",
+                    e);
+            }
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/SshConnectionService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/SshConnectionService.cs
@@ -94,7 +94,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection
         {
             Debug.Assert(vmNode.IsSshSupported());
 
+            //
             // Select node so that tracking windows are updated.
+            //
             await this.projectModelService.SetActiveNodeAsync(
                     vmNode,
                     CancellationToken.None)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ConnectionSettings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ConnectionSettings/ConnectionSettings.cs
@@ -57,7 +57,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.ConnectionSettin
         public RegistryEnumSetting<RdpBitmapPersistence> RdpBitmapPersistence { get; private set; }
         public RegistryEnumSetting<RdpNetworkLevelAuthentication> RdpNetworkLevelAuthentication { get; private set; }
         public RegistryDwordSetting RdpConnectionTimeout { get; private set; }
-        public RegistryEnumSetting<RdpCredentialGenerationBehavior> RdpCredentialGenerationBehavior { get; private set; }
         public RegistryDwordSetting RdpPort { get; private set; }
         public RegistryEnumSetting<RdpRedirectClipboard> RdpRedirectClipboard { get; private set; }
         public RegistryEnumSetting<RdpRedirectPrinter> RdpRedirectPrinter { get; private set; }
@@ -81,7 +80,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.ConnectionSettin
             this.RdpBitmapPersistence,
             this.RdpNetworkLevelAuthentication,
             this.RdpConnectionTimeout,
-            this.RdpCredentialGenerationBehavior,
             this.RdpPort,
             this.RdpRedirectClipboard,
             this.RdpRedirectPrinter,
@@ -224,13 +222,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.ConnectionSettin
                 RdpSessionParameters.DefaultTimeoutInSeconds,
                 key,
                 0, 300);
-            this.RdpCredentialGenerationBehavior = RegistryEnumSetting<RdpCredentialGenerationBehavior>.FromKey(
-                "CredentialGenerationBehavior",
-                null, // Hidden.
-                null, // Hidden.
-                null, // Hidden.
-                Data.RdpCredentialGenerationBehavior._Default,
-                key);
             this.RdpPort = RegistryDwordSetting.FromKey(
                 "RdpPort",
                 "Server port",
@@ -353,8 +344,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.ConnectionSettin
                 baseSettings.RdpNetworkLevelAuthentication.OverlayBy(overlaySettings.RdpNetworkLevelAuthentication);
             prototype.RdpConnectionTimeout = (RegistryDwordSetting)
                 baseSettings.RdpConnectionTimeout.OverlayBy(overlaySettings.RdpConnectionTimeout);
-            prototype.RdpCredentialGenerationBehavior = (RegistryEnumSetting<RdpCredentialGenerationBehavior>)
-                baseSettings.RdpCredentialGenerationBehavior.OverlayBy(overlaySettings.RdpCredentialGenerationBehavior);
             prototype.RdpPort = (RegistryDwordSetting)
                 baseSettings.RdpPort.OverlayBy(overlaySettings.RdpPort);
             prototype.RdpRedirectClipboard = (RegistryEnumSetting<RdpRedirectClipboard>)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ConnectionSettings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ConnectionSettings/ConnectionSettings.cs
@@ -451,7 +451,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.ConnectionSettin
                 .Where(s => !(s is RegistrySecureStringSetting)))
             {
                 var value = url.Parameters.Get(setting.Key);
-                if (value != null)
+                if (!string.IsNullOrEmpty(value))
                 {
                     try
                     {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Credentials/SelectCredentialsWorkflow.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Credentials/SelectCredentialsWorkflow.cs
@@ -40,6 +40,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Credentials
            IWin32Window owner,
            InstanceLocator instanceLocator,
            ConnectionSettingsBase settings,
+           RdpCredentialGenerationBehavior allowedBehavior,
            bool allowJumpToSettings);
     }
 
@@ -80,6 +81,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Credentials
             IWin32Window owner,
             InstanceLocator instanceLocator,
             ConnectionSettingsBase settings,
+            RdpCredentialGenerationBehavior allowedBehavior,
             bool allowJumpToSettings)
         {
             var credentialsService = this.serviceProvider.GetService<ICreateCredentialsWorkflow>();
@@ -91,7 +93,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Credentials
                 !string.IsNullOrEmpty(settings.RdpUsername.StringValue) &&
                 !string.IsNullOrEmpty(settings.RdpPassword.ClearTextValue);
 
-            if (settings.RdpCredentialGenerationBehavior.EnumValue == RdpCredentialGenerationBehavior.Force
+            if (allowedBehavior == RdpCredentialGenerationBehavior.Force
                 && await IsGrantedPermissionToGenerateCredentials(
                             credentialsService,
                             instanceLocator)
@@ -109,12 +111,12 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Credentials
 
             var options = new List<CredentialOption>();
             if ((!credentialsExist
-                    && settings.RdpCredentialGenerationBehavior.EnumValue == RdpCredentialGenerationBehavior.AllowIfNoCredentialsFound
+                    && allowedBehavior == RdpCredentialGenerationBehavior.AllowIfNoCredentialsFound
                     && await IsGrantedPermissionToGenerateCredentials(
                                 credentialsService,
                                 instanceLocator)
                             .ConfigureAwait(true))
-                || settings.RdpCredentialGenerationBehavior.EnumValue == RdpCredentialGenerationBehavior.Allow)
+                || allowedBehavior == RdpCredentialGenerationBehavior.Allow)
             {
                 options.Add(
                     new CredentialOption()

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Diagnostics/DiagnosticsCommands.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Diagnostics/DiagnosticsCommands.cs
@@ -137,6 +137,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Diagnostics
                 WriteTextbox("Username");
                 WriteTextbox("Domain");
                 WriteTextbox("RdpPort");
+                WriteTextbox("CredentialCallbackUrl");
                 WriteCombobox<RdpConnectionBarState>("ConnectionBarState");
                 WriteCombobox<RdpDesktopSize>("DesktopSize");
                 WriteCombobox<RdpColorDepth>("ColorDepth");
@@ -197,7 +198,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Diagnostics
                     buffer.AppendLine("<div class='input-wrapper'>");
                     buffer.AppendLine($"<label for='name'>{fieldName}</label>");
                     buffer.AppendLine("<br />");
-                    buffer.AppendLine($"<input name='{fieldName}' size='20' />");
+                    buffer.AppendLine($"<input name='{fieldName}' size='40' />");
                     buffer.AppendLine("</div>");
                 }
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/RemoteDesktopView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/RemoteDesktopView.cs
@@ -195,13 +195,16 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.RemoteDesktop
 #if DEBUG
             var statusLabel = new Label()
             {
-                Location = Point.Empty
+                Location = Point.Empty,
+                Font = new Font(FontFamily.GenericSansSerif, 7f),
+                AutoSize = false,
+                Size = new Size(210, 270)
             };
             this.Controls.Add(statusLabel);
             statusLabel.BindReadonlyObservableProperty(
                 c => c.Text,
                 viewModel,
-                m => m.StatusText,
+                m => m.DiagnosticsStatusText,
                 bindingContext);
 #endif
         }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/RemoteDesktopViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/RemoteDesktop/RemoteDesktopViewModel.cs
@@ -20,6 +20,7 @@
 //
 
 using Google.Apis.Util;
+using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.Common.Locator;
 using Google.Solutions.IapDesktop.Application.ObjectModel;
 using Google.Solutions.IapDesktop.Extensions.Shell.Data;
@@ -44,7 +45,12 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.RemoteDesktop
         public RemoteDesktopViewModel()
         {
             this.State = ObservableProperty.Build(ConnectionState.Uninitialized);
-            this.StatusText = ObservableProperty.Build(this.State, s => s.ToString());
+
+#if DEBUG
+            this.DiagnosticsStatusText = ObservableProperty.Build(
+                this.State, 
+                s => s.ToString() + "\n\n" + this.Parameters.DumpProperties());
+#endif
         }
 
         //---------------------------------------------------------------------
@@ -68,6 +74,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.RemoteDesktop
         //---------------------------------------------------------------------
 
         public ObservableProperty<ConnectionState> State { get; }
-        public ObservableFunc<string> StatusText { get; }
+
+#if DEBUG
+        public ObservableFunc<string> DiagnosticsStatusText { get; }
+#endif
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/ConnectInstanceCommand.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/ConnectInstanceCommand.cs
@@ -110,6 +110,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
                         this.AllowPersistentRdpCredentials)
                     .ConfigureAwait(true);
 
+                Debug.Assert(this.AllowPersistentRdpCredentials || template.Session.Credentials.Password == null);
+
                 session = this.sessionBroker
                     .GetInstance()
                     .Connect(template);

--- a/sources/scripts/credential-callback-server.ps1
+++ b/sources/scripts/credential-callback-server.ps1
@@ -1,0 +1,46 @@
+#
+# Copyright 2023 Google LLC
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Http Server
+$Listener = [System.Net.HttpListener]::new() 
+$Listener.Prefixes.Add("http://localhost:8080/")
+$Listener.Start()
+
+if ($Listener.IsListening) {
+    Write-Host " HTTP Server Ready! " -f 'black' -b 'gre'
+}
+
+while ($Listener.IsListening) {
+    $Context = $Listener.GetContext()
+
+    Write-Host "$($Context.Request.UserHostAddress)  =>  $($context.Request.Url)" -f 'mag'
+
+    [string]$Response = @{
+        "User" = $Context.Request.QueryString["User"]
+        "Domain" = $Context.Request.QueryString["Domain"]
+        "Password" = $Context.Request.QueryString["Password"]
+    } | ConvertTo-Json
+
+    $Buffer = [System.Text.Encoding]::UTF8.GetBytes($Response)
+    $Context.Response.ContentLength64 = $Buffer.Length
+    $Context.Response.OutputStream.Write($Buffer, 0, $Buffer.Length)
+    $Context.Response.OutputStream.Close()
+} 


### PR DESCRIPTION
Add support for `CredentialCallbackUrl` parameter in iap-rdp/// URLs. When set,
credentials are obtained from the specified URL. This is to allow portals to
pass RDP credentials to clients without exposing them in a iap-rdp/// URL.

Ref #872