### PR TITLE
b/274050182 Sessions launched via URL lack context menu

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/RemoteDesktop/TestRemoteDesktopView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/RemoteDesktop/TestRemoteDesktopView.cs
@@ -79,7 +79,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
             var broker = new InstanceSessionBroker(serviceProvider);
 
             await AssertRaisesEventAsync<SessionAbortedEvent>(
-                () => broker.Connect(
+                () => broker.ConnectRdpSession(
                     new ConnectionTemplate<RdpSessionParameters>(
                         new TransportParameters(
                             TransportParameters.TransportType.IapTunnel,
@@ -103,7 +103,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
             var broker = new InstanceSessionBroker(serviceProvider);
 
             await AssertRaisesEventAsync<SessionAbortedEvent>(
-                () => broker.Connect(
+                () => broker.ConnectRdpSession(
                     new ConnectionTemplate<RdpSessionParameters>(
                         new TransportParameters(
                             TransportParameters.TransportType.IapTunnel,
@@ -146,7 +146,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
                 var broker = new InstanceSessionBroker(serviceProvider);
 
                 await AssertRaisesEventAsync<SessionAbortedEvent>(
-                    () => broker.Connect(
+                    () => broker.ConnectRdpSession(
                         new ConnectionTemplate<RdpSessionParameters>(
                             new TransportParameters(
                                 TransportParameters.TransportType.IapTunnel,
@@ -218,7 +218,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
                 await AssertRaisesEventAsync<SessionStartedEvent>(
                     () =>
                     {
-                        session = broker.Connect(new ConnectionTemplate<RdpSessionParameters>(
+                        session = broker.ConnectRdpSession(new ConnectionTemplate<RdpSessionParameters>(
                             new TransportParameters(
                                 TransportParameters.TransportType.IapTunnel,
                                 locator,
@@ -259,7 +259,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
                 RemoteDesktopView session = null;
                 await AssertRaisesEventAsync<SessionStartedEvent>(() =>
                     {
-                        session = (RemoteDesktopView)broker.Connect(new ConnectionTemplate<RdpSessionParameters>(
+                        session = (RemoteDesktopView)broker.ConnectRdpSession(new ConnectionTemplate<RdpSessionParameters>(
                             new TransportParameters(
                                 TransportParameters.TransportType.IapTunnel,
                                 locator,
@@ -315,7 +315,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
                 RemoteDesktopView session = null;
                 await AssertRaisesEventAsync<SessionStartedEvent>(() =>
                     {
-                        session = (RemoteDesktopView)broker.Connect(new ConnectionTemplate<RdpSessionParameters>(
+                        session = (RemoteDesktopView)broker.ConnectRdpSession(new ConnectionTemplate<RdpSessionParameters>(
                             new TransportParameters(
                                 TransportParameters.TransportType.IapTunnel,
                                 locator,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/RemoteDesktop/TestRemoteDesktopViewWithGroupPolicies.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/RemoteDesktop/TestRemoteDesktopViewWithGroupPolicies.cs
@@ -88,7 +88,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
             var parameters = await CreateSessionParametersAsync(instanceLocator)
                 .ConfigureAwait(true);
 
-            return broker.Connect(
+            return broker.ConnectRdpSession(
                 new ConnectionTemplate<RdpSessionParameters>(
                     new TransportParameters(
                         TransportParameters.TransportType.IapTunnel,
@@ -138,7 +138,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
                 var broker = new InstanceSessionBroker(serviceProvider);
 
                 await AssertRaisesEventAsync<SessionAbortedEvent>(
-                    () => broker.Connect(
+                    () => broker.ConnectRdpSession(
                         new ConnectionTemplate<RdpSessionParameters>(
                             new TransportParameters(
                                 TransportParameters.TransportType.IapTunnel,
@@ -171,7 +171,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.RemoteDesktop
                 parameters.NetworkLevelAuthentication = RdpNetworkLevelAuthentication.Disabled;
 
                 var broker = new InstanceSessionBroker(serviceProvider);
-                var session = broker.Connect(
+                var session = broker.ConnectRdpSession(
                     new ConnectionTemplate<RdpSessionParameters>(
                         new TransportParameters(
                             TransportParameters.TransportType.IapTunnel,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Session/TestConnectCommands.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Session/TestConnectCommands.cs
@@ -89,8 +89,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
                 new Service<IRdpConnectionService>(serviceProvider.Object),
                 new Service<ISshConnectionService>(serviceProvider.Object),
                 new Service<IProjectModelService>(serviceProvider.Object),
-                new Service<IInstanceSessionBroker>(serviceProvider.Object),
-                new Mock<ICommandContainer<ISession>>().Object);
+                new Service<IInstanceSessionBroker>(serviceProvider.Object));
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Session/TestConnectCommands.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Session/TestConnectCommands.cs
@@ -122,7 +122,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             var sessionBroker = new Mock<IInstanceSessionBroker>();
             sessionBroker
-                .Setup(s => s.Connect(RdpConnectionTemplate))
+                .Setup(s => s.ConnectRdpSession(RdpConnectionTemplate))
                 .Returns(new Mock<IRemoteDesktopSession>().Object);
 
             var urlCommands = new UrlCommands();
@@ -223,7 +223,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             var sessionBroker = new Mock<IInstanceSessionBroker>();
             sessionBroker
-                .Setup(s => s.Connect(RdpConnectionTemplate))
+                .Setup(s => s.ConnectRdpSession(RdpConnectionTemplate))
                 .Returns(new Mock<IRemoteDesktopSession>().Object);
 
             var commands = CreateConnectCommands(
@@ -256,7 +256,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             var sessionBroker = new Mock<IInstanceSessionBroker>();
             sessionBroker
-                .Setup(s => s.ConnectAsync(SshConnectionTemplate))
+                .Setup(s => s.ConnectSshSessionAsync(SshConnectionTemplate))
                 .ReturnsAsync(new Mock<ISshTerminalSession>().Object);
 
             var commands = CreateConnectCommands(
@@ -360,7 +360,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             var sessionBroker = new Mock<IInstanceSessionBroker>();
             sessionBroker
-                .Setup(s => s.Connect(RdpConnectionTemplate))
+                .Setup(s => s.ConnectRdpSession(RdpConnectionTemplate))
                 .Returns(new Mock<IRemoteDesktopSession>().Object);
 
             var commands = CreateConnectCommands(
@@ -393,7 +393,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             var sessionBroker = new Mock<IInstanceSessionBroker>();
             sessionBroker
-                .Setup(s => s.ConnectAsync(SshConnectionTemplate))
+                .Setup(s => s.ConnectSshSessionAsync(SshConnectionTemplate))
                 .ReturnsAsync(new Mock<ISshTerminalSession>().Object);
 
             var commands = CreateConnectCommands(
@@ -498,7 +498,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             var sessionBroker = new Mock<IInstanceSessionBroker>();
             sessionBroker
-                .Setup(s => s.Connect(RdpConnectionTemplate))
+                .Setup(s => s.ConnectRdpSession(RdpConnectionTemplate))
                 .Returns(new Mock<IRemoteDesktopSession>().Object);
 
             var commands = CreateConnectCommands(
@@ -604,7 +604,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             var sessionBroker = new Mock<IInstanceSessionBroker>();
             sessionBroker
-                .Setup(s => s.ConnectAsync(SshConnectionTemplate))
+                .Setup(s => s.ConnectSshSessionAsync(SshConnectionTemplate))
                 .ReturnsAsync(new Mock<ISshTerminalSession>().Object);
 
             var commands = CreateConnectCommands(
@@ -686,7 +686,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             var sessionBroker = new Mock<IInstanceSessionBroker>();
             sessionBroker
-                .Setup(s => s.ConnectAsync(SshConnectionTemplate))
+                .Setup(s => s.ConnectSshSessionAsync(SshConnectionTemplate))
                 .ReturnsAsync(new Mock<ISshTerminalSession>().Object);
 
             var commands = CreateConnectCommands(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Session/TestConnectInstanceComand.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Session/TestConnectInstanceComand.cs
@@ -76,7 +76,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             return new ConnectInstanceCommand(
                 "&test",
-                new Mock<ICommandContainer<ISession>>().Object,
                 new Service<IRdpConnectionService>(serviceProvider.Object),
                 new Service<ISshConnectionService>(serviceProvider.Object),
                 new Service<IInstanceSessionBroker>(serviceProvider.Object))

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Session/TestConnectInstanceComand.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Session/TestConnectInstanceComand.cs
@@ -138,7 +138,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             var sessionBroker = new Mock<IInstanceSessionBroker>();
             sessionBroker
-                .Setup(s => s.Connect(RdpConnectionTemplate))
+                .Setup(s => s.ConnectRdpSession(RdpConnectionTemplate))
                 .Returns(new Mock<IRemoteDesktopSession>().Object);
             ISession nullSession;
             sessionBroker
@@ -173,7 +173,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             var sessionBroker = new Mock<IInstanceSessionBroker>();
             sessionBroker
-                .Setup(s => s.ConnectAsync(SshConnectionTemplate))
+                .Setup(s => s.ConnectSshSessionAsync(SshConnectionTemplate))
                 .ReturnsAsync(new Mock<ISshTerminalSession>().Object);
 
             var session = (ISession)new Mock<ISshTerminalSession>().Object;
@@ -210,7 +210,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             var sessionBroker = new Mock<IInstanceSessionBroker>();
             sessionBroker
-                .Setup(s => s.ConnectAsync(SshConnectionTemplate))
+                .Setup(s => s.ConnectSshSessionAsync(SshConnectionTemplate))
                 .ReturnsAsync(new Mock<ISshTerminalSession>().Object);
 
             var command = CreateCommand(
@@ -244,7 +244,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
 
             var sessionBroker = new Mock<IInstanceSessionBroker>();
             sessionBroker
-                .Setup(s => s.ConnectAsync(SshConnectionTemplate))
+                .Setup(s => s.ConnectSshSessionAsync(SshConnectionTemplate))
                 .ReturnsAsync(new Mock<ISshTerminalSession>().Object);
 
             ISession nullSession;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Session/TestConnectRdpUrlCommand.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Session/TestConnectRdpUrlCommand.cs
@@ -98,7 +98,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
             ISession nullSession;
             var rdpSessionBroker = serviceProvider.AddMock<IInstanceSessionBroker>();
             rdpSessionBroker
-                .Setup(s => s.Connect(RdpConnectionTemplate))
+                .Setup(s => s.ConnectRdpSession(RdpConnectionTemplate))
                 .Returns(new Mock<IRemoteDesktopSession>().Object);
             rdpSessionBroker
                 .Setup(s => s.TryActivate(SampleLocator, out nullSession))

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Session/TestInstanceSessionBroker.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/Session/TestInstanceSessionBroker.cs
@@ -131,7 +131,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.Session
                 var broker = new InstanceSessionBroker(serviceProvider);
                 IRemoteDesktopSession session = null;
                 await AssertRaisesEventAsync<SessionStartedEvent>(
-                        () => session = (RemoteDesktopView)broker.Connect(template))
+                        () => session = (RemoteDesktopView)broker.ConnectRdpSession(template))
                     .ConfigureAwait(true);
 
                 Assert.IsNull(this.ExceptionShown);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshTerminalView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell.Test/Views/SshTerminal/TestSshTerminalView.cs
@@ -144,7 +144,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
                 async () =>
                 {
                     pane = (SshTerminalView)await broker
-                        .ConnectAsync(template)
+                        .ConnectSshSessionAsync(template)
                         .ConfigureAwait(true);
                 })
                 .ConfigureAwait(true);
@@ -216,7 +216,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
                     TimeSpan.FromSeconds(10)));
 
             await AssertRaisesEventAsync<SessionAbortedEvent>(
-                () => broker.ConnectAsync(template))
+                () => broker.ConnectSshSessionAsync(template))
                 .ConfigureAwait(true);
 
             Assert.IsInstanceOf(typeof(SocketException), this.ExceptionShown);
@@ -246,7 +246,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
                     TimeSpan.FromSeconds(10)));
 
             await AssertRaisesEventAsync<SessionAbortedEvent>(
-                () => broker.ConnectAsync(template))
+                () => broker.ConnectSshSessionAsync(template))
                 .ConfigureAwait(true);
 
             Assert.IsInstanceOf(typeof(SocketException), this.ExceptionShown);
@@ -282,7 +282,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Test.Views.SshTerminal
                     TimeSpan.FromSeconds(10)));
 
             await AssertRaisesEventAsync<SessionAbortedEvent>(
-                () => broker.ConnectAsync(template))
+                () => broker.ConnectSshSessionAsync(template))
                 .ConfigureAwait(true);
 
             Assert.IsInstanceOf(typeof(MetadataKeyAuthenticationFailedException), this.ExceptionShown);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ShellExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/ShellExtension.cs
@@ -52,7 +52,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
     {
         private readonly IServiceProvider serviceProvider;
         private readonly IWin32Window window;
-        private readonly ICommandContainer<ISession> sessionCommands;
 
         private static CommandState GetToolbarCommandStateWhenRunningWindowsInstanceRequired(
             IProjectModelNode node)
@@ -115,27 +114,14 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
             var mainForm = serviceProvider.GetService<IMainWindow>();
 
             //
-            // Session menu.
-            //
-            // On pop-up of the menu, query the active session and use it as context.
-            //
-            this.sessionCommands = mainForm.AddMenu(
-                "&Session", 1,
-                () => this.serviceProvider
-                    .GetService<IGlobalSessionBroker>()
-                    .ActiveSession);
-
-            //
             // Let this extension handle all URL activations.
             //
-            var sessionCommands = new SessionCommands();
             var connectCommands = new ConnectCommands(
                 serviceProvider.GetService<UrlCommands>(),
                 serviceProvider.GetService<Service<IRdpConnectionService>>(),
                 serviceProvider.GetService<Service<ISshConnectionService>>(),
                 serviceProvider.GetService<Service<IProjectModelService>>(),
-                serviceProvider.GetService<Service<IInstanceSessionBroker>>(),
-                this.sessionCommands);
+                serviceProvider.GetService<Service<IInstanceSessionBroker>>());
             Debug.Assert(serviceProvider
                 .GetService<UrlCommands>()
                 .LaunchRdpUrl.QueryState(new IapRdpUrl(
@@ -223,15 +209,16 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services
             //
             // Session menu.
             //
-
-            this.sessionCommands.AddCommand(sessionCommands.EnterFullScreenOnSingleScreen);
-            this.sessionCommands.AddCommand(sessionCommands.EnterFullScreenOnAllScreens);
-            this.sessionCommands.AddCommand(connectCommands.DuplicateSession);
-            this.sessionCommands.AddCommand(sessionCommands.Disconnect);
-            this.sessionCommands.AddSeparator();
-            this.sessionCommands.AddCommand(sessionCommands.DownloadFiles);
-            this.sessionCommands.AddCommand(sessionCommands.ShowSecurityScreen);
-            this.sessionCommands.AddCommand(sessionCommands.ShowTaskManager);
+            var sessionCommands = new SessionCommands();
+            var menu = serviceProvider.GetService<IInstanceSessionBroker>().SessionMenu;
+            menu.AddCommand(sessionCommands.EnterFullScreenOnSingleScreen);
+            menu.AddCommand(sessionCommands.EnterFullScreenOnAllScreens);
+            menu.AddCommand(connectCommands.DuplicateSession);
+            menu.AddCommand(sessionCommands.Disconnect);
+            menu.AddSeparator();
+            menu.AddCommand(sessionCommands.DownloadFiles);
+            menu.AddCommand(sessionCommands.ShowSecurityScreen);
+            menu.AddCommand(sessionCommands.ShowTaskManager);
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/ConnectCommands.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/ConnectCommands.cs
@@ -40,8 +40,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
             Service<IRdpConnectionService> rdpConnectionService,
             Service<ISshConnectionService> sshConnectionService,
             Service<IProjectModelService> modelService,
-            Service<IInstanceSessionBroker> sessionBroker,
-            ICommandContainer<ISession> sessionContextMenu)
+            Service<IInstanceSessionBroker> sessionBroker)
         {
             //
             // Install command for launching URLs.
@@ -52,7 +51,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
 
             this.ToolbarActivateOrConnectInstance = new ConnectInstanceCommand(
                 "&Connect",
-                sessionContextMenu,
                 rdpConnectionService,
                 sshConnectionService,
                 sessionBroker)
@@ -65,7 +63,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
             };
             this.ContextMenuActivateOrConnectInstance = new ConnectInstanceCommand(
                 "&Connect",
-                sessionContextMenu,
                 rdpConnectionService,
                 sshConnectionService,
                 sessionBroker)
@@ -78,7 +75,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
             };
             this.ContextMenuConnectRdpAsUser = new ConnectInstanceCommand(
                 "Connect &as user...",
-                sessionContextMenu,
                 rdpConnectionService,
                 sshConnectionService,
                 sessionBroker)
@@ -91,7 +87,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
             };
             this.ContextMenuConnectSshInNewTerminal = new ConnectInstanceCommand(
                 "Connect in &new terminal",
-                sessionContextMenu,
                 rdpConnectionService,
                 sshConnectionService,
                 sessionBroker)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/ConnectInstanceCommand.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/ConnectInstanceCommand.cs
@@ -38,7 +38,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
     /// </summary>
     internal class ConnectInstanceCommand : ConnectInstanceCommandBase<IProjectModelNode>
     {
-        private readonly ICommandContainer<ISession> sessionContextMenu;
         private readonly Service<IRdpConnectionService> rdpConnectionService;
         private readonly Service<ISshConnectionService> sshConnectionService;
         private readonly Service<IInstanceSessionBroker> sessionBroker;
@@ -50,13 +49,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
 
         public ConnectInstanceCommand(
             string text,
-            ICommandContainer<ISession> sessionContextMenu,
             Service<IRdpConnectionService> rdpConnectionService,
             Service<ISshConnectionService> sshConnectionService,
             Service<IInstanceSessionBroker> sessionBroker)
             : base(text)
         {
-            this.sessionContextMenu = sessionContextMenu;
             this.rdpConnectionService = rdpConnectionService;
             this.sshConnectionService = sshConnectionService;
             this.sessionBroker = sessionBroker;
@@ -130,16 +127,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
             }
 
             Debug.Assert(session != null);
-
-            if (session != null &&
-                session is SessionViewBase sessionPane &&
-                sessionPane.ContextCommands == null)
-            {
-                //
-                // Use commands from Session menu as context menu.
-                //
-                sessionPane.ContextCommands = this.sessionContextMenu;
-            }
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/ConnectInstanceCommand.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/ConnectInstanceCommand.cs
@@ -111,7 +111,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
 
                 session = this.sessionBroker
                     .GetInstance()
-                    .Connect(template);
+                    .ConnectRdpSession(template);
             }
             else if (instanceNode.IsSshSupported())
             {
@@ -122,7 +122,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
 
                 session = await this.sessionBroker
                     .GetInstance()
-                    .ConnectAsync(template)
+                    .ConnectSshSessionAsync(template)
                     .ConfigureAwait(true);
             }
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/ConnectRdpUrlCommand.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/ConnectRdpUrlCommand.cs
@@ -80,7 +80,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
 
                 var session = this.sessionBroker
                     .GetInstance()
-                    .Connect(template);
+                    .ConnectRdpSession(template);
 
                 Debug.Assert(session != null);
             }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/SessionBroker.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/SessionBroker.cs
@@ -64,6 +64,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
         private readonly IMainWindow mainForm;
 
 
+        private void OnSessionConnected(SessionViewBase session)
+        {
+            //
+            // Add context menu.
+            //
+            Debug.Assert(session.ContextCommands == null);
+            session.ContextCommands = this.SessionMenu;
+        }
+
         public InstanceSessionBroker(IServiceProvider serviceProvider)
         {
             this.mainForm = serviceProvider.GetService<IMainWindow>();
@@ -153,8 +162,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
             await session.ConnectAsync()
                 .ConfigureAwait(false);
 
-            Debug.Assert(session.ContextCommands == null);
-            session.ContextCommands = this.SessionMenu;
+            OnSessionConnected(session);
 
             return session;
         }
@@ -177,8 +185,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
 
             session.Connect();
 
-            Debug.Assert(session.ContextCommands == null);
-            session.ContextCommands = this.SessionMenu;
+            OnSessionConnected(session);
 
             return session;
         }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/SessionBroker.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/SessionBroker.cs
@@ -27,7 +27,9 @@ using Google.Solutions.IapDesktop.Extensions.Shell.Data;
 using Google.Solutions.IapDesktop.Extensions.Shell.Services.Connection;
 using Google.Solutions.IapDesktop.Extensions.Shell.Views.RemoteDesktop;
 using Google.Solutions.IapDesktop.Extensions.Shell.Views.SshTerminal;
+using Google.Solutions.Mvvm.Binding.Commands;
 using System;
+using System.Diagnostics;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -46,23 +48,40 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
         /// </summary>
         IRemoteDesktopSession Connect(
             ConnectionTemplate<RdpSessionParameters> template);
+
+        /// <summary>
+        /// Command menu for sessions, exposed in the main menu
+        /// and as context menu.
+        /// </summary>
+        ICommandContainer<ISession> SessionMenu { get; }
     }
 
     [Service(typeof(IInstanceSessionBroker), ServiceLifetime.Singleton, ServiceVisibility.Global)]
     [ServiceCategory(typeof(ISessionBroker))]
     public class InstanceSessionBroker : IInstanceSessionBroker
     {
-
         private readonly IServiceProvider serviceProvider;
         private readonly IMainWindow mainForm;
+
 
         public InstanceSessionBroker(IServiceProvider serviceProvider)
         {
             this.mainForm = serviceProvider.GetService<IMainWindow>();
             this.serviceProvider = serviceProvider;
 
+            //
             // NB. The ServiceCategory attribute causes this class to be 
             // announced to the global connection broker.
+            //
+
+            //
+            // Register Session menu.
+            //
+            // On pop-up of the menu, query the active session and use it as context.
+            //
+            this.SessionMenu = this.mainForm.AddMenu(
+                "&Session", 1,
+                () => this.ActiveSession);
         }
 
         //---------------------------------------------------------------------
@@ -114,29 +133,38 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
         // IInstanceSessionBroker.
         //---------------------------------------------------------------------
 
+        public ICommandContainer<ISession> SessionMenu { get; }
+
         public async Task<ISshTerminalSession> ConnectAsync(
             ConnectionTemplate<SshSessionParameters> template)
         {
-            var window = ToolWindow.GetWindow<SshTerminalView, SshTerminalViewModel>(this.serviceProvider);
+            var window = ToolWindow.GetWindow<SshTerminalView, SshTerminalViewModel>(
+                this.serviceProvider);
+
             window.ViewModel.Instance = template.Transport.Instance;
             window.ViewModel.Endpoint = template.Transport.Endpoint;
             window.ViewModel.AuthorizedKey = template.Session.AuthorizedKey;
             window.ViewModel.Language = template.Session.Language;
             window.ViewModel.ConnectionTimeout = template.Session.ConnectionTimeout;
 
-            var pane = window.Bind();
+            var session = window.Bind();
             window.Show();
 
-            await pane.ConnectAsync()
+            await session.ConnectAsync()
                 .ConfigureAwait(false);
 
-            return pane;
+            Debug.Assert(session.ContextCommands == null);
+            session.ContextCommands = this.SessionMenu;
+
+            return session;
         }
 
         public IRemoteDesktopSession Connect(
             ConnectionTemplate<RdpSessionParameters> template)
         {
-            var window = ToolWindow.GetWindow<RemoteDesktopView, RemoteDesktopViewModel>(this.serviceProvider);
+            var window = ToolWindow.GetWindow<RemoteDesktopView, RemoteDesktopViewModel>(
+                this.serviceProvider);
+
             window.ViewModel.Instance = template.Transport.Instance;
             window.ViewModel.Server = IPAddress.IsLoopback(template.Transport.Endpoint.Address)
                 ? "localhost"
@@ -144,12 +172,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
             window.ViewModel.Port = (ushort)template.Transport.Endpoint.Port;
             window.ViewModel.Parameters = template.Session;
 
-            var pane = window.Bind();
+            var session = window.Bind();
             window.Show();
 
-            pane.Connect();
+            session.Connect();
 
-            return pane;
+            Debug.Assert(session.ContextCommands == null);
+            session.ContextCommands = this.SessionMenu;
+
+            return session;
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/SessionBroker.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/SessionBroker.cs
@@ -40,13 +40,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
         /// <summary>
         /// Create a new SSH session.
         /// </summary>
-        Task<ISshTerminalSession> ConnectAsync(
-            ConnectionTemplate<SshSessionParameters> template); // TODO: Rename method
+        Task<ISshTerminalSession> ConnectSshSessionAsync(
+            ConnectionTemplate<SshSessionParameters> template);
 
         /// <summary>
         /// Create a new RDP session.
         /// </summary>
-        IRemoteDesktopSession Connect(
+        IRemoteDesktopSession ConnectRdpSession(
             ConnectionTemplate<RdpSessionParameters> template);
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
 
         public ICommandContainer<ISession> SessionMenu { get; }
 
-        public async Task<ISshTerminalSession> ConnectAsync(
+        public async Task<ISshTerminalSession> ConnectSshSessionAsync(
             ConnectionTemplate<SshSessionParameters> template)
         {
             var window = ToolWindow.GetWindow<SshTerminalView, SshTerminalViewModel>(
@@ -159,7 +159,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
             return session;
         }
 
-        public IRemoteDesktopSession Connect(
+        public IRemoteDesktopSession ConnectRdpSession(
             ConnectionTemplate<RdpSessionParameters> template)
         {
             var window = ToolWindow.GetWindow<RemoteDesktopView, RemoteDesktopViewModel>(

--- a/sources/Google.Solutions.Testing.Application/Views/TestMainForm.cs
+++ b/sources/Google.Solutions.Testing.Application/Views/TestMainForm.cs
@@ -21,7 +21,9 @@
 
 using Google.Solutions.IapDesktop.Application.Services.Integration;
 using Google.Solutions.IapDesktop.Application.Views;
+using Google.Solutions.Mvvm.Binding;
 using Google.Solutions.Mvvm.Binding.Commands;
+using Moq;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -51,7 +53,10 @@ namespace Google.Solutions.Testing.Application.Views
             Func<TContext> queryCurrentContextFunc)
             where TContext : class
         {
-            throw new NotImplementedException();
+            return new CommandContainer<TContext>(
+                ToolStripItemDisplayStyle.Text, 
+                new Mock<IContextSource<TContext>>().Object,
+                new Mock<IBindingContext>().Object);
         }
 
         public void Minimize()


### PR DESCRIPTION
Let session broker maintain and add context commands. This ensures that all 
sessions receive a context menu, regardless of how the were created.