### PR TITLE
b/286941354 Use non-composite window style for main window

### DIFF
--- a/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
+++ b/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
@@ -58,7 +58,7 @@ using WeifenLuo.WinFormsUI.Docking;
 
 namespace Google.Solutions.IapDesktop.Windows
 {
-    public partial class MainForm : CompositeForm, IJobHost, IMainWindow
+    public partial class MainForm : Form, IJobHost, IMainWindow
     {
         //
         // Calculate minimum size so that it's a quarter of a 1080p screen,


### PR DESCRIPTION
Using WS_EX_COMPOSITED interferes with TSC.