### PR TITLE
b/265601343 Rename to BrowserProtocolRegistry

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Views/Options/TestGeneralOptionsViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Views/Options/TestGeneralOptionsViewModel.cs
@@ -42,12 +42,12 @@ namespace Google.Solutions.IapDesktop.Application.Test.Views.Options
         private const string TestMachinePolicyKeyPath = @"Software\Google\__TestMachinePolicy";
         private readonly RegistryKey hkcu = RegistryKey.OpenBaseKey(RegistryHive.CurrentUser, RegistryView.Default);
 
-        private Mock<IAppProtocolRegistry> protocolRegistryMock;
+        private Mock<IBrowserProtocolRegistry> protocolRegistryMock;
 
         [SetUp]
         public void SetUp()
         {
-            this.protocolRegistryMock = new Mock<IAppProtocolRegistry>();
+            this.protocolRegistryMock = new Mock<IBrowserProtocolRegistry>();
         }
 
         private ApplicationSettingsRepository CreateSettingsRepository(

--- a/sources/Google.Solutions.IapDesktop.Application/Views/Options/GeneralOptionsViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/Options/GeneralOptionsViewModel.cs
@@ -33,11 +33,11 @@ namespace Google.Solutions.IapDesktop.Application.Views.Options
 {
     internal class GeneralOptionsViewModel : OptionsViewModelBase<ApplicationSettings>
     {
-        private readonly IAppProtocolRegistry protocolRegistry;
+        private readonly IBrowserProtocolRegistry protocolRegistry;
 
         public GeneralOptionsViewModel(
             ApplicationSettingsRepository settingsRepository,
-            IAppProtocolRegistry protocolRegistry,
+            IBrowserProtocolRegistry protocolRegistry,
             HelpAdapter helpService)
             : base("General", settingsRepository)
         {

--- a/sources/Google.Solutions.IapDesktop.Application/Views/Options/OptionsDialog.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/Options/OptionsDialog.cs
@@ -46,7 +46,7 @@ namespace Google.Solutions.IapDesktop.Application.Views.Options
                     new GeneralOptionsSheet(),
                     new GeneralOptionsViewModel(
                         appSettingsRepository,
-                        serviceProvider.GetService<IAppProtocolRegistry>(),
+                        serviceProvider.GetService<IBrowserProtocolRegistry>(),
                         serviceProvider.GetService<HelpAdapter>()));
                 dialog.ViewModel.AddSheet(
                     new AppearanceOptionsSheet(),

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -387,7 +387,7 @@ namespace Google.Solutions.IapDesktop
                     profile.SettingsKey.CreateSubKey("Theme")));
                 preAuthLayer.AddSingleton<IThemeService, ThemeService>();
 
-                preAuthLayer.AddTransient<IAppProtocolRegistry, AppProtocolRegistry>();
+                preAuthLayer.AddTransient<IBrowserProtocolRegistry, BrowserProtocolRegistry>();
                 preAuthLayer.AddSingleton(appSettingsRepository);
                 preAuthLayer.AddSingleton(new ToolWindowStateRepository(
                     profile.SettingsKey.CreateSubKey("ToolWindows")));

--- a/sources/Google.Solutions.Platform.Test/Google.Solutions.Platform.Test.csproj
+++ b/sources/Google.Solutions.Platform.Test/Google.Solutions.Platform.Test.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Cryptography\TestCertificateStore.cs" />
-    <Compile Include="Net\TestAppProtocolRegistry.cs" />
+    <Compile Include="Net\TestBrowserProtocolRegistry.cs" />
     <Compile Include="Net\TestBrowser.cs" />
     <Compile Include="Net\TestChromeAutoSelectCertificateForUrlsPolicy.cs" />
     <Compile Include="Net\TestChromeCertificateSelector.cs" />

--- a/sources/Google.Solutions.Platform.Test/Net/TestBrowserProtocolRegistry.cs
+++ b/sources/Google.Solutions.Platform.Test/Net/TestBrowserProtocolRegistry.cs
@@ -26,7 +26,7 @@ using NUnit.Framework;
 namespace Google.Solutions.Platform.Test.Net
 {
     [TestFixture]
-    public class TestAppProtocolRegistry
+    public class TestBrowserProtocolRegistry
     {
         private const string TestScheme = "iapdesktop-test";
 
@@ -43,14 +43,14 @@ namespace Google.Solutions.Platform.Test.Net
         [Test]
         public void WhenProtocolNotRegistered_ThenIsRegisteredReturnsFalse()
         {
-            var registry = new AppProtocolRegistry();
+            var registry = new BrowserProtocolRegistry();
             Assert.IsFalse(registry.IsRegistered("unknown-scheme", "app.exe"));
         }
 
         [Test]
         public void WhenProtocolRegisteredByDifferentApp_ThenIsRegisteredReturnsFalse()
         {
-            var registry = new AppProtocolRegistry();
+            var registry = new BrowserProtocolRegistry();
             registry.Register(TestScheme, "Test", "app.exe");
             registry.Unregister(TestScheme);
 
@@ -60,7 +60,7 @@ namespace Google.Solutions.Platform.Test.Net
         [Test]
         public void WhenProtocolRegistered_ThenIsRegisteredReturnsTrue()
         {
-            var registry = new AppProtocolRegistry();
+            var registry = new BrowserProtocolRegistry();
             registry.Register(TestScheme, "Test", "app.exe");
 
             Assert.IsTrue(registry.IsRegistered(TestScheme, "app.exe"));
@@ -74,7 +74,7 @@ namespace Google.Solutions.Platform.Test.Net
         [Test]
         public void WhenProtocolRegisteredByDifferentApp_TheRegisterOverridesRegistration()
         {
-            var registry = new AppProtocolRegistry();
+            var registry = new BrowserProtocolRegistry();
             registry.Register(TestScheme, "Test", "someotherapp.exe");
             registry.Register(TestScheme, "Test", "app.exe");
 
@@ -88,7 +88,7 @@ namespace Google.Solutions.Platform.Test.Net
         [Test]
         public void WhenProtocolNotRegistered_ThenUnregisterDoesNothing()
         {
-            var registry = new AppProtocolRegistry();
+            var registry = new BrowserProtocolRegistry();
             registry.Unregister("unknown-scheme");
         }
     }

--- a/sources/Google.Solutions.Platform/Google.Solutions.Platform.csproj
+++ b/sources/Google.Solutions.Platform/Google.Solutions.Platform.csproj
@@ -44,7 +44,7 @@
     <Compile Include="ApiTraceSources.cs" />
     <Compile Include="Cryptography\CertificateStore.cs" />
     <Compile Include="UserEnvironment.cs" />
-    <Compile Include="Net\AppProtocolRegistry.cs" />
+    <Compile Include="Net\BrowserProtocolRegistry.cs" />
     <Compile Include="Net\Browser.cs" />
     <Compile Include="Net\ChromeAutoSelectCertificateForUrlsPolicy.cs" />
     <Compile Include="Net\ChromeCertificateSelector.cs" />

--- a/sources/Google.Solutions.Platform/Net/BrowserProtocolRegistry.cs
+++ b/sources/Google.Solutions.Platform/Net/BrowserProtocolRegistry.cs
@@ -24,9 +24,9 @@ using Microsoft.Win32;
 namespace Google.Solutions.Platform.Net
 {
     /// <summary>
-    /// Registry for application protocols.
+    /// Registry for custom browser protocols.
     /// </summary>
-    public interface IAppProtocolRegistry
+    public interface IBrowserProtocolRegistry
     {
         /// <summary>
         /// Check if a protocol scheme has been registered.
@@ -48,7 +48,7 @@ namespace Google.Solutions.Platform.Net
         void Unregister(string scheme);
     }
 
-    public class AppProtocolRegistry : IAppProtocolRegistry
+    public class BrowserProtocolRegistry : IBrowserProtocolRegistry
     {
         private static string KeyPathFromScheme(string scheme)
             => $@"SOFTWARE\Classes\{scheme}";


### PR DESCRIPTION
Rename AppProtocolRegistry to BrowserProtocolRegistry to disambiguate
custom browser protocols from IAP Desktop's own "app protocols"