### PR TITLE
Revert "b/288725273 Use composite drawing for Authorize window"

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Windows/Authorization/AuthorizeView.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/Authorization/AuthorizeView.cs
@@ -23,7 +23,6 @@ using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.IapDesktop.Application.Properties;
 using Google.Solutions.Mvvm.Binding;
 using Google.Solutions.Mvvm.Binding.Commands;
-using Google.Solutions.Mvvm.Controls;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -32,7 +31,7 @@ using System.Windows.Forms;
 namespace Google.Solutions.IapDesktop.Application.Windows.Authorization
 {
     [SkipCodeCoverage("UI")]
-    public partial class AuthorizeView : CompositeForm, IView<AuthorizeViewModel>
+    public partial class AuthorizeView : Form, IView<AuthorizeViewModel>
     {
         public AuthorizeView()
         {


### PR DESCRIPTION
When a different window has focus, the Authorize window isn't shown in the task bar.

Revert #1030 to fix this issue