### PR TITLE
b/285957479 Use multiple jobs to track child processes

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Transport/Policies/TestChildProcessPolicy.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Transport/Policies/TestChildProcessPolicy.cs
@@ -36,7 +36,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Transport.Policies
     {
         protected override ProcessPolicyBase CreateInstance()
         {
-            return new ProcessInJobPolicy(new Mock<IWin32Job>().Object);
+            return new ChildProcessPolicy(new Mock<IWin32ChildProcessCollection>().Object);
         }
 
         //---------------------------------------------------------------------
@@ -48,7 +48,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Transport.Policies
         {
             Assert.AreEqual(
                 "Child processes", 
-                new ProcessInJobPolicy(new Mock<IWin32Job>().Object).ToString());
+                new ChildProcessPolicy(new Mock<IWin32ChildProcessCollection>().Object).ToString());
         }
 
         //---------------------------------------------------------------------
@@ -59,7 +59,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Transport.Policies
         public void WhenEndpointNotLoopback_ThenIsClientAllowedReturnsFalse()
         {
             var endpoint = new IPEndPoint(IPAddress.Parse("10.0.0.1"), 1111);
-            var policy = new ProcessInJobPolicy(new Mock<IWin32Job>().Object);
+            var policy = new ChildProcessPolicy(new Mock<IWin32ChildProcessCollection>().Object);
 
             Assert.IsFalse(policy.IsClientAllowed(endpoint));
         }
@@ -68,7 +68,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Transport.Policies
         public void WhenEndpointBelongsToDifferentProcess_ThenIsClientAllowedReturnsFalse()
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 445);
-            var policy = new ProcessInJobPolicy(new Mock<IWin32Job>().Object);
+            var policy = new ChildProcessPolicy(new Mock<IWin32ChildProcessCollection>().Object);
 
             Assert.IsFalse(policy.IsClientAllowed(endpoint));
         }
@@ -80,19 +80,19 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Transport.Policies
         [Test]
         public void WhenProcessInJob_ThenIsClientProcessAllowedReturnsTrue()
         {
-            var job = new Mock<IWin32Job>();
-            job.Setup(j => j.IsInJob(It.IsAny<uint>())).Returns(true);
+            var job = new Mock<IWin32ChildProcessCollection>();
+            job.Setup(j => j.Contains(It.IsAny<uint>())).Returns(true);
 
-            Assert.IsTrue(new ProcessInJobPolicy(job.Object).IsClientProcessAllowed(1));
+            Assert.IsTrue(new ChildProcessPolicy(job.Object).IsClientProcessAllowed(1));
         }
 
         [Test]
         public void WhenProcessNotInJob_ThenIsClientProcessAllowedReturnsFalse()
         {
-            var job = new Mock<IWin32Job>();
-            job.Setup(j => j.IsInJob(It.IsAny<uint>())).Returns(false);
+            var job = new Mock<IWin32ChildProcessCollection>();
+            job.Setup(j => j.Contains(It.IsAny<uint>())).Returns(false);
 
-            Assert.IsFalse(new ProcessInJobPolicy(job.Object).IsClientProcessAllowed(1));
+            Assert.IsFalse(new ChildProcessPolicy(job.Object).IsClientProcessAllowed(1));
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Transport/Policies/TestChildProcessPolicy.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Transport/Policies/TestChildProcessPolicy.cs
@@ -36,7 +36,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Transport.Policies
     {
         protected override ProcessPolicyBase CreateInstance()
         {
-            return new ChildProcessPolicy(new Mock<IWin32ChildProcessCollection>().Object);
+            return new ChildProcessPolicy(new Mock<IWin32ProcessSet>().Object);
         }
 
         //---------------------------------------------------------------------
@@ -48,7 +48,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Transport.Policies
         {
             Assert.AreEqual(
                 "Child processes", 
-                new ChildProcessPolicy(new Mock<IWin32ChildProcessCollection>().Object).ToString());
+                new ChildProcessPolicy(new Mock<IWin32ProcessSet>().Object).ToString());
         }
 
         //---------------------------------------------------------------------
@@ -59,7 +59,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Transport.Policies
         public void WhenEndpointNotLoopback_ThenIsClientAllowedReturnsFalse()
         {
             var endpoint = new IPEndPoint(IPAddress.Parse("10.0.0.1"), 1111);
-            var policy = new ChildProcessPolicy(new Mock<IWin32ChildProcessCollection>().Object);
+            var policy = new ChildProcessPolicy(new Mock<IWin32ProcessSet>().Object);
 
             Assert.IsFalse(policy.IsClientAllowed(endpoint));
         }
@@ -68,7 +68,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Transport.Policies
         public void WhenEndpointBelongsToDifferentProcess_ThenIsClientAllowedReturnsFalse()
         {
             var endpoint = new IPEndPoint(IPAddress.Loopback, 445);
-            var policy = new ChildProcessPolicy(new Mock<IWin32ChildProcessCollection>().Object);
+            var policy = new ChildProcessPolicy(new Mock<IWin32ProcessSet>().Object);
 
             Assert.IsFalse(policy.IsClientAllowed(endpoint));
         }
@@ -80,7 +80,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Transport.Policies
         [Test]
         public void WhenProcessInJob_ThenIsClientProcessAllowedReturnsTrue()
         {
-            var job = new Mock<IWin32ChildProcessCollection>();
+            var job = new Mock<IWin32ProcessSet>();
             job.Setup(j => j.Contains(It.IsAny<uint>())).Returns(true);
 
             Assert.IsTrue(new ChildProcessPolicy(job.Object).IsClientProcessAllowed(1));
@@ -89,7 +89,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Transport.Policies
         [Test]
         public void WhenProcessNotInJob_ThenIsClientProcessAllowedReturnsFalse()
         {
-            var job = new Mock<IWin32ChildProcessCollection>();
+            var job = new Mock<IWin32ProcessSet>();
             job.Setup(j => j.Contains(It.IsAny<uint>())).Returns(false);
 
             Assert.IsFalse(new ChildProcessPolicy(job.Object).IsClientProcessAllowed(1));

--- a/sources/Google.Solutions.IapDesktop.Core.Test/Google.Solutions.IapDesktop.Core.Test.csproj
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/Google.Solutions.IapDesktop.Core.Test.csproj
@@ -95,7 +95,7 @@
     <Compile Include="ClientModel\Traits\TestTraitDetector.cs" />
     <Compile Include="ClientModel\Traits\TestWindowsTrait.cs" />
     <Compile Include="ClientModel\Traits\TestInstanceTrait.cs" />
-    <Compile Include="ClientModel\Transport\Policies\TestProcessInJobPolicy.cs" />
+    <Compile Include="ClientModel\Transport\Policies\TestChildProcessPolicy.cs" />
     <Compile Include="ClientModel\Transport\Policies\TestCurrentProcessPolicy.cs" />
     <Compile Include="ClientModel\Transport\Policies\TestAllowAllPolicy.cs" />
     <Compile Include="ClientModel\Transport\TestDirectTransportFactory.cs" />

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/Policies/ChildProcessPolicy.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/Policies/ChildProcessPolicy.cs
@@ -25,16 +25,15 @@ using Google.Solutions.Platform.Dispatch;
 namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport.Policies
 {
     /// <summary>
-    /// Policy that only allows access from processes in a 
-    /// certain job.
+    /// Policy that only allows access from child processes.
     /// </summary>
-    public class ProcessInJobPolicy : ProcessPolicyBase
+    public class ChildProcessPolicy : ProcessPolicyBase
     {
-        public IWin32Job Job { get; }
+        private readonly IWin32ChildProcessCollection childProcesses;
 
-        public ProcessInJobPolicy(IWin32Job job)
+        public ChildProcessPolicy(IWin32ChildProcessCollection processFactory)
         {
-            this.Job = job.ExpectNotNull(nameof(job));
+            this.childProcesses = processFactory.ExpectNotNull(nameof(processFactory));
         }
 
         //---------------------------------------------------------------------
@@ -45,7 +44,7 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport.Policies
 
         protected internal override bool IsClientProcessAllowed(uint processId)
         {
-            return this.Job.IsInJob(processId);
+            return this.childProcesses.Contains(processId);
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/Policies/ChildProcessPolicy.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/Policies/ChildProcessPolicy.cs
@@ -29,9 +29,9 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport.Policies
     /// </summary>
     public class ChildProcessPolicy : ProcessPolicyBase
     {
-        private readonly IWin32ChildProcessCollection childProcesses;
+        private readonly IWin32ProcessSet childProcesses;
 
-        public ChildProcessPolicy(IWin32ChildProcessCollection processFactory)
+        public ChildProcessPolicy(IWin32ProcessSet processFactory)
         {
             this.childProcesses = processFactory.ExpectNotNull(nameof(processFactory));
         }

--- a/sources/Google.Solutions.IapDesktop.Core/Google.Solutions.IapDesktop.Core.csproj
+++ b/sources/Google.Solutions.IapDesktop.Core/Google.Solutions.IapDesktop.Core.csproj
@@ -83,7 +83,7 @@
     </Compile>
     <Compile Include="ClientModel\Transport\ITransportPolicy.cs" />
     <Compile Include="ClientModel\Transport\Policies\AllowAllPolicy.cs" />
-    <Compile Include="ClientModel\Transport\Policies\ProcessInJobPolicy.cs" />
+    <Compile Include="ClientModel\Transport\Policies\ChildProcessPolicy.cs" />
     <Compile Include="ClientModel\Transport\Policies\CurrentProcessPolicy.cs" />
     <Compile Include="ClientModel\Transport\Policies\ProcessPolicyBase.cs" />
     <Compile Include="CoreTraceSources.cs" />

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/InitializeSessionExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/InitializeSessionExtension.cs
@@ -129,8 +129,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Session
             //
             // Only allow connections from our own child processes.
             //
-            var clientAppPolicy = new ProcessInJobPolicy(
-                serviceProvider.GetService<IWin32ProcessFactory>().Job);
+            var clientAppPolicy = new ChildProcessPolicy(
+                serviceProvider.GetService<IWin32ChildProcessCollection>());
             
             protocolRegistry.RegisterProtocol(
                 new AppProtocol(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/InitializeSessionExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/InitializeSessionExtension.cs
@@ -130,7 +130,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session
             // Only allow connections from our own child processes.
             //
             var clientAppPolicy = new ChildProcessPolicy(
-                serviceProvider.GetService<IWin32ChildProcessCollection>());
+                serviceProvider.GetService<IWin32ProcessSet>());
             
             protocolRegistry.RegisterProtocol(
                 new AppProtocol(

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -343,7 +343,7 @@ namespace Google.Solutions.IapDesktop
 
             var install = new Install(Install.DefaultBaseKeyPath);
             using (var profile = LoadProfileOrExit(install, this.commandLineOptions))
-            using (var jobForChildProcesses = new Win32Job(true))
+            using (var processFactory = new Win32ChildProcessFactory(true))
             {
                 Debug.Assert(!Install.IsExecutingTests);
 
@@ -374,7 +374,6 @@ namespace Google.Solutions.IapDesktop
 
                 preAuthLayer.AddSingleton<ProtocolRegistry>();
 
-                var processFactory = new Win32ChildProcessFactory(true);
                 preAuthLayer.AddSingleton<IWin32ProcessFactory>(processFactory);
                 preAuthLayer.AddSingleton<IWin32ProcessSet>(processFactory);
 

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -373,8 +373,10 @@ namespace Google.Solutions.IapDesktop
                 preAuthLayer.AddTransient<IHttpProxyAdapter, HttpProxyAdapter>();
 
                 preAuthLayer.AddSingleton<ProtocolRegistry>();
-                preAuthLayer.AddSingleton<IWin32ProcessFactory>(
-                    new Win32ProcessFactory(jobForChildProcesses));
+
+                var processFactory = new Win32ChildProcessFactory(true);
+                preAuthLayer.AddSingleton<IWin32ProcessFactory>(processFactory);
+                preAuthLayer.AddSingleton<IWin32ChildProcessCollection>(processFactory);
 
                 var appSettingsRepository = new ApplicationSettingsRepository(
                     profile.SettingsKey.CreateSubKey("Application"),

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -376,7 +376,7 @@ namespace Google.Solutions.IapDesktop
 
                 var processFactory = new Win32ChildProcessFactory(true);
                 preAuthLayer.AddSingleton<IWin32ProcessFactory>(processFactory);
-                preAuthLayer.AddSingleton<IWin32ChildProcessCollection>(processFactory);
+                preAuthLayer.AddSingleton<IWin32ProcessSet>(processFactory);
 
                 var appSettingsRepository = new ApplicationSettingsRepository(
                     profile.SettingsKey.CreateSubKey("Application"),

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ChildProcessFactory.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ChildProcessFactory.cs
@@ -1,0 +1,92 @@
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Platform.Dispatch;
+using NUnit.Framework;
+using System;
+using System.Net;
+
+namespace Google.Solutions.Platform.Test.Dispatch
+{
+    [TestFixture]
+    public class TestWin32ChildProcessFactory
+    {
+        private static readonly string CmdExe
+            = $"{Environment.GetFolderPath(Environment.SpecialFolder.System)}\\cmd.exe";
+
+        //---------------------------------------------------------------------
+        // Contains.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenProcessFound_ThenContainsReturnsTrue()
+        {
+            using (var factory = new Win32ChildProcessFactory(true))
+            using (var process = factory.CreateProcess(CmdExe, null))
+            {
+                Assert.IsTrue(factory.Contains(process));
+                Assert.IsTrue(factory.Contains(process.Id));
+            }
+        }
+
+        [Test]
+        public void WhenProcessNotFound_ThenContainsReturnsFalse()
+        {
+            using (var factory = new Win32ChildProcessFactory(true))
+            {
+                Assert.IsFalse(factory.Contains(4));
+            }
+        }
+
+        //---------------------------------------------------------------------
+        // Dispose.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenTerminateOnCloseIsFalse_ThenDisposeKeepsProcesses()
+        {
+            var factory = new Win32ChildProcessFactory(false);
+            var process = factory.CreateProcess(CmdExe, null);
+            process.Resume();
+
+            Assert.IsTrue(process.IsRunning);
+            factory.Dispose();
+
+            Assert.IsTrue(process.IsRunning);
+            process.Terminate(0);
+            process.Dispose();
+        }
+
+        [Test]
+        public void WhenTerminateOnCloseIsTrue_ThenDisposeTerminatesProcesses()
+        {
+            var factory = new Win32ChildProcessFactory(true);
+            var process = factory.CreateProcess(CmdExe, null);
+            process.Resume();
+
+            Assert.IsTrue(process.IsRunning);
+            factory.Dispose();
+
+            Assert.IsFalse(process.IsRunning);
+            process.Dispose();
+        }
+    }
+}

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Job.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Job.cs
@@ -80,11 +80,11 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         //---------------------------------------------------------------------
-        // Add, IsInJob.
+        // Add, Contains.
         //---------------------------------------------------------------------
 
         [Test]
-        public void WhenAdded_ThenIsInJobReturnsTrue()
+        public void WhenAdded_ThenContainsReturnsTrue()
         {
             var factory = new Win32ProcessFactory();
 
@@ -93,24 +93,24 @@ namespace Google.Solutions.Platform.Test.Dispatch
                 CmdExe,
                 null))
             {
-                Assert.IsFalse(job.IsInJob(process));
-                Assert.IsFalse(job.IsInJob(process.Id));
+                Assert.IsFalse(job.Contains(process));
+                Assert.IsFalse(job.Contains(process.Id));
 
                 job.Add(process);
                 job.Add(process); // Again.
 
-                Assert.IsTrue(job.IsInJob(process));
-                Assert.IsTrue(job.IsInJob(process.Id));
+                Assert.IsTrue(job.Contains(process));
+                Assert.IsTrue(job.Contains(process.Id));
             }
         }
 
         [Test]
-        public void WhenProcessDoesNotExist_ThenIsInJobThrowsException()
+        public void WhenProcessDoesNotExist_ThenContainsThrowsException()
         {
             using (var job = new Win32Job(true))
             {
                 Assert.Throws<DispatchException>(
-                    () => job.IsInJob(uint.MaxValue));
+                    () => job.Contains(uint.MaxValue));
             }
         }
 

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Job.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Job.cs
@@ -42,9 +42,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         {
             var factory = new Win32ProcessFactory();
 
-            using (var process = factory.CreateProcess(
-                CmdExe,
-                null))
+            using (var process = factory.CreateProcess(CmdExe, null))
             {
                 var job = new Win32Job(true);
 
@@ -63,9 +61,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         {
             var factory = new Win32ProcessFactory();
 
-            using (var process = factory.CreateProcess(
-                CmdExe,
-                null))
+            using (var process = factory.CreateProcess(CmdExe, null))
             {
                 var job = new Win32Job(false);
 
@@ -76,6 +72,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
                 job.Dispose();
 
                 Assert.IsTrue(process.IsRunning);
+                process.Terminate(0);
             }
         }
 

--- a/sources/Google.Solutions.Platform.Test/Google.Solutions.Platform.Test.csproj
+++ b/sources/Google.Solutions.Platform.Test/Google.Solutions.Platform.Test.csproj
@@ -58,6 +58,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Cryptography\TestCertificateStore.cs" />
+    <Compile Include="Dispatch\TestWin32ChildProcessFactory.cs" />
     <Compile Include="Dispatch\TestWtsSession.cs" />
     <Compile Include="Net\TestBrowserProtocolRegistry.cs" />
     <Compile Include="Net\TestBrowser.cs" />

--- a/sources/Google.Solutions.Platform/Dispatch/IWin32ProcessSet.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/IWin32ProcessSet.cs
@@ -1,0 +1,39 @@
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+namespace Google.Solutions.Platform.Dispatch
+{
+    /// <summary>
+    /// A transitive set of processes, can be used to track child processes.
+    /// </summary>
+    public interface IWin32ProcessSet
+    {
+        /// <summary>
+        /// Check if a process is direct or indirect member of this set.
+        /// </summary>
+        bool Contains(IWin32Process process);
+
+        /// <summary>
+        /// Check if a process is direct or indirect member of this set.
+        /// </summary>
+        bool Contains(uint processId);
+    }
+}

--- a/sources/Google.Solutions.Platform/Dispatch/Win32ChildProcessFactory.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32ChildProcessFactory.cs
@@ -26,26 +26,9 @@ using System.Linq;
 namespace Google.Solutions.Platform.Dispatch
 {
     /// <summary>
-    /// Collection that contains all direct and indirect
-    /// child processes.
-    /// </summary>
-    public interface IWin32ChildProcessCollection // TODO: DOcument
-    {
-        /// <summary>
-        /// Check if a process is direct or indirect child process.
-        /// </summary>
-        bool Contains(IWin32Process process);
-
-        /// <summary>
-        /// Check if a process is direct or indirect child process.
-        /// </summary>
-        bool Contains(uint processId);
-    }
-
-    /// <summary>
     /// Factory for Win32 processes that uses jobs to track child processes
     /// </summary>
-    public class Win32ChildProcessFactory : Win32ProcessFactory, IWin32ChildProcessCollection, IDisposable
+    public class Win32ChildProcessFactory : Win32ProcessFactory, IWin32ProcessSet, IDisposable
     {
         //
         // NB. The easiest way to implement this class would be to use a single
@@ -77,14 +60,18 @@ namespace Google.Solutions.Platform.Dispatch
             this.TerminateOnClose = terminateOnClose;
         }
 
+        //---------------------------------------------------------------------
+        // IWin32ProcessSet.
+        //---------------------------------------------------------------------
+
         public bool Contains(IWin32Process process)
         {
-            return this.jobs.Any(j => j.IsInJob(process));
+            return this.jobs.Any(j => j.Contains(process));
         }
 
         public bool Contains(uint processId)
         {
-            return this.jobs.Any(j => j.IsInJob(processId));
+            return this.jobs.Any(j => j.Contains(processId));
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.Platform/Dispatch/Win32ChildProcessFactory.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32ChildProcessFactory.cs
@@ -1,0 +1,139 @@
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+
+namespace Google.Solutions.Platform.Dispatch
+{
+    /// <summary>
+    /// Collection that contains all direct and indirect
+    /// child processes.
+    /// </summary>
+    public interface IWin32ChildProcessCollection // TODO: DOcument
+    {
+        /// <summary>
+        /// Check if a process is direct or indirect child process.
+        /// </summary>
+        bool Contains(IWin32Process process);
+
+        /// <summary>
+        /// Check if a process is direct or indirect child process.
+        /// </summary>
+        bool Contains(uint processId);
+    }
+
+    /// <summary>
+    /// Factory for Win32 processes that uses jobs to track child processes
+    /// </summary>
+    public class Win32ChildProcessFactory : Win32ProcessFactory, IWin32ChildProcessCollection, IDisposable
+    {
+        //
+        // NB. The easiest way to implement this class would be to use a single
+        // job for all processes. But that doesn't work reliably for processes
+        // started with CreateProcessAsUser.
+        //
+        // When a process is started with CreateProcessAsUser, Windows
+        // automatically places the process in a (system-defined) job. 
+        // Recent versions of Windows allow processes to belong to multiple
+        // jobs, so we can add it to another job later.
+        //
+        // However, this only works once: If we launch another process
+        // using CreateProcessAsUser, and try to add it to the same job,
+        // then AssignProcessToJob fails with an access-denied error.
+        //
+        // To work around this limitations, we place each process in its
+        // own job, and maintain a collection of jobs. This is more complex,
+        // but it ensures that we're compatible with theq quirky
+        // CreateProcessAsUser behavior and also capture child processes.
+        //
+
+        private readonly ConcurrentBag<IWin32Job> jobs = new ConcurrentBag<IWin32Job>();
+
+        public bool TerminateOnClose { get; }
+        public bool IsDisposed { get; private set; }
+
+        public Win32ChildProcessFactory(bool terminateOnClose)
+        {
+            this.TerminateOnClose = terminateOnClose;
+        }
+
+        public bool Contains(IWin32Process process)
+        {
+            return this.jobs.Any(j => j.IsInJob(process));
+        }
+
+        public bool Contains(uint processId)
+        {
+            return this.jobs.Any(j => j.IsInJob(processId));
+        }
+
+        //---------------------------------------------------------------------
+        // Overrides.
+        //---------------------------------------------------------------------
+
+        protected override void OnProcessCreated(IWin32Process process)
+        {
+            var job = new Win32Job(this.TerminateOnClose);
+            try
+            {
+                job.Add(process);
+                this.jobs.Add(job);
+
+                //
+                // NB. We're not holding on to the process object
+                // at it might be disposed at any time.
+                //
+            }
+            catch (Exception)
+            {
+                job.Dispose();
+                throw;
+            }
+
+            base.OnProcessCreated(process);
+        }
+
+        //---------------------------------------------------------------------
+        // IDisposable.
+        //---------------------------------------------------------------------
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!this.IsDisposed)
+            {
+                foreach (var job in this.jobs)
+                {
+                    job.Dispose();
+                }
+
+                this.IsDisposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/sources/Google.Solutions.Platform/Dispatch/Win32Job.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32Job.cs
@@ -33,7 +33,7 @@ namespace Google.Solutions.Platform.Dispatch
     /// <summary>
     /// A Win32 job.
     /// </summary>
-    public interface IWin32Job : IDisposable
+    public interface IWin32Job : IWin32ProcessSet, IDisposable
     {
         /// <summary>
         /// Job handle.
@@ -44,16 +44,6 @@ namespace Google.Solutions.Platform.Dispatch
         /// Add a process to the job.
         /// </summary>
         void Add(IWin32Process process);
-
-        /// <summary>
-        /// Check if a process is in the job.
-        /// </summary>
-        bool IsInJob(IWin32Process process);
-
-        /// <summary>
-        /// Check if a process is in the job.
-        /// </summary>
-        bool IsInJob(uint processId);
 
         /// <summary>
         /// Return the IDs of processes in this job.
@@ -132,7 +122,7 @@ namespace Google.Solutions.Platform.Dispatch
             }
         }
 
-        public bool IsInJob(IWin32Process process)
+        public bool Contains(IWin32Process process)
         {
             process.ExpectNotNull(nameof(process));
 
@@ -148,7 +138,7 @@ namespace Google.Solutions.Platform.Dispatch
             return inJob;
         }
 
-        public bool IsInJob(uint processId)
+        public bool Contains(uint processId)
         {
             using (var process = NativeMethods.OpenProcess(
                 NativeMethods.PROCESS_QUERY_LIMITED_INFORMATION,

--- a/sources/Google.Solutions.Platform/Dispatch/Win32JobCollection.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32JobCollection.cs
@@ -1,0 +1,48 @@
+﻿using Google.Solutions.Common.Runtime;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+
+namespace Google.Solutions.Platform.Dispatch
+{
+    /// <summary>
+    /// Collection of jobs.
+    /// </summary>
+    public interface IWin32JobCollection : IDisposable
+    {
+        void Add(IWin32Job job);
+
+        IEnumerable<IWin32Job> Jobs { get; }
+    }
+
+    public class Win32JobCollection : DisposableBase, IWin32JobCollection
+    {
+        private readonly ConcurrentBag<IWin32Job> jobs = new ConcurrentBag<IWin32Job>();
+
+        //---------------------------------------------------------------------
+        // IWin32JobCollection.
+        //---------------------------------------------------------------------
+
+        public IEnumerable<IWin32Job> Jobs => this.jobs;
+
+        public void Add(IWin32Job job)
+        {
+            this.jobs.Add(job);
+        }
+
+
+        //---------------------------------------------------------------------
+        // DisposableBase.
+        //---------------------------------------------------------------------
+
+        protected override void Dispose(bool disposing)
+        {
+            foreach (var job in this.jobs)
+            {
+                job.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/sources/Google.Solutions.Platform/Dispatch/Win32JobCollection.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32JobCollection.cs
@@ -1,4 +1,25 @@
-﻿using Google.Solutions.Common.Runtime;
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Runtime;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;

--- a/sources/Google.Solutions.Platform/Google.Solutions.Platform.csproj
+++ b/sources/Google.Solutions.Platform/Google.Solutions.Platform.csproj
@@ -41,6 +41,8 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Dispatch\Win32JobCollection.cs" />
+    <Compile Include="Dispatch\Win32ChildProcessFactory.cs" />
     <Compile Include="PlatformTraceSources.cs" />
     <Compile Include="Cryptography\CertificateStore.cs" />
     <Compile Include="Dispatch\DispatchException.cs" />

--- a/sources/Google.Solutions.Platform/Google.Solutions.Platform.csproj
+++ b/sources/Google.Solutions.Platform/Google.Solutions.Platform.csproj
@@ -41,6 +41,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Dispatch\IWin32ProcessSet.cs" />
     <Compile Include="Dispatch\Win32JobCollection.cs" />
     <Compile Include="Dispatch\Win32ChildProcessFactory.cs" />
     <Compile Include="PlatformTraceSources.cs" />


### PR DESCRIPTION
Use a dedicated job for each child process launched to work around
the limitations imposed by CreateProcessAsUser.