### PR TITLE
b/290481676 Automatically resolve path if client executable is a registered app

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolConfigurationFileSection.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolConfigurationFileSection.cs
@@ -23,6 +23,7 @@ using Google.Solutions.IapDesktop.Core.ClientModel.Protocol;
 using Google.Solutions.IapDesktop.Core.ClientModel.Traits;
 using NUnit.Framework;
 using System;
+using System.IO;
 using System.Linq;
 using System.Net;
 
@@ -39,7 +40,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         public void WhenValueIsNullOrEmpty_ThenParseNameThrowsException(
             [Values(" ", "", null)] string value)
         {
-            var section = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+            var section = new AppProtocolConfigurationFile.MainSection()
             {
                 Name = value
             };
@@ -55,7 +56,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         public void WhenConditionIsNullOrEmpty_ThenParseConditionReturnsEmpty(
             [Values(" ", "", null)] string condition)
         {
-            var section = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+            var section = new AppProtocolConfigurationFile.MainSection()
             {
                 Condition = condition
             };
@@ -67,7 +68,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         public void WhenConditionContainsSingleClause_ThenParseConditionReturnsTraits(
             [Values("isInstance()", " \nisInstance( )\r\n")] string condition)
         {
-            var section = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+            var section = new AppProtocolConfigurationFile.MainSection()
             {
                 Condition = condition
             };
@@ -81,7 +82,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         [Test]
         public void WhenConditionContainsMultipleClauses_ThenParseConditionReturnsTraits()
         {
-            var section = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+            var section = new AppProtocolConfigurationFile.MainSection()
             {
                 Condition = "isInstance() && isWindows() &&isLinux() "
             };
@@ -99,7 +100,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         public void WhenConditionContainsUnknownClause_ThenParseConditionThrowsException(
             [Values("isFoo()", " \nisInstance( ) && isBar\r\n")] string condition)
         {
-            var section = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+            var section = new AppProtocolConfigurationFile.MainSection()
             {
                 Condition = condition
             };
@@ -115,7 +116,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         public void WhenValueIsNullOrEmpty_ThenParseRemotePortThrowsException(
             [Values(null, "", " \n")] string value)
         {
-            var section = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+            var section = new AppProtocolConfigurationFile.MainSection()
             {
                 RemotePort = value
             };
@@ -128,7 +129,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         public void WhenValueIsMalformed_ThenParseRemotePortThrowsException(
             [Values("test", "-1", "100000")] string value)
         {
-            var section = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+            var section = new AppProtocolConfigurationFile.MainSection()
             {
                 RemotePort = value
             };
@@ -139,7 +140,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         [Test]
         public void WhenValueIsValid_ThenParseRemotePortReturnsPort()
         {
-            var section = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+            var section = new AppProtocolConfigurationFile.MainSection()
             {
                 RemotePort = "80"
             };
@@ -155,7 +156,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         public void WhenValueIsNullOrEmpty_ThenParseLocalEndpointReturnsNull(
             [Values(null, "", " \n")] string value)
         {
-            var section = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+            var section = new AppProtocolConfigurationFile.MainSection()
             {
                 LocalPort = value
             };
@@ -167,7 +168,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         public void WhenValueIsMalformed_ThenParseLocalEndpointThrowsException(
             [Values("::", "test:0", "127.0.0.1:test", ":")] string value)
         {
-            var section = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+            var section = new AppProtocolConfigurationFile.MainSection()
             {
                 LocalPort = value
             };
@@ -180,62 +181,62 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
         {
             Assert.AreEqual(
                 new IPEndPoint(IPAddress.Loopback, 80),
-                new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+                new AppProtocolConfigurationFile.MainSection()
                 {
                     LocalPort = "80"
                 }.ParseLocalEndpoint());
             Assert.AreEqual(
                 new IPEndPoint(IPAddress.Loopback, 80),
-                new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+                new AppProtocolConfigurationFile.MainSection()
                 {
                     LocalPort = "127.0.0.1:80"
                 }.ParseLocalEndpoint());
             Assert.AreEqual(
                 new IPEndPoint(IPAddress.Parse("127.0.0.2"), 80),
-                new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+                new AppProtocolConfigurationFile.MainSection()
                 {
                     LocalPort = "127.0.0.2:80"
                 }.ParseLocalEndpoint());
         }
 
         //---------------------------------------------------------------------
-        // ParseCommand.
+        // ParseClientSection.
         //---------------------------------------------------------------------
 
         [Test]
-        public void WhenCommandIsNull_ThenParseCommandReturnsEmpty()
+        public void WhenClientIsNull_ThenParseClientSectionReturnsEmpty()
         {
-            Assert.IsNull(new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection().ParseCommand());
+            Assert.IsNull(new AppProtocolConfigurationFile.MainSection().ParseClientSection());
         }
 
         [Test]
-        public void WhenCommandExecutableIsNullOrEmpty_ThenParseCommandReturnsEmpty(
+        public void WhenClientExecutableIsNullOrEmpty_ThenParseClientSectionReturnsEmpty(
             [Values(null, "", " \n")] string value)
         {
-            var section = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+            var section = new AppProtocolConfigurationFile.MainSection()
             {
-                Client = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.ClientSection()
+                Client = new AppProtocolConfigurationFile.ClientSection()
                 {
                     Executable = value
                 }
             };
 
-            Assert.IsNull(section.ParseCommand());
+            Assert.IsNull(section.ParseClientSection());
         }
 
         [Test]
-        public void WhenCommandContainsVariables_ThenParseCommandExpandsVariables()
+        public void WhenClientExecutableContainsVariables_ThenParseClientSectionExpandsVariables()
         {
-            var section = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.MainSection()
+            var section = new AppProtocolConfigurationFile.MainSection()
             {
-                Client = new Core.ClientModel.Protocol.AppProtocolConfigurationFile.ClientSection()
+                Client = new AppProtocolConfigurationFile.ClientSection()
                 {
                     Executable = "%ProgramFiles(x86)%\\foo.exe",
                     Arguments = "%ProgramFiles(x86)%\\foo.txt {host}",
                 }
             };
 
-            var client = (AppProtocolClient)section.ParseCommand();
+            var client = (AppProtocolClient)section.ParseClientSection();
             Assert.IsNotNull(client);
 
             var programsFolder = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
@@ -243,6 +244,39 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
             StringAssert.Contains(programsFolder, client.Executable);
             StringAssert.Contains(programsFolder, client.ArgumentsTemplate);
             StringAssert.Contains("{host}", client.ArgumentsTemplate);
+        }
+
+        [Test]
+        public void WhenClientExecutableContainsFilenameOfRegisteredApp_ThenParseClientSectionResolvesAppPath()
+        {
+            var section = new AppProtocolConfigurationFile.MainSection()
+            {
+                Client = new AppProtocolConfigurationFile.ClientSection()
+                {
+                    Executable = "powershell.exe"
+                }
+            };
+
+            var client = (AppProtocolClient)section.ParseClientSection();
+            Assert.IsNotNull(client);
+            Assert.IsTrue(File.Exists(client.Executable));
+        }
+
+        [Test]
+        public void WhenClientExecutableContainsFilename_ThenParseClientSectionReturnsFilename(
+            [Values("notaregisteredapp.exe", "notanapp.txt")] string fileName)
+        {
+            var section = new AppProtocolConfigurationFile.MainSection()
+            {
+                Client = new AppProtocolConfigurationFile.ClientSection()
+                {
+                    Executable = fileName
+                }
+            };
+
+            var client = (AppProtocolClient)section.ParseClientSection();
+            Assert.IsNotNull(client);
+            Assert.AreEqual("doesnotexist.exe", client.Executable);
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolConfigurationFileSection.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Protocol/TestAppProtocolConfigurationFileSection.cs
@@ -276,7 +276,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Protocol
 
             var client = (AppProtocolClient)section.ParseClientSection();
             Assert.IsNotNull(client);
-            Assert.AreEqual("doesnotexist.exe", client.Executable);
+            Assert.AreEqual(fileName, client.Executable);
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Properties/Config/chrome-8080.iapc
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Properties/Config/chrome-8080.iapc
@@ -12,7 +12,7 @@
     // Use guest mode to prevent any browsing history or cookies from bleeding
     // to or from the IAP-protected resource.
     //
-    "executable": "%ProgramW6432%\\Google\\Chrome\\Application\\chrome.exe",
+    "executable": "chrome.exe",
     "arguments": "--user-data-dir=%temp%\\chrome-guest-{port} --guest \"http://{host}:{port}/"
   }
 }

--- a/sources/Google.Solutions.Platform.Test/TestUserEnvironment.cs
+++ b/sources/Google.Solutions.Platform.Test/TestUserEnvironment.cs
@@ -21,6 +21,7 @@
 
 using NUnit.Framework;
 using System;
+using System.IO;
 
 namespace Google.Solutions.Platform.Test
 {
@@ -60,6 +61,24 @@ namespace Google.Solutions.Platform.Test
             Assert.AreEqual(
                 source,
                 UserEnvironment.ExpandEnvironmentStrings(source));
+        }
+
+        //---------------------------------------------------------------------
+        // TryResolveAppPath.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenAppUnknown_ThenTryResolveAppPathReturnsFalse()
+        {
+            Assert.IsFalse(UserEnvironment.TryResolveAppPath("doesnotexist.exe", out var _));
+        }
+
+        [Test]
+        public void WhenAppRegistered_ThenTryResolveAppPathReturnsPath()
+        {
+            Assert.IsTrue(UserEnvironment.TryResolveAppPath("IExPlOrE.EXE", out var iexplore));
+            Assert.IsNotNull(iexplore);
+            Assert.IsTrue(File.Exists(iexplore));
         }
     }
 }

--- a/sources/Google.Solutions.Platform.Test/TestUserEnvironment.cs
+++ b/sources/Google.Solutions.Platform.Test/TestUserEnvironment.cs
@@ -76,9 +76,16 @@ namespace Google.Solutions.Platform.Test
         [Test]
         public void WhenAppRegistered_ThenTryResolveAppPathReturnsPath()
         {
-            Assert.IsTrue(UserEnvironment.TryResolveAppPath("IExPlOrE.EXE", out var iexplore));
-            Assert.IsNotNull(iexplore);
-            Assert.IsTrue(File.Exists(iexplore));
+            Assert.IsTrue(UserEnvironment.TryResolveAppPath("Powershell.EXE", out var powershell));
+            Assert.IsNotNull(powershell);
+            Assert.IsTrue(File.Exists(powershell));
+        }
+
+        [Test]
+        public void WhenAppNameIsPath_ThenTryResolveAppPathReturnsFalse(
+            [Values("../app.exe", "c:\\app.exe")] string exeName)
+        {
+            Assert.IsFalse(UserEnvironment.TryResolveAppPath(exeName, out var _));
         }
     }
 }

--- a/sources/Google.Solutions.Platform/Net/Browser.cs
+++ b/sources/Google.Solutions.Platform/Net/Browser.cs
@@ -105,17 +105,15 @@ namespace Google.Solutions.Platform.Net
 
     public class ChromeBrowser : Browser
     {
-        private const string AppPath = @"SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths";
-        private static string ChromeExecutablePath { get; }
+        private static string ChromeExecutablePath { get; } = null;
 
         private readonly string arguments;
 
         static ChromeBrowser()
         {
-            using (var hive = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Default))
-            using (var chromeAppPath = hive.OpenSubKey($@"{AppPath}\chrome.exe", false))
+            if (UserEnvironment.TryResolveAppPath("chrome.exe", out var chromePath))
             {
-                ChromeExecutablePath = (string)chromeAppPath?.GetValue(null);
+                ChromeExecutablePath = chromePath;
             }
         }
 

--- a/sources/Google.Solutions.Platform/UserEnvironment.cs
+++ b/sources/Google.Solutions.Platform/UserEnvironment.cs
@@ -21,7 +21,9 @@
 
 using Google.Solutions.Common.Util;
 using Microsoft.Win32;
+using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -65,7 +67,23 @@ namespace Google.Solutions.Platform
         public static bool TryResolveAppPath(string exeName, out string path)
         {
             Precondition.ExpectNotEmpty(exeName,nameof(exeName));
-            Debug.Assert(exeName.EndsWith(".exe", System.StringComparison.OrdinalIgnoreCase));
+
+            if (exeName.Contains('\\') || exeName.Contains('/'))
+            {
+                //
+                // This looks like a path, not an app name.
+                //
+                path = null;
+                return false;
+            }
+            else if (!exeName.EndsWith(".exe", StringComparison.OrdinalIgnoreCase))
+            {
+                //
+                // Not an app.
+                //
+                path = null;
+                return false;
+            }
 
             var hives = new[] { RegistryHive.CurrentUser, RegistryHive.LocalMachine };
             foreach (var hive in hives )


### PR DESCRIPTION
* Add helper method to resolve registered apps using `App Paths` registry key
* Allow the executable in client protocol configuration files to refer to registered apps
* Use the mechanism for Chrome so that it works for 32-bit and 64-bit installs