### PR TITLE
b/289861037 Change display of app settings

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Dialog/TestCredentialDialog.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Dialog/TestCredentialDialog.cs
@@ -109,8 +109,8 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Dialog
 
             if (dialog.PromptForUsername(
                 null,
-                "Caption",
-                "Message",
+                "A very, very, very, very, very long caption",
+                "A very, very, very, very, very long message ",
                 out var username) == DialogResult.OK)
             {
                 Assert.NotNull(username);

--- a/sources/Google.Solutions.IapDesktop.Application/Windows/Dialog/UsernameDialog.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/Dialog/UsernameDialog.cs
@@ -57,14 +57,15 @@ namespace Google.Solutions.IapDesktop.Application.Windows.Dialog
             {
                 Text = caption,
                 Location = new Point(24 - 2, 40),
-                Size = new Size(200, 30),
+                AutoSize = false,
+                Size = new Size(this.Width - 50, 30),
             });
             this.Controls.Add(new Label()
             {
                 Text = message,
                 Location = new Point(24, 80),
                 AutoSize = false,
-                Size = new Size(200, 20),
+                Size = new Size(this.Width - 50, 20),
             });
 
             //

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
@@ -68,7 +68,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
             public static readonly string SshConnection = Order(5, "SSH Connection");
             public static readonly string SshCredentials = Order(6, "SSH Credentials");
 
-            public static readonly string AppCredentials = Order(7, "Client Application Credentials");
+            public static readonly string AppCredentials = Order(7, "SQL Server");
         }
 
         //---------------------------------------------------------------------
@@ -408,9 +408,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
             //
             this.AppUsername = RegistryStringSetting.FromKey(
                 "AppUsername",
-                "Username",
-                "Preferred username for client applications",
-                Categories.AppCredentials,
+                null, // Hidden.
+                null, // Hidden.
+                null, // Hidden.
                 null,
                 key,
                 username => string.IsNullOrEmpty(username) || !username.Contains(' '));


### PR DESCRIPTION
* Rename category to "SQL Server" as SSMS is currently the only client that the settings apply to
* Hide username setting as persisted usernames might be confusing when there are multiple client apps
* Fix length of label in username dialog so that the entire protocol name is displayed