### PR TITLE
b/285787664 Use deterministic port number if possible

### DIFF
--- a/sources/Google.Solutions.Common.Test/Format/TestBsdChecksum.cs
+++ b/sources/Google.Solutions.Common.Test/Format/TestBsdChecksum.cs
@@ -1,0 +1,59 @@
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Format;
+using NUnit.Framework;
+using System;
+using System.Text;
+
+namespace Google.Solutions.Common.Test.Format
+{
+    [TestFixture]
+    public class TestBsdChecksum
+    {
+        [Test]
+        public void Enpty([Values(1, 16, 32)] int lengthInBits)
+        {
+            Assert.AreEqual(
+                0,
+                BsdChecksum.Create(Array.Empty<byte>(), (ushort)lengthInBits));
+        }
+
+        [Test]
+        public void Zeros([Values(1, 16, 32)] int lengthInBits)
+        {
+            Assert.AreEqual(
+                0, 
+                BsdChecksum.Create(new byte[] { 0, 0, 0, 0 }, (ushort)lengthInBits));
+        }
+
+        [Test]
+        public void NonZero()
+        {
+            Assert.AreEqual(
+                41076,
+                BsdChecksum.Create(Encoding.ASCII.GetBytes("test\n"), 16));
+            Assert.AreEqual(
+                27248,
+                BsdChecksum.Create(Encoding.ASCII.GetBytes("Testdata\n"), 16));
+        }
+    }
+}

--- a/sources/Google.Solutions.Common.Test/Format/TestBsdChecksum.cs
+++ b/sources/Google.Solutions.Common.Test/Format/TestBsdChecksum.cs
@@ -32,28 +32,34 @@ namespace Google.Solutions.Common.Test.Format
         [Test]
         public void Enpty([Values(1, 16, 32)] int lengthInBits)
         {
-            Assert.AreEqual(
-                0,
-                BsdChecksum.Create(Array.Empty<byte>(), (ushort)lengthInBits));
+            var checksum = new BsdChecksum((ushort)lengthInBits);
+            checksum.Add(Array.Empty<byte>());
+            Assert.AreEqual(0, checksum.Value);
         }
 
         [Test]
         public void Zeros([Values(1, 16, 32)] int lengthInBits)
         {
-            Assert.AreEqual(
-                0, 
-                BsdChecksum.Create(new byte[] { 0, 0, 0, 0 }, (ushort)lengthInBits));
+            var checksum = new BsdChecksum((ushort)lengthInBits);
+            checksum.Add(new byte[] { 0, 0, 0, 0 });
+            Assert.AreEqual(0, checksum.Value);
         }
 
         [Test]
-        public void NonZero()
+        public void SingleChunk()
         {
-            Assert.AreEqual(
-                41076,
-                BsdChecksum.Create(Encoding.ASCII.GetBytes("test\n"), 16));
-            Assert.AreEqual(
-                27248,
-                BsdChecksum.Create(Encoding.ASCII.GetBytes("Testdata\n"), 16));
+            var checksum = new BsdChecksum(16);
+            checksum.Add(Encoding.ASCII.GetBytes("test\n"));
+            Assert.AreEqual(41076, checksum.Value);
+        }
+
+        [Test]
+        public void MultipleChunks()
+        {
+            var checksum = new BsdChecksum(16);
+            checksum.Add(Encoding.ASCII.GetBytes("Test"));
+            checksum.Add(Encoding.ASCII.GetBytes("data\n"));
+            Assert.AreEqual(27248, checksum.Value);
         }
     }
 }

--- a/sources/Google.Solutions.Common.Test/Google.Solutions.Common.Test.csproj
+++ b/sources/Google.Solutions.Common.Test/Google.Solutions.Common.Test.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Diagnostics\TestDumpObjectExtensions.cs" />
     <Compile Include="Diagnostics\TestTraceSourceExtensions.cs" />
     <Compile Include="Format\TestBigEndian.cs" />
+    <Compile Include="Format\TestBsdChecksum.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Interop\TestCoTaskMemAllocSafeHandle.cs" />
     <Compile Include="Interop\TestHresultExtensions.cs" />

--- a/sources/Google.Solutions.Common/Format/BsdChecksum.cs
+++ b/sources/Google.Solutions.Common/Format/BsdChecksum.cs
@@ -28,23 +28,30 @@ namespace Google.Solutions.Common.Format
     /// BSD checksum implementation, adapted to allow 
     /// checksums of arbitraty bit size (not just 16).
     /// </summary>
-    internal static class BsdChecksum
+    public class BsdChecksum
     {
-        public static uint Create(byte[] data, ushort lengthInBits)
+        private readonly ushort lengthInBits;
+        private uint checksum = 0;
+
+        public BsdChecksum(ushort lengthInBits)
+        {
+            Debug.Assert(lengthInBits > 0 && lengthInBits <= 32);
+            this.lengthInBits = lengthInBits;
+        }
+
+        public uint Value => this.checksum;
+
+        public void Add(byte[] data)
         {
             data.ExpectNotNull(nameof(data));
-            Debug.Assert(lengthInBits > 0 && lengthInBits <= 32);
 
-            uint mask = (uint)(1 << lengthInBits) - 1;
-            uint checksum = 0;
+            uint mask = (uint)(1 << this.lengthInBits) - 1;
             for (int i = 0; i < data.Length; i++)
             {
-                checksum = (checksum >> 1) + ((checksum & 1) << (lengthInBits - 1));
-                checksum += data[i];
-                checksum &= mask;
+                this.checksum = (this.checksum >> 1) + ((this.checksum & 1) << (this.lengthInBits - 1));
+                this.checksum += data[i];
+                this.checksum &= mask;
             }
-
-            return checksum;
         }
     }
 }

--- a/sources/Google.Solutions.Common/Format/BsdChecksum.cs
+++ b/sources/Google.Solutions.Common/Format/BsdChecksum.cs
@@ -1,0 +1,50 @@
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Util;
+using System.Diagnostics;
+
+namespace Google.Solutions.Common.Format
+{
+    /// <summary>
+    /// BSD checksum implementation, adapted to allow 
+    /// checksums of arbitraty bit size (not just 16).
+    /// </summary>
+    internal static class BsdChecksum
+    {
+        public static uint Create(byte[] data, ushort lengthInBits)
+        {
+            data.ExpectNotNull(nameof(data));
+            Debug.Assert(lengthInBits > 0 && lengthInBits <= 32);
+
+            uint mask = (uint)(1 << lengthInBits) - 1;
+            uint checksum = 0;
+            for (int i = 0; i < data.Length; i++)
+            {
+                checksum = (checksum >> 1) + ((checksum & 1) << (lengthInBits - 1));
+                checksum += data[i];
+                checksum &= mask;
+            }
+
+            return checksum;
+        }
+    }
+}

--- a/sources/Google.Solutions.Common/Google.Solutions.Common.csproj
+++ b/sources/Google.Solutions.Common/Google.Solutions.Common.csproj
@@ -46,6 +46,7 @@
     <Compile Include="Diagnostics\TraceCallScope.cs" />
     <Compile Include="Diagnostics\TraceSourceExtensions.cs" />
     <Compile Include="Format\BigEndian.cs" />
+    <Compile Include="Format\BsdChecksum.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Interop\ComReference.cs" />
     <Compile Include="Interop\CoTaskMemAllocSafeHandle.cs" />

--- a/sources/Google.Solutions.Iap.Test/Google.Solutions.Iap.Test.csproj
+++ b/sources/Google.Solutions.Iap.Test/Google.Solutions.Iap.Test.csproj
@@ -80,6 +80,7 @@
   <ItemGroup>
     <Compile Include="IapFixtureBase.cs" />
     <Compile Include="InitializeScripts.cs" />
+    <Compile Include="Net\TestPortFinder.cs" />
     <Compile Include="Protocol\Mocks.cs" />
     <Compile Include="Util\WebSocketServerExtensions.cs" />
     <Compile Include="Protocol\TestEchoOverIapBase.cs" />

--- a/sources/Google.Solutions.Iap.Test/Net/TestPortFinder.cs
+++ b/sources/Google.Solutions.Iap.Test/Net/TestPortFinder.cs
@@ -1,0 +1,74 @@
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Iap.Net;
+using NUnit.Framework;
+using System;
+using System.Net.WebSockets;
+using System.Text;
+
+namespace Google.Solutions.Iap.Test.Net
+{
+    [TestFixture]
+    public class TestPortFinder
+    {
+        //---------------------------------------------------------------------
+        // FindPort - no seed.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenNoSeedProvided_ThenFindPortReturnsRandomPort()
+        {
+            var portFinder = new PortFinder();
+
+            var port1 = portFinder.FindPort(out var preferred);
+            Assert.IsFalse(preferred);
+
+            var port2 = portFinder.FindPort(out preferred);
+            Assert.IsFalse(preferred);
+
+            Assert.AreNotEqual(port1, port2);
+        }
+
+        //---------------------------------------------------------------------
+        // FindPort - with seed.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenSeedProvided_ThenFindPortReturnsSamePort()
+        {
+            var portFinder = new PortFinder();
+            portFinder.AddSeed(Encoding.ASCII.GetBytes("some seed"));
+
+            var port1 = portFinder.FindPort(out var preferred);
+            
+            if (!preferred)
+            {
+                Assert.Inconclusive();
+            }
+
+            var port2 = portFinder.FindPort(out preferred);
+            Assert.IsTrue(preferred);
+
+            Assert.AreEqual(port1, port2);
+        }
+    }
+}

--- a/sources/Google.Solutions.Iap.Test/Util/WebSocketServer.cs
+++ b/sources/Google.Solutions.Iap.Test/Util/WebSocketServer.cs
@@ -38,7 +38,7 @@ namespace Google.Solutions.Iap.Test.Util
         {
             this.listener = new HttpListener();
 
-            var port = PortFinder.FindFreeLocalPort();
+            var port = new PortFinder().FindPort(out var _);
             this.Endpoint = new Uri($"ws://localhost:{port}/");
 
             this.listener.Prefixes.Add($"http://localhost:{port}/");

--- a/sources/Google.Solutions.Iap/IapListener.cs
+++ b/sources/Google.Solutions.Iap/IapListener.cs
@@ -126,7 +126,7 @@ namespace Google.Solutions.Iap
                 //
                 localEndpoint = new IPEndPoint(
                     IPAddress.Loopback,
-                    PortFinder.FindFreeLocalPort());
+                    new PortFinder().FindPort(out var _));
             }
 
             this.listener = new TcpListener(localEndpoint);

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/IapTunnel.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/IapTunnel.cs
@@ -224,6 +224,15 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport
                 this.LocalEndpoint = localEndpoint; // Optional.
             }
 
+            // TODO: Implement
+            //public ushort PreferredPort
+            //{
+            //    get
+            //    {
+            //        var buffer = EntryWrittenEventArgs
+            //    }
+            //}
+
             public override int GetHashCode()
             {
                 return
@@ -320,10 +329,16 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport
                         .ProbeAsync(probeTimeout)
                         .ConfigureAwait(false);
 
+                    var localEndpoint = profile.LocalEndpoint;
+                    if (localEndpoint == null)
+                    {
+                        // TODO: determine deterministic port.
+                    }
+
                     var listener = new IapListener(
                         client,
                         profile.Policy,
-                        profile.LocalEndpoint);
+                        localEndpoint);
 
                     var tunnel = new IapTunnel(
                         listener,


### PR DESCRIPTION
Whenever possible, use the same port number every time a tunnel
to the same destination is created. This helps avoid polluting the
history in client applications and take advantage of saved credentials.