### PR TITLE
b/274055916 Don't persist operating system filter

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Views/ProjectExplorer/TestProjectExplorerSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Views/ProjectExplorer/TestProjectExplorerSettings.cs
@@ -47,36 +47,6 @@ namespace Google.Solutions.IapDesktop.Application.Test.Views.ProjectExplorer
         }
 
         //---------------------------------------------------------------------
-        // OperatingSystemsFilter.
-        //---------------------------------------------------------------------
-
-        [Test]
-        public void WhenValueSaved_ThenOperatingSystemsFilterReturnsSavedValue()
-        {
-            var settings = this.settingsRepository.GetSettings();
-            settings.IncludeOperatingSystems.Value = OperatingSystems.Windows;
-            this.settingsRepository.SetSettings(settings);
-
-            using (var explorerSettings = new ProjectExplorerSettings(this.settingsRepository, true))
-            {
-                Assert.AreEqual(OperatingSystems.Windows, explorerSettings.OperatingSystemsFilter);
-            }
-        }
-
-        [Test]
-        public void WhenDisposed_ThenOperatingSystemsFilterIsSaved()
-        {
-            using (var explorerSettings = new ProjectExplorerSettings(this.settingsRepository, false))
-            {
-                Assert.AreNotEqual(OperatingSystems.Windows, explorerSettings.OperatingSystemsFilter);
-                explorerSettings.OperatingSystemsFilter = OperatingSystems.Windows;
-            }
-
-            var settings = this.settingsRepository.GetSettings();
-            Assert.AreEqual(OperatingSystems.Windows, settings.IncludeOperatingSystems.Value);
-        }
-
-        //---------------------------------------------------------------------
         // CollapsedProjects.
         //---------------------------------------------------------------------
 

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Views/ProjectExplorer/TestProjectExplorerViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Views/ProjectExplorer/TestProjectExplorerViewModel.cs
@@ -193,38 +193,6 @@ namespace Google.Solutions.IapDesktop.Application.Test.Views.ProjectExplorer
         }
 
         [Test]
-        public void WhenAllOsEnabledInSettings_ThenAllOsAreIncluded()
-        {
-            // Write settings.
-            var initialViewModel = CreateViewModel();
-            initialViewModel.IsWindowsIncluded = true;
-            initialViewModel.IsLinuxIncluded = true;
-
-            // Read again.
-            var viewModel = CreateViewModel();
-            Assert.IsTrue(viewModel.IsWindowsIncluded);
-            Assert.IsTrue(viewModel.IsLinuxIncluded);
-        }
-
-        [Test]
-        public void WhenAllOsDisabledInSettings_ThenNoOsAreIncluded()
-        {
-            // Write settings.
-            using (var initialViewModel = CreateViewModel())
-            {
-                initialViewModel.IsWindowsIncluded = false;
-                initialViewModel.IsLinuxIncluded = false;
-            }
-
-            // Read again.
-            using (var viewModel = CreateViewModel())
-            {
-                Assert.IsFalse(viewModel.IsWindowsIncluded);
-                Assert.IsFalse(viewModel.IsLinuxIncluded);
-            }
-        }
-
-        [Test]
         public async Task WhenOsFilterChanged_ThenViewModelIsUpdated()
         {
             var viewModel = CreateViewModel();

--- a/sources/Google.Solutions.IapDesktop.Application/Services/Settings/ApplicationSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Services/Settings/ApplicationSettingsRepository.cs
@@ -80,8 +80,6 @@ namespace Google.Solutions.IapDesktop.Application.Services.Settings
 
         public RegistryStringSetting FullScreenDevices { get; private set; }
 
-        public RegistryEnumSetting<OperatingSystems> IncludeOperatingSystems { get; private set; }
-
         public RegistryStringSetting DeviceCertificateSelector { get; private set; }
 
         public RegistryStringSetting CollapsedProjects { get; private set; }
@@ -102,7 +100,6 @@ namespace Google.Solutions.IapDesktop.Application.Services.Settings
             this.ProxyPassword,
             this.IsDeviceCertificateAuthenticationEnabled,
             this.FullScreenDevices,
-            this.IncludeOperatingSystems,
             this.DeviceCertificateSelector,
             this.CollapsedProjects,
             this.ConnectionLimit
@@ -244,13 +241,6 @@ namespace Google.Solutions.IapDesktop.Application.Services.Settings
                     null,
                     settingsKey,
                     _ => true),
-                IncludeOperatingSystems = RegistryEnumSetting<OperatingSystems>.FromKey(
-                    "IncludeOperatingSystems",
-                    "IncludeOperatingSystems",
-                    null,
-                    null,
-                    OperatingSystems.Windows | OperatingSystems.Linux,
-                    settingsKey),
                 CollapsedProjects = RegistryStringSetting.FromKey(
                     "CollapsedProjects",
                     "CollapsedProjects",

--- a/sources/Google.Solutions.IapDesktop.Application/Views/ProjectExplorer/ProjectExplorerSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/ProjectExplorer/ProjectExplorerSettings.cs
@@ -32,11 +32,6 @@ namespace Google.Solutions.IapDesktop.Application.Views.ProjectExplorer
     internal interface IProjectExplorerSettings : IDisposable
     {
         /// <summary>
-        /// Last used filter.
-        /// </summary>
-        OperatingSystems OperatingSystemsFilter { get; set; }
-
-        /// <summary>
         /// Collapsed projects. 
         /// NB. We store the collapsed projects instead of the expanded
         /// projects so that we're (a) backwards-compatible and (b)
@@ -64,15 +59,12 @@ namespace Google.Solutions.IapDesktop.Application.Views.ProjectExplorer
             //
             var settings = this.settingsRepository.GetSettings();
 
-            this.OperatingSystemsFilter = settings.IncludeOperatingSystems.EnumValue;
             this.CollapsedProjects = (settings.CollapsedProjects.StringValue ?? string.Empty)
                 .Split(',')
                 .Where(projectId => !string.IsNullOrWhiteSpace(projectId))
                 .Select(projectId => new ProjectLocator(projectId.Trim()))
                 .ToHashSet();
         }
-
-        public OperatingSystems OperatingSystemsFilter { get; set; }
 
         public ISet<ProjectLocator> CollapsedProjects { get; }
 
@@ -84,7 +76,6 @@ namespace Google.Solutions.IapDesktop.Application.Views.ProjectExplorer
 
             var settings = this.settingsRepository.GetSettings();
 
-            settings.IncludeOperatingSystems.EnumValue = this.OperatingSystemsFilter;
             settings.CollapsedProjects.StringValue = string.Join(
                 ",",
                 this.CollapsedProjects.Select(locator => locator.ProjectId));

--- a/sources/Google.Solutions.IapDesktop.Application/Views/ProjectExplorer/ProjectExplorerViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/ProjectExplorer/ProjectExplorerViewModel.cs
@@ -49,6 +49,7 @@ namespace Google.Solutions.IapDesktop.Application.Views.ProjectExplorer
 
         private ViewModelNode selectedNode;
         private string instanceFilter;
+        private OperatingSystems operatingSystemsFilter = OperatingSystems.All;
         private readonly IProjectExplorerSettings settings;
 
         private bool isUnloadProjectCommandVisible;
@@ -299,10 +300,10 @@ namespace Google.Solutions.IapDesktop.Application.Views.ProjectExplorer
 
         public OperatingSystems OperatingSystemsFilter
         {
-            get => this.settings.OperatingSystemsFilter;
+            get => this.operatingSystemsFilter;
             set
             {
-                this.settings.OperatingSystemsFilter = value;
+                this.operatingSystemsFilter = value;
 
                 RaisePropertyChange();
 


### PR DESCRIPTION
Remove persistence for the OS filter in the Project Explorer window. This behavior is more consistent with how the instance name filter works, and ensures that all instances are shown again when the application is restarted.