### PR TITLE
b/280531854 Include error details from failed operation

### DIFF
--- a/sources/Google.Solutions.Apis.Test/Google.Solutions.Apis.Test.csproj
+++ b/sources/Google.Solutions.Apis.Test/Google.Solutions.Apis.Test.csproj
@@ -35,6 +35,9 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=5.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.5.0.0\lib\net462\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Google.Apis, Version=1.57.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.Apis.1.57.0\lib\net45\Google.Apis.dll</HintPath>
     </Reference>
@@ -53,6 +56,9 @@
     <Reference Include="Google.Apis.PlatformServices, Version=1.57.0.0, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
       <HintPath>..\packages\Google.Apis.1.57.0\lib\net45\Google.Apis.PlatformServices.dll</HintPath>
     </Reference>
+    <Reference Include="Moq, Version=4.18.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.18.1\lib\net462\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -60,9 +66,16 @@
       <HintPath>..\packages\NUnit.3.13.3\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Client\TestClientServiceMtlsExtensions.cs" />

--- a/sources/Google.Solutions.Apis.Test/packages.config
+++ b/sources/Google.Solutions.Apis.Test/packages.config
@@ -1,9 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="5.0.0" targetFramework="net462" />
   <package id="Google.Apis" version="1.57.0" targetFramework="net462" />
   <package id="Google.Apis.Auth" version="1.57.0" targetFramework="net462" />
   <package id="Google.Apis.Compute.v1" version="1.57.0.2714" targetFramework="net462" />
   <package id="Google.Apis.Core" version="1.57.0" targetFramework="net462" />
+  <package id="Moq" version="4.18.1" targetFramework="net462" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
   <package id="NUnit" version="3.13.3" targetFramework="net462" />
   <package id="NUnit.Console" version="3.15.0" targetFramework="net462" />
@@ -14,4 +16,6 @@
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.7" targetFramework="net462" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.9.0" targetFramework="net462" />
   <package id="NUnit3TestAdapter" version="4.2.1" targetFramework="net462" developmentDependency="true" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net462" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net462" />
 </packages>

--- a/sources/Google.Solutions.Apis/Client/RequestExtensions.cs
+++ b/sources/Google.Solutions.Apis/Client/RequestExtensions.cs
@@ -146,7 +146,16 @@ namespace Google.Solutions.Apis.Client
                             ? operation.Error.Errors
                                 .Select(e => new SingleError()
                                 {
-                                    Message = e.Message,
+                                    //
+                                    // e.Message typically contains a readable error message
+                                    // that should be displayed to the user.
+                                    //
+                                    // This is different from non-Operation API calls where
+                                    // Message typically contains a concatenated mess.
+                                    //
+                                    // To avoid losing the message here, map it to Reason.
+                                    //
+                                    Reason = e.Message,
                                     Location = e.Location
                                 })
                                 .ToList()


### PR DESCRIPTION
When an operation fails with a status such as CONDITION_NOT_MET, include the error message in the dialog shown to the user.