### PR TITLE
b/291170927 Fix InvalidOperationException when cancelling wait

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Windows/WaitDialog.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/WaitDialog.cs
@@ -21,7 +21,6 @@
 
 using System;
 using System.Diagnostics;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -50,7 +49,18 @@ namespace Google.Solutions.IapDesktop.Application.Windows
 
         private void cancelButton_Click(object sender, EventArgs e)
         {
-            this.cancellationSource.Cancel();
+            try
+            {
+                this.cancellationSource.Cancel();
+            }
+            catch 
+            {
+                //
+                // Canceallation may fail if the task has been completed
+                // or cancelled already.
+                //
+            }
+
             Close();
         }
 


### PR DESCRIPTION
When cancalling the wait dialog that's shown during exit, it's possible that the task completes before it can be cancelled.