### PR TITLE
b/271897730 Create separate nuget package for TSC interop assemblies

### DIFF
--- a/dependencies/makefile
+++ b/dependencies/makefile
@@ -25,12 +25,14 @@ PACKAGES_BUCKET = iapdesktop-kokoro-artifacts
 
 # Directories containing projects
 DIRS=\
+    $(MAKEDIR)\sources\tsc \
     $(MAKEDIR)\sources\vtnetcore \
     $(MAKEDIR)\sources\dockpanelsuite \
     $(MAKEDIR)\sources\libssh2
     
 # Nuget packages to build
 PACKAGES=\
+    $(MAKEDIR)\sources\tsc\obj\google.solutions.tsc.nupkg \
     $(MAKEDIR)\sources\vtnetcore\obj\vtnetcore.nupkg \
     $(MAKEDIR)\sources\dockpanelsuite\obj\dockpanelsuite.nupkg \
     $(MAKEDIR)\sources\libssh2\obj\libssh2.nupkg \

--- a/dependencies/makefile
+++ b/dependencies/makefile
@@ -32,7 +32,7 @@ DIRS=\
     
 # Nuget packages to build
 PACKAGES=\
-    $(MAKEDIR)\sources\tsc\google.solutions.tsc.nupkg \
+    $(MAKEDIR)\sources\tsc\obj\google.solutions.tsc.nupkg \
     $(MAKEDIR)\sources\vtnetcore\obj\vtnetcore.nupkg \
     $(MAKEDIR)\sources\dockpanelsuite\obj\dockpanelsuite.nupkg \
     $(MAKEDIR)\sources\libssh2\obj\libssh2.nupkg \

--- a/dependencies/makefile
+++ b/dependencies/makefile
@@ -32,7 +32,7 @@ DIRS=\
     
 # Nuget packages to build
 PACKAGES=\
-    $(MAKEDIR)\sources\tsc\obj\google.solutions.tsc.nupkg \
+    $(MAKEDIR)\sources\tsc\google.solutions.tsc.nupkg \
     $(MAKEDIR)\sources\vtnetcore\obj\vtnetcore.nupkg \
     $(MAKEDIR)\sources\dockpanelsuite\obj\dockpanelsuite.nupkg \
     $(MAKEDIR)\sources\libssh2\obj\libssh2.nupkg \

--- a/dependencies/sources/tsc/Google.Solutions.Tsc.csproj
+++ b/dependencies/sources/tsc/Google.Solutions.Tsc.csproj
@@ -12,7 +12,6 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-    <AssemblyVersionNumber>1.0.1.0</AssemblyVersionNumber>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -61,5 +60,4 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\MSBuild.AssemblyVersion.1.3.0\build\MSBuild.AssemblyVersion.targets" Condition="Exists('..\packages\MSBuild.AssemblyVersion.1.3.0\build\MSBuild.AssemblyVersion.targets')" />
 </Project>

--- a/dependencies/sources/tsc/Google.Solutions.Tsc.csproj
+++ b/dependencies/sources/tsc/Google.Solutions.Tsc.csproj
@@ -1,0 +1,65 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{F2985F18-BE52-4E64-BB66-0F330D369947}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Google.Solutions.Tsc</RootNamespace>
+    <AssemblyName>Google.Solutions.Tsc</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <Deterministic>true</Deterministic>
+    <AssemblyVersionNumber>1.0.1.0</AssemblyVersionNumber>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="Microsoft.CSharp" />
+    <COMReference Include="AxMSTSCLib">
+      <Guid>{8C11EFA1-92C3-11D1-BC1E-00C04FA31489}</Guid>
+      <VersionMajor>1</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>aximp</WrapperTool>
+      <Isolated>False</Isolated>
+    </COMReference>
+    <COMReference Include="MSTSCLib">
+      <Guid>{8C11EFA1-92C3-11D1-BC1E-00C04FA31489}</Guid>
+      <VersionMajor>1</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>tlbimp</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="MsRdpClient.cs">
+      <SubType>Component</SubType>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\MSBuild.AssemblyVersion.1.3.0\build\MSBuild.AssemblyVersion.targets" Condition="Exists('..\packages\MSBuild.AssemblyVersion.1.3.0\build\MSBuild.AssemblyVersion.targets')" />
+</Project>

--- a/dependencies/sources/tsc/Google.Solutions.Tsc.sln
+++ b/dependencies/sources/tsc/Google.Solutions.Tsc.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32630.194
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Google.Solutions.Tsc", "Google.Solutions.Tsc.csproj", "{F2985F18-BE52-4E64-BB66-0F330D369947}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F2985F18-BE52-4E64-BB66-0F330D369947}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F2985F18-BE52-4E64-BB66-0F330D369947}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F2985F18-BE52-4E64-BB66-0F330D369947}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F2985F18-BE52-4E64-BB66-0F330D369947}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4DF3A8E1-DCDF-495A-905C-1FE043FD1664}
+	EndGlobalSection
+EndGlobal

--- a/dependencies/sources/tsc/MsRdpClient.cs
+++ b/dependencies/sources/tsc/MsRdpClient.cs
@@ -1,0 +1,52 @@
+﻿//
+// Copyright 2021 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System.Windows.Forms;
+
+namespace Google.Solutions.Tsc
+{
+    public class MsRdpClient : AxMSTSCLib.AxMsRdpClient9NotSafeForScripting
+    {
+        private const int WM_MOUSEACTIVATE = 0x0021;
+
+        protected override void WndProc(ref Message m)
+        {
+            //
+            // When the RDP control loses focus and you later click into the
+            // control again, the control does not re-gain focus. Fix this
+            // default behavior by forcing the focus back on the control 
+            // whenever we see a WM_MOUSEACTIVATE message.
+            //
+            // Cf. https://www.codeproject.com/Tips/109917/Fix-the-focus-issue-on-RDP-Client-from-the-AxInter
+            //
+            // NB. Only do this when the control does not have focus yet, 
+            // otherwise we're interfering with operations such as dragging 
+            // or resizing windows.
+            //
+            if (!this.ContainsFocus && m.Msg == WM_MOUSEACTIVATE)
+            {
+                this.Focus();
+            }
+
+            base.WndProc(ref m);
+        }
+    }
+}

--- a/dependencies/sources/tsc/MsRdpClient.cs
+++ b/dependencies/sources/tsc/MsRdpClient.cs
@@ -1,5 +1,5 @@
 ﻿//
-// Copyright 2021 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed to the Apache Software Foundation (ASF) under one
 // or more contributor license agreements.  See the NOTICE file

--- a/dependencies/sources/tsc/Properties/AssemblyInfo.cs
+++ b/dependencies/sources/tsc/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Google.Solutions.Tsc")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Google.Solutions.Tsc")]
+[assembly: AssemblyCopyright("Copyright ©  2023")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("f2985f18-be52-4e64-bb66-0f330d369947")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/dependencies/sources/tsc/Properties/AssemblyInfo.cs
+++ b/dependencies/sources/tsc/Properties/AssemblyInfo.cs
@@ -1,36 +1,35 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System.Reflection;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Google.Solutions.Tsc")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Google.Solutions.Tsc")]
-[assembly: AssemblyCopyright("Copyright ©  2023")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+[assembly: AssemblyDescription("Terminal services client interop")]
+[assembly: AssemblyCompany("Google LLC")]
+[assembly: AssemblyProduct("IAP Desktop")]
+[assembly: AssemblyCopyright("Copyright © 2019-2023 Google LLC")]
+[assembly: AssemblyTrademark("Google LLC")]
 
-// Setting ComVisible to false makes the types in this assembly not visible
-// to COM components.  If you need to access a type in this assembly from
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("f2985f18-be52-4e64-bb66-0f330d369947")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("9.0.0.0")]
+[assembly: AssemblyFileVersion("9.0.0.0")]

--- a/dependencies/sources/tsc/makefile
+++ b/dependencies/sources/tsc/makefile
@@ -27,7 +27,7 @@ TSC_VERSION = 9.0.0.$(TAG)
 
 default: package
 
-$(MAKEDIR)\bin\$(CONFIGURATION)\Google.Solutions.Tsc.$(TSC_VERSION).nupkg:
+$(MAKEDIR)\obj\$(CONFIGURATION)\Google.Solutions.Tsc.$(TSC_VERSION).nupkg:
 	@echo "========================================================"
 	@echo "=== Building tsc                                     ==="
 	@echo "========================================================"
@@ -62,8 +62,8 @@ $(MAKEDIR)\bin\$(CONFIGURATION)\Google.Solutions.Tsc.$(TSC_VERSION).nupkg:
 # Main targets
 #------------------------------------------------------------------------------
 
-package: $(MAKEDIR)\bin\$(CONFIGURATION)\Google.Solutions.Tsc.$(TSC_VERSION).nupkg
-    copy /Y $(MAKEDIR)\obj\$(CONFIGURATION)\Google.Solutions.Tsc.$(TSC_VERSION).nupkg $(MAKEDIR)\Google.Solutions.Tsc.nupkg
+package: $(MAKEDIR)\obj\$(CONFIGURATION)\Google.Solutions.Tsc.$(TSC_VERSION).nupkg
+    copy /Y $(MAKEDIR)\obj\$(CONFIGURATION)\Google.Solutions.Tsc.$(TSC_VERSION).nupkg $(MAKEDIR)\obj\Google.Solutions.Tsc.nupkg
 
 clean:
     msbuild /t:Clean "$(MAKEDIR)\Google.Solutions.Tsc.csproj"

--- a/dependencies/sources/tsc/makefile
+++ b/dependencies/sources/tsc/makefile
@@ -1,0 +1,74 @@
+#
+# Copyright 2023 Google LLC
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+CONFIGURATION = Release
+
+# The tag should be increased whenever one of the dependencies is changed
+TAG = 1
+
+TSC_VERSION = 9.0.0.$(TAG)
+
+default: package
+
+$(MAKEDIR)\bin\$(CONFIGURATION)\Google.Solutions.Tsc.$(TSC_VERSION).nupkg:
+	@echo "========================================================"
+	@echo "=== Building tsc                                     ==="
+	@echo "========================================================"
+
+	msbuild \
+		/t:Restore;Build \
+		"/p:Configuration=$(CONFIGURATION);TargetFrameworks=net462;TargetFrameworkVersion=v4.6.2;Platform=Any CPU;Version=$(TSC_VERSION);OutputPath=bin\$(CONFIGURATION)" \
+		"$(MAKEDIR)\Google.Solutions.Tsc.sln"
+        
+    	nuget pack -OutputDirectory $(MAKEDIR)\obj\$(CONFIGURATION)\ <<Google.Solutions.Tsc.nuspec
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>Google.Solutions.Tsc</id>
+    <version>$(TSC_VERSION)</version>
+    <authors>Google LLC</authors>
+    <owners>Google LLC</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Terminal service client</description><dependencies>
+      <group targetFramework=".NETFramework4.6.2" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="$(MAKEDIR)\bin\$(CONFIGURATION)\AxInterop.MSTSCLib.dll" target="lib\net462\AxInterop.MSTSCLib.dll" />
+    <file src="$(MAKEDIR)\bin\$(CONFIGURATION)\Google.Solutions.Tsc.dll" target="lib\net462\Google.Solutions.Tsc.dll" />
+    <file src="$(MAKEDIR)\bin\$(CONFIGURATION)\Interop.MSTSCLib.dll" target="lib\net462\Interop.MSTSCLib.dll" />
+  </files>
+</package>
+<<NOKEEP
+
+#------------------------------------------------------------------------------
+# Main targets
+#------------------------------------------------------------------------------
+
+package: $(MAKEDIR)\bin\$(CONFIGURATION)\Google.Solutions.Tsc.$(TSC_VERSION).nupkg
+    copy /Y $(MAKEDIR)\obj\$(CONFIGURATION)\Google.Solutions.Tsc.$(TSC_VERSION).nupkg $(MAKEDIR)\Google.Solutions.Tsc.nupkg
+
+clean:
+    msbuild /t:Clean "$(MAKEDIR)\Google.Solutions.Tsc.csproj"
+    -rd /S /Q $(MAKEDIR)\bin
+    -rd /S /Q $(MAKEDIR)\obj
+    -del $(MAKEDIR)\Google.Solutions.Tsc.nupkg
+    
+distclean: clean


### PR DESCRIPTION
Building the interop assemblies works poorly with SDK-style projects and
requires Windows Server with Desktop Experience. Extract into separate project
to remove these constraints from the main solution.