### PR TITLE
b/286161182 Allow custom usernames for SQL Server auth

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolClient.cs
@@ -57,7 +57,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         }
 
         [Test]
-        public void WhenArgumentsContainsPlaceholders_ThenFormatArgumentsResolvesPlaceholders()
+        public void WhenArgumentsContainsPlaceholdersButParametersAreEmpty_ThenFormatArgumentsResolvesPlaceholders()
         {
             var transport = new Mock<ITransport>();
             transport
@@ -66,12 +66,34 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
 
             var client = new AppProtocolClient(
                 "doesnotexist.exe",
-                "/port %port% /host %host% /ignore %HOST%Port%% %foo%%%");
+                "/port %port% /host %host% /ignore %HOST%Port%% %foo%%% /user %username%%");
 
             var parameters = new AppProtocolParameters();
 
             Assert.AreEqual(
-                "/port 8080 /host 127.0.0.2 /ignore %HOST%Port%% %foo%%%",
+                "/port 8080 /host 127.0.0.2 /ignore %HOST%Port%% %foo%%% /user %",
+                client.FormatArguments(transport.Object, parameters));
+        }
+
+        [Test]
+        public void WhenArgumentsContainsPlaceholdersAndParametersSet_ThenFormatArgumentsResolvesPlaceholders()
+        {
+            var transport = new Mock<ITransport>();
+            transport
+                .SetupGet(t => t.Endpoint)
+                .Returns(new IPEndPoint(IPAddress.Parse("127.0.0.2"), 8080));
+
+            var client = new AppProtocolClient(
+                "doesnotexist.exe",
+                "/port %port% /host %host% /ignore %HOST%Port%% %foo%%% /user %username%%");
+
+            var parameters = new AppProtocolParameters()
+            {
+                PreferredUsername = "root",
+            };
+
+            Assert.AreEqual(
+                "/port 8080 /host 127.0.0.2 /ignore %HOST%Port%% %foo%%% /user root%",
                 client.FormatArguments(transport.Object, parameters));
         }
 

--- a/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolClient.cs
@@ -19,6 +19,7 @@
 // under the License.
 //
 
+using Google.Solutions.IapDesktop.Core.ClientModel;
 using Google.Solutions.IapDesktop.Core.ClientModel.Protocol;
 using Google.Solutions.IapDesktop.Core.ClientModel.Transport;
 using Moq;
@@ -50,7 +51,9 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
             var transport = new Mock<ITransport>();
             var client = new AppProtocolClient("doesnotexist.exe", null);
 
-            Assert.IsNull(client.FormatArguments(transport.Object));
+            Assert.IsNull(client.FormatArguments(
+                transport.Object, 
+                new AppProtocolParameters()));
         }
 
         [Test]
@@ -65,9 +68,11 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
                 "doesnotexist.exe",
                 "/port %port% /host %host% /ignore %HOST%Port%% %foo%%%");
 
+            var parameters = new AppProtocolParameters();
+
             Assert.AreEqual(
                 "/port 8080 /host 127.0.0.2 /ignore %HOST%Port%% %foo%%%",
-                client.FormatArguments(transport.Object));
+                client.FormatArguments(transport.Object, parameters));
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolContext.cs
@@ -200,7 +200,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
                         SampleLocator,
                         protocol.RemotePort,
                         protocol.LocalEndpoint,
-                        context.ConnectionTimeout,
+                        context.Parameters.ConnectionTimeout,
                         CancellationToken.None),
                     Times.Once);
             }

--- a/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolContext.cs
@@ -142,7 +142,11 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         {
             var client = new Mock<IAppProtocolClient>();
             client.SetupGet(c => c.Executable).Returns("client.exe");
-            client.Setup(c => c.FormatArguments(It.IsAny<ITransport>())).Returns("args");
+            client
+                .Setup(c => c.FormatArguments(
+                    It.IsAny<ITransport>(),
+                    It.IsAny<AppProtocolParameters>()))
+                .Returns("args");
 
             var processFactory = new Mock<IWin32ProcessFactory>();
             processFactory

--- a/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolContext.cs
@@ -20,6 +20,7 @@
 //
 
 using Google.Solutions.Apis.Locator;
+using Google.Solutions.IapDesktop.Core.ClientModel;
 using Google.Solutions.IapDesktop.Core.ClientModel.Protocol;
 using Google.Solutions.IapDesktop.Core.ClientModel.Traits;
 using Google.Solutions.IapDesktop.Core.ClientModel.Transport;
@@ -106,7 +107,11 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         {
             var client = new Mock<IAppProtocolClient>();
             client.SetupGet(c => c.Executable).Returns("client.exe");
-            client.Setup(c => c.FormatArguments(It.IsAny<ITransport>())).Returns("args");
+            client
+                .Setup(c => c.FormatArguments(
+                    It.IsAny<ITransport>(),
+                    It.IsAny<AppProtocolParameters>()))
+                .Returns("args");
 
             var processFactory = new Mock<IWin32ProcessFactory>();
             processFactory

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/AppProtocolParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/AppProtocolParameters.cs
@@ -25,6 +25,9 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel
 {
     public class AppProtocolParameters
     {
+        internal AppProtocolParameters()
+        {
+        }
 
         /// <summary>
         /// Timeout for connecting transport.

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/AppProtocolParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/AppProtocolParameters.cs
@@ -1,0 +1,34 @@
+﻿//
+// Copyright 2023 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
+
+namespace Google.Solutions.IapDesktop.Core.ClientModel
+{
+    public class AppProtocolParameters
+    {
+
+        /// <summary>
+        /// Timeout for connecting transport.
+        /// </summary>
+        public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(20);
+    }
+}

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/AppProtocolParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/AppProtocolParameters.cs
@@ -33,5 +33,10 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel
         /// Timeout for connecting transport.
         /// </summary>
         public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(20);
+
+        /// <summary>
+        /// Preferred username.
+        /// </summary>
+        public string PreferredUsername { get; set; } = null;
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Protocol/AppProtocolClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Protocol/AppProtocolClient.cs
@@ -59,8 +59,9 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
         /// Optional: Arguments to be passed. Arguments can contain the
         /// following placeholders:
         /// 
-        ///   %port% - contains the local port to connect to
-        ///   %host% - contain the locat IP address to connect to
+        ///   %port%:     the local port to connect to
+        ///   %host%:     the locat IP address to connect to
+        ///   %username%: the username to authenticate with (can be empty)
         ///   
         /// </summary>
         internal string ArgumentsTemplate { get; }
@@ -97,7 +98,8 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
             {
                 arguments = arguments
                     .Replace("%port%", transport.Endpoint.Port.ToString())
-                    .Replace("%host%", transport.Endpoint.Address.ToString());
+                    .Replace("%host%", transport.Endpoint.Address.ToString())
+                    .Replace("%username%", parameters.PreferredUsername ?? string.Empty);
             }
 
             return arguments;

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Protocol/AppProtocolClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Protocol/AppProtocolClient.cs
@@ -43,7 +43,9 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
         /// Create command line arguments, incorporating the information
         /// from the transport if necessary.
         /// </summary>
-        string FormatArguments(ITransport transport);
+        string FormatArguments(
+            ITransport transport,
+            AppProtocolParameters parameters);
     }
 
     public class AppProtocolClient : IAppProtocolClient
@@ -63,7 +65,7 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
         /// </summary>
         internal string ArgumentsTemplate { get; }
 
-        internal protected AppProtocolClient(
+        protected internal AppProtocolClient(
             string executable,
             string argumentsTemplate)
         {
@@ -86,11 +88,19 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
             get => true;
         }
 
-        public string FormatArguments(ITransport transport)
+        public string FormatArguments(
+            ITransport transport,
+            AppProtocolParameters parameters)
         {
-            return this.ArgumentsTemplate?
-                .Replace("%port%", transport.Endpoint.Port.ToString())?
-                .Replace("%host%", transport.Endpoint.Address.ToString());
+            string arguments = this.ArgumentsTemplate;
+            if (arguments != null)
+            {
+                arguments = arguments
+                    .Replace("%port%", transport.Endpoint.Port.ToString())
+                    .Replace("%host%", transport.Endpoint.Address.ToString());
+            }
+
+            return arguments;
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Protocol/AppProtocolContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Protocol/AppProtocolContext.cs
@@ -74,7 +74,7 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
             {
                 return this.processFactory.CreateProcessAsUser(
                     client.Executable,
-                    client.FormatArguments(transport),
+                    client.FormatArguments(transport, this.Parameters),
                     LogonFlags.NetCredentialsOnly,
                     this.NetworkCredential);
             }
@@ -82,7 +82,7 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
             {
                 return this.processFactory.CreateProcess(
                     client.Executable,
-                    client.FormatArguments(transport));
+                    client.FormatArguments(transport, this.Parameters));
             }
         }
 

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Protocol/AppProtocolContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Protocol/AppProtocolContext.cs
@@ -42,10 +42,7 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
         /// </summary>
         public NetworkCredential NetworkCredential { get; set; }
 
-        /// <summary>
-        /// Timeout for connecting transport.
-        /// </summary>
-        public TimeSpan ConnectionTimeout { get; set; } = TimeSpan.FromSeconds(20);
+        public AppProtocolParameters Parameters { get; }
 
         public AppProtocolContext(
             AppProtocol protocol,
@@ -57,6 +54,7 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
             this.transportFactory = transportFactory.ExpectNotNull(nameof(transportFactory));
             this.processFactory = processFactory.ExpectNotNull(nameof(processFactory));
             this.target = target.ExpectNotNull(nameof(target));
+            this.Parameters = new AppProtocolParameters();
         }
 
         //---------------------------------------------------------------------
@@ -101,7 +99,7 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
                 this.target,
                 this.protocol.RemotePort,
                 this.protocol.LocalEndpoint,
-                this.ConnectionTimeout,
+                this.Parameters.ConnectionTimeout,
                 cancellationToken);
         }
 

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Protocol/AppProtocolFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Protocol/AppProtocolFactory.cs
@@ -272,8 +272,9 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
             /// Arguments can contain the following
             /// placeholders:
             /// 
-            ///   %port% - contains the local port to connect to
-            ///   %host% - contain the locat IP address to connect to
+            ///   %port%:     the local port to connect to
+            ///   %host%:     the locat IP address to connect to
+            ///   %username%: the username to authenticate with (can be empty)
             ///   
             /// </summary>
             [JsonProperty("arguments")]

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/App/TestSsmsClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/App/TestSsmsClient.cs
@@ -62,7 +62,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
         //---------------------------------------------------------------------
 
         [Test]
-        public void WhenNetworkCredentialTypeIsDefault_ThenFormatArgumentsReturnsString()
+        public void WhenNetworkCredentialTypeIsDefaultAndUsernameEmpty_ThenFormatArgumentsReturnsStringForSqlAuth(
+            [Values("", " ", null)] string emptyish)
         {
             var transport = new Mock<ITransport>();
             transport
@@ -70,7 +71,10 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
                 .Returns(new IPEndPoint(IPAddress.Parse("127.0.0.2"), 11443));
             var client = new SsmsClient("SSMS", NetworkCredentialType.Default);
 
-            var parameters = new AppProtocolParameters();
+            var parameters = new AppProtocolParameters()
+            {
+                PreferredUsername = emptyish
+            };
 
             Assert.AreEqual(
                 "-S 127.0.0.2,11443 -U sa",
@@ -78,7 +82,26 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
         }
 
         [Test]
-        public void WhenNetworkCredentialTypeIsWindows_ThenFormatArgumentsReturnsString(
+        public void WhenNetworkCredentialTypeIsDefaultAndUsernameSet_ThenFormatArgumentsReturnsStringForSqlAuth()
+        {
+            var transport = new Mock<ITransport>();
+            transport
+                .SetupGet(t => t.Endpoint)
+                .Returns(new IPEndPoint(IPAddress.Parse("127.0.0.2"), 11443));
+            var client = new SsmsClient("SSMS", NetworkCredentialType.Default);
+
+            var parameters = new AppProtocolParameters()
+            {
+                PreferredUsername = "username",
+            };
+
+            Assert.AreEqual(
+                "-S 127.0.0.2,11443 -U username",
+                client.FormatArguments(transport.Object, parameters));
+        }
+
+        [Test]
+        public void WhenNetworkCredentialTypeIsWindows_ThenFormatArgumentsReturnsStringForWindowsAuth(
             [Values(
                 NetworkCredentialType.Rdp,
                 NetworkCredentialType.Prompt)] NetworkCredentialType type)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/App/TestSsmsClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/App/TestSsmsClient.cs
@@ -20,6 +20,7 @@
 //
 
 
+using Google.Solutions.IapDesktop.Core.ClientModel;
 using Google.Solutions.IapDesktop.Core.ClientModel.Transport;
 using Google.Solutions.IapDesktop.Extensions.Session.Protocol.App;
 using Moq;
@@ -69,9 +70,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
                 .Returns(new IPEndPoint(IPAddress.Parse("127.0.0.2"), 11443));
             var client = new SsmsClient("SSMS", NetworkCredentialType.Default);
 
+            var parameters = new AppProtocolParameters();
+
             Assert.AreEqual(
                 "-S 127.0.0.2,11443 -U sa",
-                client.FormatArguments(transport.Object));
+                client.FormatArguments(transport.Object, parameters));
         }
 
         [Test]
@@ -86,9 +89,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
                 .Returns(new IPEndPoint(IPAddress.Parse("127.0.0.2"), 11443));
             var client = new SsmsClient("SSMS", type);
 
+            var parameters = new AppProtocolParameters();
+
             Assert.AreEqual(
                 "-S 127.0.0.2,11443 -E",
-                client.FormatArguments(transport.Object));
+                client.FormatArguments(transport.Object, parameters));
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Rdp/TestRdpContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Rdp/TestRdpContext.cs
@@ -51,7 +51,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
             var context = new RdpContext(
                 new Mock<IIapTransportFactory>().Object,
                 new Mock<IDirectTransportFactory>().Object,
-                new Mock<IAddressResolver>().Object,
                 SampleInstance,
                 credential,
                 RdpParameters.ParameterSources.Inventory);
@@ -86,7 +85,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
             var context = new RdpContext(
                 factory.Object,
                 new Mock<IDirectTransportFactory>().Object,
-                new Mock<IAddressResolver>().Object,
                 SampleInstance,
                 RdpCredential.Empty,
                 RdpParameters.ParameterSources.Inventory);
@@ -102,14 +100,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
         [Test]
         public async Task WhenTransportTypeIsVpcInternal_ThenConnectTransportCreatesDirectTransport()
         {
-            var addressResolver = new Mock<IAddressResolver>();
-            addressResolver.Setup(
-                r => r.GetAddressAsync(
-                    SampleInstance,
-                    NetworkInterfaceType.PrimaryInternal,
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(IPAddress.Parse("20.21.22.23"));
-
             var transport = new Mock<ITransport>();
             var factory = new Mock<IDirectTransportFactory>();
             factory
@@ -124,7 +114,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
             var context = new RdpContext(
                 new Mock<IIapTransportFactory>().Object,
                 factory.Object,
-                addressResolver.Object,
                 SampleInstance,
                 RdpCredential.Empty,
                 RdpParameters.ParameterSources.Inventory);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Rdp/TestSessionContextFactoryForRdp.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Rdp/TestSessionContextFactoryForRdp.cs
@@ -105,7 +105,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
                 settingsService.Object,
                 new Mock<IIapTransportFactory>().Object,
                 new Mock<IDirectTransportFactory>().Object,
-                new Mock<IAddressResolver>().Object,
                 new Mock<ISelectCredentialsDialog>().Object,
                 new Mock<IRdpCredentialCallback>().Object,
                 CreateSshSettingsRepository());
@@ -156,7 +155,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
                 settingsService.Object,
                 new Mock<IIapTransportFactory>().Object,
                 new Mock<IDirectTransportFactory>().Object,
-                new Mock<IAddressResolver>().Object,
                 new Mock<ISelectCredentialsDialog>().Object,
                 new Mock<IRdpCredentialCallback>().Object,
                 CreateSshSettingsRepository());
@@ -212,7 +210,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
                 settingsService.Object,
                 new Mock<IIapTransportFactory>().Object,
                 new Mock<IDirectTransportFactory>().Object,
-                new Mock<IAddressResolver>().Object,
                 credentialDialog.Object,
                 new Mock<IRdpCredentialCallback>().Object,
                 CreateSshSettingsRepository());
@@ -266,7 +263,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
                 settingsService.Object,
                 new Mock<IIapTransportFactory>().Object,
                 new Mock<IDirectTransportFactory>().Object,
-                new Mock<IAddressResolver>().Object,
                 credentialDialog.Object,
                 new Mock<IRdpCredentialCallback>().Object,
                 CreateSshSettingsRepository());
@@ -331,7 +327,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
                 settingsService.Object,
                 new Mock<IIapTransportFactory>().Object,
                 new Mock<IDirectTransportFactory>().Object,
-                new Mock<IAddressResolver>().Object,
                 credentialDialog.Object,
                 new Mock<IRdpCredentialCallback>().Object,
                 CreateSshSettingsRepository());
@@ -378,7 +373,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
                 new Mock<IConnectionSettingsService>().Object,
                 new Mock<IIapTransportFactory>().Object,
                 new Mock<IDirectTransportFactory>().Object,
-                new Mock<IAddressResolver>().Object,
                 new Mock<ISelectCredentialsDialog>().Object,
                 callbackService.Object,
                 CreateSshSettingsRepository());
@@ -416,7 +410,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
                 new Mock<IConnectionSettingsService>().Object,
                 new Mock<IIapTransportFactory>().Object,
                 new Mock<IDirectTransportFactory>().Object,
-                new Mock<IAddressResolver>().Object,
                 new Mock<ISelectCredentialsDialog>().Object,
                 callbackService.Object,
                 CreateSshSettingsRepository());

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestSessionContextFactoryForSsh.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestSessionContextFactoryForSsh.cs
@@ -132,7 +132,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
                 settingsService.Object,
                 new Mock<IIapTransportFactory>().Object,
                 new Mock<IDirectTransportFactory>().Object,
-                new Mock<IAddressResolver>().Object,
                 new Mock<ISelectCredentialsDialog>().Object,
                 new Mock<IRdpCredentialCallback>().Object,
                 CreateSshSettingsRepository());
@@ -177,7 +176,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
                 settingsService.Object,
                 new Mock<IIapTransportFactory>().Object,
                 new Mock<IDirectTransportFactory>().Object,
-                new Mock<IAddressResolver>().Object,
                 new Mock<ISelectCredentialsDialog>().Object,
                 new Mock<IRdpCredentialCallback>().Object,
                 CreateSshSettingsRepository());
@@ -223,7 +221,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
                 settingsService.Object,
                 new Mock<IIapTransportFactory>().Object,
                 new Mock<IDirectTransportFactory>().Object,
-                new Mock<IAddressResolver>().Object,
                 new Mock<ISelectCredentialsDialog>().Object,
                 new Mock<IRdpCredentialCallback>().Object,
                 sshSettingsRepository);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestSshContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestSshContext.cs
@@ -70,7 +70,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
                 new Mock<IIapTransportFactory>().Object,
                 new Mock<IDirectTransportFactory>().Object,
                 keyAuthorizer.Object,
-                new Mock<IAddressResolver>().Object,
                 SampleInstance,
                 key);
 
@@ -107,7 +106,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
                 factory.Object,
                 new Mock<IDirectTransportFactory>().Object,
                 new Mock<IKeyAuthorizer>().Object,
-                new Mock<IAddressResolver>().Object,
                 SampleInstance,
                 new Mock<ISshKeyPair>().Object);
             context.Parameters.TransportType = SessionTransportType.IapTunnel;
@@ -122,14 +120,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
         [Test]
         public async Task WhenTransportTypeIsVpcInternal_ThenConnectTransportCreatesDirectTransport()
         {
-            var addressResolver = new Mock<IAddressResolver>();
-            addressResolver.Setup(
-                r => r.GetAddressAsync(
-                    SampleInstance,
-                    NetworkInterfaceType.PrimaryInternal,
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(IPAddress.Parse("20.21.22.23"));
-
             var transport = new Mock<ITransport>();
             var factory = new Mock<IDirectTransportFactory>();
             factory
@@ -145,7 +135,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
                 new Mock<IIapTransportFactory>().Object,
                 factory.Object,
                 new Mock<IKeyAuthorizer>().Object,
-                addressResolver.Object,
                 SampleInstance,
                 new Mock<ISshKeyPair>().Object);
             context.Parameters.TransportType = SessionTransportType.Vpc;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestConnectionSettingsService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestConnectionSettingsService.cs
@@ -58,7 +58,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             settingsRepository.SetProjectSettings(projectSettings);
         }
 
-
         private IProjectModelProjectNode CreateProjectNode()
         {
             var projectNode = new Mock<IProjectModelProjectNode>();
@@ -313,6 +312,25 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             CollectionAssert.IsNotSupersetOf(
                 settings.Settings,
                 settings.TypedCollection.RdpSettings);
+        }
+
+        //---------------------------------------------------------------------
+        // AppSettings.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void AppUsername()
+        {
+            var vmNode = CreateVmInstanceNode(false);
+
+            var settings = this.service.GetConnectionSettings(vmNode);
+
+            settings.TypedCollection.AppUsername.Value = "sa";
+            settings.TypedCollection.AppUsername.Value = null;
+            settings.TypedCollection.AppUsername.Value = string.Empty;
+
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => settings.TypedCollection.AppUsername.Value = "has spaces");
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestConnectionSettingsService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestConnectionSettingsService.cs
@@ -278,25 +278,41 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
         //---------------------------------------------------------------------
 
         [Test]
-        public void WhenInstanceIsWindows_ThenSettingsOnlyContainRdpSettings()
+        public void WhenInstanceIsWindows_ThenSettingsContainRdpAndAppSettings()
         {
             var vmNode = CreateVmInstanceNode(true);
 
             var settings = this.service.GetConnectionSettings(vmNode);
-            CollectionAssert.AreEquivalent(
-                settings.TypedCollection.RdpSettings,
-                settings.Settings);
+
+            CollectionAssert.IsSupersetOf(
+                settings.Settings,
+                settings.TypedCollection.RdpSettings);
+            CollectionAssert.IsSupersetOf(
+                settings.Settings,
+                settings.TypedCollection.AppSettings);
+
+            CollectionAssert.IsNotSupersetOf(
+                settings.Settings,
+                settings.TypedCollection.SshSettings);
         }
 
         [Test]
-        public void WhenInstanceIsLinux_ThenSettingsOnlyContainRdpSettings()
+        public void WhenInstanceIsLinux_ThenSettingsContainSshAndAppSettings()
         {
             var vmNode = CreateVmInstanceNode(false);
 
             var settings = this.service.GetConnectionSettings(vmNode);
-            CollectionAssert.AreEquivalent(
-                settings.TypedCollection.SshSettings,
-                settings.Settings);
+
+            CollectionAssert.IsSupersetOf(
+                settings.Settings,
+                settings.TypedCollection.SshSettings);
+            CollectionAssert.IsSupersetOf(
+                settings.Settings,
+                settings.TypedCollection.AppSettings);
+
+            CollectionAssert.IsNotSupersetOf(
+                settings.Settings,
+                settings.TypedCollection.RdpSettings);
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/App/TestOpenWithAppCommand.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/App/TestOpenWithAppCommand.cs
@@ -287,6 +287,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.App
                 .Setup(f => f.CreateProcess(It.IsAny<string>(), It.IsAny<string>()))
                 .Returns(process.Object);
 
+            var settingsService = new Mock<IConnectionSettingsService>();
+            settingsService
+                .Setup(s => s.GetConnectionSettings(It.IsAny<IProjectModelNode>()))
+                .Returns(InstanceConnectionSettings
+                    .CreateNew(SampleLocator)
+                    .ToPersistentSettingsCollection(s => Assert.Fail("should not be called")));
+
             var factory = new AppContextFactory(
                 new AppProtocol(
                     "app-1",
@@ -297,7 +304,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.App
                     client.Object),
                 new Mock<IIapTransportFactory>().Object,
                 processFactory.Object,
-                new Mock<IConnectionSettingsService>().Object);
+                settingsService.Object);
 
             var command = new OpenWithAppCommand(
                 new Mock<IWin32Window>().Object,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/App/AppContextFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/App/AppContextFactory.cs
@@ -27,6 +27,7 @@ using Google.Solutions.IapDesktop.Core.ProjectModel;
 using Google.Solutions.IapDesktop.Extensions.Session.Settings;
 using Google.Solutions.Platform.Dispatch;
 using System;
+using System.Diagnostics;
 using System.Net;
 using System.Security;
 using System.Threading;
@@ -83,16 +84,18 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.App
                     this.processFactory,
                     instance.Instance);
 
+                Debug.Assert(context.Parameters != null);
+
+                var settings = this.settingsService
+                    .GetConnectionSettings(instance)
+                    .TypedCollection;
+
                 var contextFlags = (AppProtocolContextFlags)flags;
                 if (contextFlags.HasFlag(AppProtocolContextFlags.TryUseRdpNetworkCredentials))
                 {
                     //
                     // See if we have RDP credentials.
                     //
-                    var settings = this.settingsService
-                        .GetConnectionSettings(instance)
-                        .TypedCollection;
-
                     if (!string.IsNullOrEmpty(settings.RdpUsername.StringValue))
                     {
                         context.NetworkCredential = new NetworkCredential(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/App/AppContextFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/App/AppContextFactory.cs
@@ -90,6 +90,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.App
                     .GetConnectionSettings(instance)
                     .TypedCollection;
 
+                //
+                // Populate parameters from settings.
+                //
+                context.Parameters.PreferredUsername = settings.AppUsername.StringValue;
+
                 var contextFlags = (AppProtocolContextFlags)flags;
                 if (contextFlags.HasFlag(AppProtocolContextFlags.TryUseRdpNetworkCredentials))
                 {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/App/SsmsClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/App/SsmsClient.cs
@@ -19,6 +19,7 @@
 // under the License.
 //
 
+using Google.Solutions.IapDesktop.Core.ClientModel;
 using Google.Solutions.IapDesktop.Core.ClientModel.Transport;
 using System.Drawing;
 
@@ -70,7 +71,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.App
             get => this.ssms?.ExecutablePath;
         }
 
-        public string FormatArguments(ITransport transport)
+        public string FormatArguments(
+            ITransport transport,
+            AppProtocolParameters parameters)
         {
             //
             // Create command line arguments based on

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/App/SsmsClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/App/SsmsClient.cs
@@ -79,9 +79,23 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.App
             // Create command line arguments based on
             // https://learn.microsoft.com/en-us/sql/ssms/ssms-utility?view=sql-server-ver16
             //
-            var authFlag = this.RequiredCredential == NetworkCredentialType.Default
-                ? "-U sa"  // SQL Server authentication.
-                : "-E";    // Windows authentication.
+            string authFlag;
+            if (this.RequiredCredential == NetworkCredentialType.Default)
+            {
+                //
+                // SQL Server authentication.
+                //
+                authFlag = string.IsNullOrWhiteSpace(parameters.PreferredUsername)
+                    ? "-U sa"
+                    : $"-U {parameters.PreferredUsername}";
+            }
+            else
+            {
+                //
+                // Windows authentication.
+                //
+                authFlag = "-E";
+            }
 
             var endpoint = transport.Endpoint;
             return $"-S {endpoint.Address},{endpoint.Port} {authFlag}";

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpContext.cs
@@ -38,14 +38,12 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
         internal RdpContext(
             IIapTransportFactory iapTransportFactory,
             IDirectTransportFactory directTransportFactory,
-            IAddressResolver addressResolver,
             InstanceLocator instance,
             RdpCredential credential,
             RdpParameters.ParameterSources sources)
             : base(
                   iapTransportFactory,
                   directTransportFactory,
-                  addressResolver,
                   instance,
                   new RdpParameters()
                   {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextBase.cs
@@ -37,7 +37,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol
     {
         private readonly IIapTransportFactory iapTransportFactory;
         private readonly IDirectTransportFactory directTransportFactory;
-        private readonly IAddressResolver addressResolver;
 
         protected async Task<ITransport> ConnectTransportAsync(
             IProtocol protocol,
@@ -78,13 +77,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol
         protected SessionContextBase(
             IIapTransportFactory iapTransportFactory,
             IDirectTransportFactory directTransportFactory,
-            IAddressResolver addressResolver,
             InstanceLocator instance,
             TParameters parameters)
         {
             this.iapTransportFactory = iapTransportFactory.ExpectNotNull(nameof(SessionContextBase<TCredential, TParameters>.iapTransportFactory));
             this.directTransportFactory = directTransportFactory.ExpectNotNull(nameof(directTransportFactory));
-            this.addressResolver = addressResolver.ExpectNotNull(nameof(addressResolver));
             this.Instance = instance.ExpectNotNull(nameof(instance));
             this.Parameters = parameters.ExpectNotNull(nameof(parameters));
         }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextFactory.cs
@@ -90,7 +90,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol
         private readonly SshSettingsRepository sshSettingsRepository;
         private readonly IIapTransportFactory iapTransportFactory;
         private readonly IDirectTransportFactory directTransportFactory;
-        private readonly IAddressResolver addressResolver;
         private readonly ISelectCredentialsDialog credentialDialog;
         private readonly IRdpCredentialCallback rdpCredentialCallbackService;
 
@@ -103,7 +102,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol
             IConnectionSettingsService settingsService,
             IIapTransportFactory iapTransportFactory,
             IDirectTransportFactory directTransportFactory,
-            IAddressResolver addressResolver,
             ISelectCredentialsDialog credentialDialog,
             IRdpCredentialCallback credentialCallbackService,
             SshSettingsRepository sshSettingsRepository)
@@ -116,7 +114,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol
             this.settingsService = settingsService.ExpectNotNull(nameof(settingsService));
             this.iapTransportFactory = iapTransportFactory.ExpectNotNull(nameof(iapTransportFactory));
             this.directTransportFactory = directTransportFactory.ExpectNotNull(nameof(directTransportFactory));
-            this.addressResolver = addressResolver;
             this.credentialDialog = credentialDialog;
             this.rdpCredentialCallbackService = credentialCallbackService.ExpectNotNull(nameof(credentialCallbackService));
             this.sshSettingsRepository = sshSettingsRepository.ExpectNotNull(nameof(sshSettingsRepository));
@@ -144,7 +141,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol
             var context = new RdpContext(
                 this.iapTransportFactory,
                 this.directTransportFactory,
-                this.addressResolver,
                 instance,
                 credential,
                 sources);
@@ -331,7 +327,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol
                 this.iapTransportFactory,
                 this.directTransportFactory,
                 this.keyAuthorizer,
-                this.addressResolver,
                 node.Instance,
                 localKeyPair);
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Ssh/SshContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Ssh/SshContext.cs
@@ -44,13 +44,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Ssh
             IIapTransportFactory iapTransportFactory,
             IDirectTransportFactory directTransportFactory,
             IKeyAuthorizer keyAuthorizer,
-            IAddressResolver addressResolver,
             InstanceLocator instance,
             ISshKeyPair localKeyPair)
             : base(
                   iapTransportFactory,
                   directTransportFactory,
-                  addressResolver,
                   instance,
                   new SshParameters())
         {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
@@ -410,7 +410,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                 Categories.AppCredentials,
                 null,
                 key,
-                username => string.IsNullOrEmpty(username));
+                username => string.IsNullOrEmpty(username) || !username.Contains(' '));
 
             Debug.Assert(this.Settings.All(s => s != null));
         }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
@@ -402,7 +402,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
             //
             // App Settings.
             //
-
             this.AppUsername = RegistryStringSetting.FromKey(
                 "AppUsername",
                 "Username",

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
@@ -22,6 +22,7 @@
 using Google.Solutions.Apis.Locator;
 using Google.Solutions.IapDesktop.Application.Data;
 using Google.Solutions.IapDesktop.Application.Profile.Settings;
+using Google.Solutions.IapDesktop.Core.ProjectModel;
 using Google.Solutions.IapDesktop.Extensions.Session.Protocol;
 using Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp;
 using Google.Solutions.IapDesktop.Extensions.Session.Protocol.Ssh;
@@ -37,11 +38,8 @@ using System.Security.Cryptography;
 
 namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
 {
-
-
     public abstract class ConnectionSettingsBase : IRegistrySettingsCollection
     {
-
         private static class Categories
         {
             private const ushort MaxIndex = 6;
@@ -128,8 +126,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
             this.RdpAuthenticationLevel,
         };
 
-        internal bool IsRdpSetting(ISetting setting) => this.RdpSettings.Contains(setting);
-
         //---------------------------------------------------------------------
         // SSH settings.
         //---------------------------------------------------------------------
@@ -151,7 +147,27 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
             this.SshUsername,
         };
 
-        internal bool IsSshSetting(ISetting setting) => this.SshSettings.Contains(setting);
+        //---------------------------------------------------------------------
+        // Internals.
+        //---------------------------------------------------------------------
+
+        internal bool AppliesTo(
+            ISetting setting,
+            IProjectModelInstanceNode node)
+        {
+            if (this.SshSettings.Contains(setting))
+            {
+                return node.IsSshSupported();
+            }
+            else if (this.RdpSettings.Contains(setting))
+            {
+                return node.IsRdpSupported();
+            }
+            else
+            {
+                return true;
+            }
+        }
 
         //---------------------------------------------------------------------
         // IRegistrySettingsCollection.

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettingsService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettingsService.cs
@@ -93,9 +93,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                     vmNode.Instance.ProjectId,
                     vmNode.Instance.Name);
 
-                var supportsRdp = vmNode.IsRdpSupported();
-                var supportsSsh = vmNode.IsSshSupported();
-
                 // Apply overlay to get effective settings.
                 return projectSettings
                     .OverlayBy(zoneSettings)
@@ -104,10 +101,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                     // Save back to same repository.
                     .ToPersistentSettingsCollection(s => this.repository.SetVmInstanceSettings(s))
 
-                    // Hide any settings that are not applicable to the operating system.
-                    .ToFilteredSettingsCollection((coll, setting) => supportsRdp
-                        ? coll.IsRdpSetting(setting)
-                        : supportsSsh && coll.IsSshSetting(setting));
+                    // Hide any settings that are not applicable to this instance.
+                    .ToFilteredSettingsCollection((coll, setting) => coll.AppliesTo(setting, vmNode));
             }
             else
             {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/App/AppCommands.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/App/AppCommands.cs
@@ -103,7 +103,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.App
         private class ConnectWithAppCommand : MenuCommandBase<IProjectModelNode>
         {
             public ConnectWithAppCommand()
-                : base("Connect &with client")
+                : base("Connect client a&pplication")
             {
             }
 

--- a/sources/Google.Solutions.Testing.Apis/Integration/InstanceAttribute.cs
+++ b/sources/Google.Solutions.Testing.Apis/Integration/InstanceAttribute.cs
@@ -74,7 +74,7 @@ namespace Google.Solutions.Testing.Apis.Integration
                 var imageSpecificationRaw = Encoding.UTF8.GetBytes(imageSpecification.ToString());
                 return this.InstanceNamePrefix + BitConverter
                     .ToString(sha.ComputeHash(imageSpecificationRaw))
-                    .Replace("-", String.Empty)
+                    .Replace("-", string.Empty)
                     .Substring(0, 14)
                     .ToLower();
             }


### PR DESCRIPTION
* Add `AppUsername` setting to connection settings
* Change AppProtolContext to use parameters object
* Use `AppUsername` for SQL Server auth