### PR TITLE
b/279510055 Load extensions into main layer

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/ObjectModel/TestServiceAttribute.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/ObjectModel/TestServiceAttribute.cs
@@ -173,65 +173,6 @@ namespace Google.Solutions.IapDesktop.Application.Test.ObjectModel
         }
 
         //---------------------------------------------------------------------
-        // Visibility.
-        //---------------------------------------------------------------------
-
-        [Service(ServiceLifetime.Transient)]
-        public class TransientServiceWithVisibilityScoped
-        {
-        }
-
-        [Service(ServiceLifetime.Transient, ServiceVisibility.Global)]
-        public class TransientServiceWithVisibilityGlobal
-        {
-        }
-
-        [Service(ServiceLifetime.Singleton, ServiceVisibility.Global)]
-        public class SingletonServiceWithVisibilityGlobal
-        {
-            public SingletonServiceWithVisibilityGlobal(IServiceProvider sp)
-            {
-                Assert.IsNotNull(sp.GetService<TransientServiceWithVisibilityScoped>());
-            }
-        }
-
-        [Test]
-        public void WhenVisibilityIsScoped_ThenServiceIsNotVisibleToParentRegistry()
-        {
-            var parentRegistry = new ServiceRegistry();
-            var childRegistry = new ServiceRegistry(parentRegistry);
-            childRegistry.AddExtensionAssembly(Assembly.GetExecutingAssembly());
-
-            Assert.IsNotNull(childRegistry.GetService<TransientServiceWithVisibilityScoped>());
-            Assert.Throws<UnknownServiceException>(() => parentRegistry.GetService<TransientServiceWithVisibilityScoped>());
-        }
-
-        [Test]
-        public void WhenVisibilityIsGlobal_ThenServiceIsNotVisibleToParentRegistry()
-        {
-            var parentRegistry = new ServiceRegistry();
-            var childRegistry = new ServiceRegistry(parentRegistry);
-            childRegistry.AddExtensionAssembly(Assembly.GetExecutingAssembly());
-
-            Assert.IsNotNull(childRegistry.GetService<TransientServiceWithVisibilityGlobal>());
-            Assert.IsNotNull(parentRegistry.GetService<TransientServiceWithVisibilityGlobal>());
-        }
-
-        [Test]
-        public void WhenVisibilityIsGlobal_ThenDependenciesOfSameLayerAreResolved()
-        {
-            var parentRegistry = new ServiceRegistry();
-            var childRegistry = new ServiceRegistry(parentRegistry);
-            childRegistry.AddExtensionAssembly(Assembly.GetExecutingAssembly());
-
-            Assert.IsNotNull(childRegistry.GetService<SingletonServiceWithVisibilityGlobal>());
-            Assert.IsNotNull(parentRegistry.GetService<SingletonServiceWithVisibilityGlobal>());
-            Assert.AreSame(
-                childRegistry.GetService<SingletonServiceWithVisibilityGlobal>(),
-                parentRegistry.GetService<SingletonServiceWithVisibilityGlobal>());
-        }
-
-        //---------------------------------------------------------------------
         // Register service category.
         //---------------------------------------------------------------------
 

--- a/sources/Google.Solutions.IapDesktop.Application/ObjectModel/ServiceAttribute.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ObjectModel/ServiceAttribute.cs
@@ -41,11 +41,6 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel
         public ServiceLifetime Lifetime { get; }
 
         /// <summary>
-        /// Restrict visibility to other services.
-        /// </summary>
-        public ServiceVisibility Visibility { get; } = ServiceVisibility.Scoped;
-
-        /// <summary>
         /// Delay instance creation until first use. Ignored
         /// for transient services.
         /// </summary>
@@ -53,8 +48,7 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel
 
         public ServiceAttribute(
             Type serviceInterface,
-            ServiceLifetime lifetime,
-            ServiceVisibility visibility)
+            ServiceLifetime lifetime)
         {
             if (serviceInterface != null && !serviceInterface.IsInterface)
             {
@@ -63,12 +57,6 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel
 
             this.ServiceInterface = serviceInterface;
             this.Lifetime = lifetime;
-            this.Visibility = visibility;
-        }
-
-        public ServiceAttribute(Type serviceInterface, ServiceLifetime lifetime)
-            : this(serviceInterface, lifetime, ServiceVisibility.Scoped)
-        {
         }
 
         public ServiceAttribute(Type serviceInterface)
@@ -78,11 +66,6 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel
 
         public ServiceAttribute(ServiceLifetime lifetime)
             : this(null, lifetime)
-        {
-        }
-
-        public ServiceAttribute(ServiceLifetime lifetime, ServiceVisibility visibility)
-            : this(null, lifetime, visibility)
         {
         }
 
@@ -97,20 +80,6 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel
         Transient,
         Singleton
     }
-
-    public enum ServiceVisibility
-    {
-        /// <summary>
-        /// Visible across all layers of service registries.
-        /// </summary>
-        Global,
-
-        /// <summary>
-        /// Visible within current and lower layers.
-        /// </summary>
-        Scoped
-    }
-
 
     /// <summary>
     /// Declare that a class implements a category interface.

--- a/sources/Google.Solutions.IapDesktop.Application/ObjectModel/ServiceRegistry.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ObjectModel/ServiceRegistry.cs
@@ -372,14 +372,6 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel
         // Extension assembly handling.
         //---------------------------------------------------------------------
 
-        private ServiceRegistry GetServiceRegistryToRegisterWith(ServiceAttribute attribute)
-        {
-            // If it's visible globally, use the root registry.
-            return attribute.Visibility == ServiceVisibility.Global
-                ? this.RootRegistry
-                : this;
-        }
-
         public void AddExtensionAssembly(Assembly assembly)
         {
             //
@@ -399,7 +391,7 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel
                 if (type.GetCustomAttribute<ServiceAttribute>() is ServiceAttribute attribute &&
                     attribute.Lifetime == ServiceLifetime.Transient)
                 {
-                    GetServiceRegistryToRegisterWith(attribute).AddTransient(
+                    AddTransient(
                         attribute.ServiceInterface ?? type,
                         type);
                 }
@@ -419,7 +411,7 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel
                         ? new SingletonStub(() => CreateInstance(type))
                         : new SingletonStub(CreateInstance(type));
 
-                    GetServiceRegistryToRegisterWith(attribute).AddSingleton(
+                    AddSingleton(
                         attribute.ServiceInterface ?? type,
                         stub);
                 }
@@ -433,7 +425,7 @@ namespace Google.Solutions.IapDesktop.Application.ObjectModel
                 if (type.GetCustomAttribute<ServiceAttribute>() is ServiceAttribute attribute &&
                     type.GetCustomAttribute<ServiceCategoryAttribute>() is ServiceCategoryAttribute categoryAttribute)
                 {
-                    GetServiceRegistryToRegisterWith(attribute).AddServiceToCategory(
+                    AddServiceToCategory(
                         categoryAttribute.Category,
                         attribute.ServiceInterface ?? type);
                 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Settings/SshSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Settings/SshSettings.cs
@@ -36,7 +36,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Settings
     /// 
     /// Service is a singleton so that objects can subscribe to events.
     /// </summary>
-    [Service(ServiceLifetime.Singleton, ServiceVisibility.Global)]
+    [Service(ServiceLifetime.Singleton)]
     public class SshSettingsRepository : PolicyEnabledSettingsRepository<SshSettings>
     {
         private readonly Profile.SchemaVersion schemaVersion;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Settings/TerminalSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Services/Settings/TerminalSettings.cs
@@ -38,7 +38,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Services.Settings
     /// 
     /// Service is a singleton so that objects can subscribe to events.
     /// </summary>
-    [Service(ServiceLifetime.Singleton, ServiceVisibility.Global)]
+    [Service(ServiceLifetime.Singleton)]
     public class TerminalSettingsRepository : SettingsRepositoryBase<TerminalSettings>
     {
         public event EventHandler<EventArgs<TerminalSettings>> SettingsChanged;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Options/SshOptionsSheet.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Options/SshOptionsSheet.cs
@@ -32,7 +32,7 @@ using System.Windows.Forms;
 namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Options
 {
     [SkipCodeCoverage("UI code")]
-    [Service(ServiceLifetime.Transient, ServiceVisibility.Global)]
+    [Service(ServiceLifetime.Transient)]
     [ServiceCategory(typeof(IPropertiesSheetView))]
     public partial class SshOptionsSheet : UserControl, IPropertiesSheetView
     {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Options/SshOptionsViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Options/SshOptionsViewModel.cs
@@ -30,7 +30,7 @@ using System.Linq;
 
 namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Options
 {
-    [Service(ServiceLifetime.Transient, ServiceVisibility.Global)]
+    [Service(ServiceLifetime.Transient)]
     public class SshOptionsViewModel : OptionsViewModelBase<SshSettings>
     {
         private static readonly SshKeyType[] publicKeyTypes =

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Options/TerminalOptionsSheet.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Options/TerminalOptionsSheet.cs
@@ -32,7 +32,7 @@ using System.Windows.Forms;
 namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Options
 {
     [SkipCodeCoverage("UI code")]
-    [Service(ServiceLifetime.Transient, ServiceVisibility.Global)]
+    [Service(ServiceLifetime.Transient)]
     [ServiceCategory(typeof(IPropertiesSheetView))]
     public partial class TerminalOptionsSheet : UserControl, IPropertiesSheetView
     {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Options/TerminalOptionsViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Options/TerminalOptionsViewModel.cs
@@ -28,7 +28,7 @@ using System.Drawing;
 
 namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Options
 {
-    [Service(ServiceLifetime.Transient, ServiceVisibility.Global)]
+    [Service(ServiceLifetime.Transient)]
     public class TerminalOptionsViewModel : OptionsViewModelBase<TerminalSettings>
     {
         public TerminalOptionsViewModel(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/SessionBroker.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Shell/Views/Session/SessionBroker.cs
@@ -57,7 +57,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Shell.Views.Session
         ICommandContainer<ISession> SessionMenu { get; }
     }
 
-    [Service(typeof(IInstanceSessionBroker), ServiceLifetime.Singleton, ServiceVisibility.Global)]
+    [Service(typeof(IInstanceSessionBroker), ServiceLifetime.Singleton)]
     [ServiceCategory(typeof(ISessionBroker))]
     public class InstanceSessionBroker : IInstanceSessionBroker
     {

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -501,10 +501,9 @@ namespace Google.Solutions.IapDesktop
                 //
                 // Load extensions.
                 //
-                var extensionLayer = new ServiceRegistry(mainLayer);
                 foreach (var extension in LoadExtensionAssemblies())
                 {
-                    extensionLayer.AddExtensionAssembly(extension);
+                    mainLayer.AddExtensionAssembly(extension);
                 }
 
                 //


### PR DESCRIPTION
Use a common layer for main classes and application. The separation in now redundant to DLL separation, and caused unnecessary friction.