### PR TITLE
Use composite drawing for top-level windows

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Views/About/AboutView.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Views/About/AboutView.cs
@@ -31,7 +31,7 @@ namespace Google.Solutions.IapDesktop.Application.Views.About
 {
     [SkipCodeCoverage("UI code")]
     [Service]
-    public partial class AboutView : Form, IView<AboutViewModel>
+    public partial class AboutView : CompositeForm, IView<AboutViewModel>
     {
 
         public static Version ProgramVersion => typeof(AboutView).Assembly.GetName().Version;

--- a/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
+++ b/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
@@ -40,6 +40,7 @@ using Google.Solutions.IapDesktop.Application.Views.ProjectExplorer;
 using Google.Solutions.IapDesktop.Core.ObjectModel;
 using Google.Solutions.Mvvm.Binding;
 using Google.Solutions.Mvvm.Binding.Commands;
+using Google.Solutions.Mvvm.Controls;
 using Google.Solutions.Mvvm.Drawing;
 using Google.Solutions.Mvvm.Shell;
 using System;
@@ -57,7 +58,7 @@ using WeifenLuo.WinFormsUI.Docking;
 
 namespace Google.Solutions.IapDesktop.Windows
 {
-    public partial class MainForm : Form, IJobHost, IMainWindow
+    public partial class MainForm : CompositeForm, IJobHost, IMainWindow
     {
         //
         // Calculate minimum size so that it's a quarter of a 1080p screen,

--- a/sources/Google.Solutions.Mvvm/Binding/PropertiesView.cs
+++ b/sources/Google.Solutions.Mvvm/Binding/PropertiesView.cs
@@ -21,6 +21,7 @@
 
 using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.Mvvm.Binding.Commands;
+using Google.Solutions.Mvvm.Controls;
 using Google.Solutions.Mvvm.Theme;
 using System.Drawing;
 using System.Windows.Forms;
@@ -28,7 +29,7 @@ using System.Windows.Forms;
 namespace Google.Solutions.Mvvm.Binding
 {
     [SkipCodeCoverage("UI code")]
-    public partial class PropertiesView : Form, IThemedView<PropertiesViewModel>
+    public partial class PropertiesView : CompositeForm, IThemedView<PropertiesViewModel>
     {
         public IControlTheme Theme { get; set; }
 

--- a/sources/Google.Solutions.Mvvm/Controls/CompositeForm.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/CompositeForm.cs
@@ -1,0 +1,50 @@
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+
+using Google.Solutions.Mvvm.Interop;
+using System.Windows.Forms;
+
+namespace Google.Solutions.Mvvm.Controls
+{
+    /// <summary>
+    /// A form that is drawn with WS_EX_COMPOSITED style.
+    /// 
+    /// If a form contains many consols, this style can
+    /// provide a better (flicker-free) experience.
+    /// </summary>
+    public class CompositeForm : Form
+    {
+        protected override CreateParams CreateParams
+        {
+            get
+            {
+                //
+                // Draw all controls at once. This helps reduce flickering,
+                // particularly in dark mode.
+                //
+                var cp = base.CreateParams;
+                cp.ExStyle |= (int)WindowStyles.WS_EX_COMPOSITED;
+                return cp;
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.Mvvm/Interop/WindowStyles.cs
+++ b/sources/Google.Solutions.Mvvm/Interop/WindowStyles.cs
@@ -1,0 +1,28 @@
+﻿//
+// Copyright 2022 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+namespace Google.Solutions.Mvvm.Interop
+{
+    public enum WindowStyles : int
+    {
+        WS_EX_COMPOSITED = 0x02000000
+    }
+}


### PR DESCRIPTION
Reduce flickering by using composite drawing for top-level windows.
The effects are particularly noticable in dark mode.