### PR TITLE
b/289962760 Include file name in error message

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolConfigurationFile.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolConfigurationFile.cs
@@ -117,6 +117,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
             File.WriteAllText(filePath, json);
 
             ExceptionAssert.ThrowsAggregateException<InvalidAppProtocolException>(
+                $"file {filePath}",
                 () => AppProtocolConfigurationFile.ReadFileAsync(filePath).Wait());
         }
     }

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Protocol/AppProtocolConfigurationFile.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Protocol/AppProtocolConfigurationFile.cs
@@ -108,7 +108,7 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
             catch (JsonException e)
             {
                 throw new InvalidAppProtocolException(
-                    "The protocol configuration is malformed", e);
+                    "The protocol configuration contains format errors", e);
             }
         }
 
@@ -125,10 +125,15 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Protocol
                             .Deserialize<MainSection>(stream));
                     }
                 }
+                catch (InvalidAppProtocolException e)
+                {
+                    throw new InvalidAppProtocolException(
+                        $"The protocol configuration file {path} contains format errors", e);
+                }
                 catch (JsonException e)
                 {
                     throw new InvalidAppProtocolException(
-                        $"The protocol configuration file {path} is malformed", e);
+                        $"The protocol configuration file {path} contains format errors", e);
                 }
             });
         }

--- a/sources/Google.Solutions.Testing.Apis/Assert.cs
+++ b/sources/Google.Solutions.Testing.Apis/Assert.cs
@@ -71,6 +71,29 @@ namespace Google.Solutions.Testing.Apis
                 }
             });
         }
+
+        public static TActual ThrowsAggregateException<TActual>(
+                string expectedStringInMessage,
+                TestDelegate code)
+            where TActual : Exception
+        {
+            return Assert.Throws<TActual>(() =>
+            {
+                try
+                {
+                    code();
+                }
+                catch (AggregateException e)
+                {
+                    StringAssert.Contains(
+                        expectedStringInMessage, 
+                        e.FullMessage(),
+                        "Expected different exception message");
+
+                    throw e.Unwrap();
+                }
+            });
+        }
     }
 
     public static class PropertyAssert


### PR DESCRIPTION
When a file contains syntax errors, show an error message that includes the name of the offending file.