### PR TITLE
b/274025818 Apply custom timeout for REST requests

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Connection/TestRdpCredentialCallbackService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Services/Connection/TestRdpCredentialCallbackService.cs
@@ -91,6 +91,22 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Services.Connection
         }
 
         [Test]
+        public void WhenServerRequestTimesOut_ThenGetCredentialsThrowsException()
+        {
+            var adapter = new Mock<IExternalRestAdapter>();
+            adapter
+                .Setup(a => a.GetAsync<RdpCredentialCallbackService.CredentialCallbackResponse>(
+                    SampleCallbackUrl,
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new TimeoutException());
+
+            var service = new RdpCredentialCallbackService(adapter.Object);
+
+            ExceptionAssert.ThrowsAggregateException<CredentialCallbackException>(
+                () => service.GetCredentialsAsync(SampleCallbackUrl, CancellationToken.None).Wait());
+        }
+
+        [Test]
         public async Task WhenServerReturnsResult_ThenGetCredentialsReturnsCredentials()
         {
             var adapter = new Mock<IExternalRestAdapter>();

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/RdpCredentialCallbackService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Connection/RdpCredentialCallbackService.cs
@@ -48,7 +48,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection
             this.restAdapter = restAdapter;
         }
 
-        public async Task<RdpCredentials> GetCredentialsAsync( // TODO: Test
+        public async Task<RdpCredentials> GetCredentialsAsync(
             Uri callbackUrl,
             CancellationToken cancellationToken)
         {
@@ -83,6 +83,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection
                     $"The credential callback endpoint at {callbackUrl} returned " +
                     $"an invalid result",
                     e);
+            }
+            catch (Exception e)
+            {
+                throw new CredentialCallbackException(
+                    $"Obtaining credentials from the callback endpoint at {callbackUrl} failed", e);
             }
         }
 


### PR DESCRIPTION
* Extend RestClient to detect timeouts
* Use shorter default timeout
* Show proper error message when credential callback times out