### PR TITLE
b/274998103 Use RSAES-OAEP for domain credentials

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/ActiveDirectory/DomainJoinService.StartupScript.ps1
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/ActiveDirectory/DomainJoinService.StartupScript.ps1
@@ -80,7 +80,7 @@ try {
     $PlainTextPassword = [System.Text.Encoding]::UTF8.GetString(
         $Key.Decrypt(
             [Convert]::FromBase64String($JoinRequest.EncryptedPassword), 
-            [System.Security.Cryptography.RSAEncryptionPadding]::Pkcs1))
+            [System.Security.Cryptography.RSAEncryptionPadding]::OaepSHA256))
 
     $Password = ConvertTo-SecureString `
         -AsPlainText `

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/ActiveDirectory/DomainJoinService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Services/ActiveDirectory/DomainJoinService.cs
@@ -197,7 +197,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Services.ActiveDirec
                     var encryptedPassword = Convert.ToBase64String(
                         key.Encrypt(
                             Encoding.UTF8.GetBytes(domainCredential.Password),
-                            RSAEncryptionPadding.Pkcs1));
+                            RSAEncryptionPadding.OaepSHA256));
 
                     var joinRequest = new JoinRequest()
                     {


### PR DESCRIPTION
Avoid using PKCS#1.5 padding as it's no longer recommended.