### PR TITLE
b/278635927 Move OAuth client to main namespace

### DIFF
--- a/sources/Google.Solutions.IapDesktop/OAuthClient.cs.default
+++ b/sources/Google.Solutions.IapDesktop/OAuthClient.cs.default
@@ -1,6 +1,6 @@
 ﻿using Google.Apis.Auth.OAuth2;
 
-namespace Google.Solutions.CloudIap.IapDesktop
+namespace Google.Solutions.IapDesktop
 {
     internal class OAuthClient
     {

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -21,7 +21,6 @@
 
 using Google.Apis.Util;
 using Google.Solutions.Apis;
-using Google.Solutions.CloudIap;
 using Google.Solutions.Common;
 using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.Common.Util;


### PR DESCRIPTION
Use main namespace instead of the legacy "CloudIap" namespace