### PR TITLE
b/280944842 Set icon for Authorize dialog

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Views/Authorization/AuthorizeView.Designer.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/Authorization/AuthorizeView.Designer.cs
@@ -217,7 +217,6 @@ namespace Google.Solutions.IapDesktop.Application.Views.Authorization
             this.Controls.Add(this.watermarkPictureBox);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.Name = "AuthorizeView";
-            this.ShowIcon = false;
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Sign in";

--- a/sources/Google.Solutions.IapDesktop.Application/Views/Authorization/AuthorizeView.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/Authorization/AuthorizeView.cs
@@ -20,6 +20,7 @@
 //
 
 using Google.Solutions.Common.Diagnostics;
+using Google.Solutions.IapDesktop.Application.Properties;
 using Google.Solutions.Mvvm.Binding;
 using Google.Solutions.Mvvm.Binding.Commands;
 using System.Diagnostics;
@@ -36,8 +37,15 @@ namespace Google.Solutions.IapDesktop.Application.Views.Authorization
         {
             InitializeComponent();
 
+            //
             // Don't maximize when double-clicking title bar.
+            //
             this.MaximumSize = this.Size;
+
+            //
+            // Show the right icon in Alt+Tab.
+            //
+            this.Icon = Resources.logo;
         }
 
         public void Bind(AuthorizeViewModel viewModel, IBindingContext bindingContext)


### PR DESCRIPTION
Use the product icon when the Authorize dialog
is shown in Alt+Tab or the taskbar preview.