### PR TITLE
b/293968777 Set user agent in token requests

### DIFF
--- a/sources/Google.Solutions.Apis.Test/Auth/Gaia/TestGaiaOidcClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Auth/Gaia/TestGaiaOidcClient.cs
@@ -27,6 +27,7 @@ using Google.Solutions.Apis.Auth;
 using Google.Solutions.Apis.Auth.Gaia;
 using Google.Solutions.Apis.Client;
 using Google.Solutions.Testing.Apis;
+using Google.Solutions.Testing.Apis.Integration;
 using Moq;
 using NUnit.Framework;
 using System.Threading;
@@ -270,7 +271,7 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
                 IDeviceEnrollment deviceEnrollment,
                 IOidcOfflineCredentialStore store,
                 ClientSecrets clientSecrets) 
-                : base(endpoint, deviceEnrollment, store, clientSecrets)
+                : base(endpoint, deviceEnrollment, store, clientSecrets, TestProject.UserAgent)
             {
             }
 
@@ -308,7 +309,8 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
                 GaiaOidcClient.CreateEndpoint(),
                 enrollment.Object,
                 store.Object,
-                new ClientSecrets());
+                new ClientSecrets(),
+                TestProject.UserAgent);
 
             ExceptionAssert.ThrowsAggregateException<TokenResponseException>(
                 () => client.AuthorizeAsync(codeReceiver, CancellationToken.None).Wait());
@@ -349,7 +351,8 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
                 GaiaOidcClient.CreateEndpoint(),
                 enrollment.Object,
                 store.Object,
-                new ClientSecrets());
+                new ClientSecrets(),
+                TestProject.UserAgent);
 
             ExceptionAssert.ThrowsAggregateException<TokenResponseException>(
                 () => client.AuthorizeAsync(codeReceiver, CancellationToken.None).Wait());
@@ -379,7 +382,8 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
                 GaiaOidcClient.CreateEndpoint(),
                 enrollment.Object,
                 store.Object,
-                new ClientSecrets());
+                new ClientSecrets(),
+                TestProject.UserAgent);
 
             ExceptionAssert.ThrowsAggregateException<TokenResponseException>(
                 () => client.AuthorizeAsync(codeReceiver, CancellationToken.None).Wait());
@@ -408,7 +412,8 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
                 GaiaOidcClient.CreateEndpoint(),
                 enrollment.Object,
                 store.Object,
-                new ClientSecrets());
+                new ClientSecrets(),
+                TestProject.UserAgent);
 
             ExceptionAssert.ThrowsAggregateException<TokenResponseException>(
                 () => client.AuthorizeAsync(codeReceiver, CancellationToken.None).Wait());
@@ -443,7 +448,8 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
                 GaiaOidcClient.CreateEndpoint(),
                 enrollment.Object,
                 store.Object,
-                new ClientSecrets());
+                new ClientSecrets(),
+                TestProject.UserAgent);
 
             var session = await client
                 .TryAuthorizeSilentlyAsync(
@@ -468,7 +474,8 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
 
             var initializer = new GaiaOidcClient.CodeFlowInitializer(
                 GaiaOidcClient.CreateEndpoint(),
-                enrollment.Object);
+                enrollment.Object,
+                TestProject.UserAgent);
 
             Assert.AreEqual("https://accounts.google.com/o/oauth2/v2/auth", initializer.AuthorizationServerUrl);
             Assert.AreEqual("https://oauth2.googleapis.com/token", initializer.TokenServerUrl);
@@ -483,7 +490,8 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
 
             var initializer = new GaiaOidcClient.CodeFlowInitializer(
                 GaiaOidcClient.CreateEndpoint(),
-                enrollment.Object);
+                enrollment.Object,
+                TestProject.UserAgent);
 
             Assert.AreEqual("https://accounts.google.com/o/oauth2/v2/auth", initializer.AuthorizationServerUrl);
             Assert.AreEqual("https://oauth2.mtls.googleapis.com/token", initializer.TokenServerUrl);

--- a/sources/Google.Solutions.Apis/Auth/Gaia/GaiaOidcClient.cs
+++ b/sources/Google.Solutions.Apis/Auth/Gaia/GaiaOidcClient.cs
@@ -41,17 +41,20 @@ namespace Google.Solutions.Apis.Auth.Gaia
         private readonly ServiceEndpoint<GaiaOidcClient> endpoint;
         private readonly ClientSecrets clientSecrets;
         private readonly IDeviceEnrollment deviceEnrollment;
+        private readonly UserAgent userAgent;
 
         public GaiaOidcClient(
             ServiceEndpoint<GaiaOidcClient> endpoint,
             IDeviceEnrollment deviceEnrollment,
             IOidcOfflineCredentialStore store,
-            ClientSecrets clientSecrets)
+            ClientSecrets clientSecrets,
+            UserAgent userAgent)
             : base(store)
         {
             this.endpoint = endpoint.ExpectNotNull(nameof(endpoint));
             this.clientSecrets = clientSecrets.ExpectNotNull(nameof(clientSecrets));
             this.deviceEnrollment = deviceEnrollment.ExpectNotNull(nameof(deviceEnrollment));
+            this.userAgent = userAgent.ExpectNotNull(nameof(userAgent));
         }
 
         public static ServiceEndpoint<GaiaOidcClient> CreateEndpoint(
@@ -180,7 +183,8 @@ namespace Google.Solutions.Apis.Auth.Gaia
 
             var initializer = new CodeFlowInitializer(
                 this.endpoint,
-                this.deviceEnrollment)
+                this.deviceEnrollment,
+                this.userAgent)
             {
                 ClientSecrets = this.clientSecrets
             };
@@ -293,7 +297,8 @@ namespace Google.Solutions.Apis.Auth.Gaia
 
             var initializer = new CodeFlowInitializer(
                 this.endpoint,
-                this.deviceEnrollment)
+                this.deviceEnrollment,
+                this.userAgent)
             {
                 ClientSecrets = this.clientSecrets
             };
@@ -347,7 +352,8 @@ namespace Google.Solutions.Apis.Auth.Gaia
         {
             protected CodeFlowInitializer(
                 ServiceEndpointDirections directions,
-                IDeviceEnrollment deviceEnrollment)
+                IDeviceEnrollment deviceEnrollment,
+                UserAgent userAgent)
                 : base(
                       GoogleAuthConsts.OidcAuthorizationUrl,
                       new Uri(directions.BaseUri, "/token").ToString(),
@@ -355,7 +361,8 @@ namespace Google.Solutions.Apis.Auth.Gaia
             {
                 this.HttpClientFactory = new PscAndMtlsAwareHttpClientFactory(
                     directions,
-                    deviceEnrollment);
+                    deviceEnrollment,
+                    userAgent);
 
                 ApiTraceSources.Default.TraceInformation(
                     "Using endpoint {0}",
@@ -364,10 +371,12 @@ namespace Google.Solutions.Apis.Auth.Gaia
 
             public CodeFlowInitializer(
                 ServiceEndpoint<GaiaOidcClient> endpoint,
-                IDeviceEnrollment deviceEnrollment)
+                IDeviceEnrollment deviceEnrollment,
+                UserAgent userAgent)
                 : this(
                       endpoint.GetDirections(deviceEnrollment.State),
-                      deviceEnrollment)
+                      deviceEnrollment,
+                      userAgent)
             {
             }
         }

--- a/sources/Google.Solutions.Apis/Auth/Gaia/GaiaPkceOidcClient.cs
+++ b/sources/Google.Solutions.Apis/Auth/Gaia/GaiaPkceOidcClient.cs
@@ -31,8 +31,9 @@ namespace Google.Solutions.Apis.Auth.Gaia
             ServiceEndpoint<GaiaOidcClient> endpoint,
             IDeviceEnrollment deviceEnrollment,
             IOidcOfflineCredentialStore store,
-            ClientSecrets clientSecrets) 
-            : base(endpoint, deviceEnrollment, store, clientSecrets)
+            ClientSecrets clientSecrets,
+            UserAgent userAgent) 
+            : base(endpoint, deviceEnrollment, store, clientSecrets, userAgent)
         {
         }
 

--- a/sources/Google.Solutions.Apis/Client/ApiClientBase.cs
+++ b/sources/Google.Solutions.Apis/Client/ApiClientBase.cs
@@ -50,10 +50,10 @@ namespace Google.Solutions.Apis.Client
             this.Initializer = new BaseClientService.Initializer()
             {
                 BaseUri = directions.BaseUri.ToString(),
-                ApplicationName = userAgent.ToApplicationName(),
                 HttpClientFactory = new PscAndMtlsAwareHttpClientFactory(
                     directions,
-                    authorization)
+                    authorization,
+                    userAgent)
             };
         }
 

--- a/sources/Google.Solutions.Apis/Client/PscAndMtlsAwareHttpClientFactory.cs
+++ b/sources/Google.Solutions.Apis/Client/PscAndMtlsAwareHttpClientFactory.cs
@@ -40,23 +40,28 @@ namespace Google.Solutions.Apis.Client
         private readonly ServiceEndpointDirections directions;
         private readonly IDeviceEnrollment deviceEnrollment;
         private readonly ICredential credential;
+        private readonly UserAgent userAgent;
 
         public PscAndMtlsAwareHttpClientFactory(
             ServiceEndpointDirections directions,
-            IAuthorization authorization)
+            IAuthorization authorization,
+            UserAgent userAgent)
         {
-            this.directions = directions;
-            this.deviceEnrollment = authorization.DeviceEnrollment;
+            this.directions = directions.ExpectNotNull(nameof(directions));
+            this.deviceEnrollment = authorization.DeviceEnrollment.ExpectNotNull(nameof(this.deviceEnrollment));
             this.credential = authorization.Credential;
+            this.userAgent = userAgent.ExpectNotNull(nameof(userAgent));
         }
 
         public PscAndMtlsAwareHttpClientFactory(
             ServiceEndpointDirections directions,
-            IDeviceEnrollment deviceEnrollment)
+            IDeviceEnrollment deviceEnrollment,
+            UserAgent userAgent)
         {
-            this.directions = directions;
-            this.deviceEnrollment = deviceEnrollment;
+            this.directions = directions.ExpectNotNull(nameof(directions));
+            this.deviceEnrollment = deviceEnrollment.ExpectNotNull(nameof(deviceEnrollment));
             this.credential = null;
+            this.userAgent = userAgent.ExpectNotNull(nameof(userAgent));
         }
 
         public ConfigurableHttpClient CreateHttpClient(CreateHttpClientArgs args)
@@ -66,7 +71,7 @@ namespace Google.Solutions.Apis.Client
                 args.Initializers.Add(this.credential);
             }
 
-            // TODO: b/293968777: Set user agent
+            args.ApplicationName = this.userAgent.ToApplicationName();
 
             var factory = new MtlsAwareHttpClientFactory(this.directions, this.deviceEnrollment);
             var httpClient = factory.CreateHttpClient(args);

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Authorization/TestAuthorizeViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Authorization/TestAuthorizeViewModel.cs
@@ -30,6 +30,7 @@ using Google.Solutions.IapDesktop.Application.Profile.Auth;
 using Google.Solutions.IapDesktop.Application.Windows.Authorization;
 using Google.Solutions.Platform.Net;
 using Google.Solutions.Testing.Apis;
+using Google.Solutions.Testing.Apis.Integration;
 using Google.Solutions.Testing.Application.Test;
 using Moq;
 using NUnit.Framework;
@@ -54,7 +55,8 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Authorization
                 : base(
                     GaiaOidcClient.CreateEndpoint(),
                     install,
-                    offlineStore)
+                    offlineStore,
+                    TestProject.UserAgent)
             {
             }
 

--- a/sources/Google.Solutions.IapDesktop.Application/Windows/Authorization/AuthorizeViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/Authorization/AuthorizeViewModel.cs
@@ -41,16 +41,19 @@ namespace Google.Solutions.IapDesktop.Application.Windows.Authorization
     {
         private readonly ServiceEndpoint<GaiaOidcClient> gaiaEndpoint;
         private readonly IOidcOfflineCredentialStore offlineStore;
+        private readonly UserAgent userAgent;
 
         private CancellationTokenSource cancelCurrentSignin = null;
 
         public AuthorizeViewModel(
             ServiceEndpoint<GaiaOidcClient> gaiaEndpoint,
             IInstall install,
-            IOidcOfflineCredentialStore offlineStore)
+            IOidcOfflineCredentialStore offlineStore,
+            UserAgent userAgent)
         {
             this.gaiaEndpoint = gaiaEndpoint.ExpectNotNull(nameof(gaiaEndpoint));
             this.offlineStore = offlineStore.ExpectNotNull(nameof(offlineStore));
+            this.userAgent = userAgent.ExpectNotNull(nameof(userAgent));
 
             //
             // NB. Properties are access from a non-GUI thread, so
@@ -95,7 +98,8 @@ namespace Google.Solutions.IapDesktop.Application.Windows.Authorization
                 this.gaiaEndpoint,
                 this.DeviceEnrollment,
                 this.offlineStore,
-                this.ClientSecrets);
+                this.ClientSecrets,
+                this.userAgent);
 
             return new Profile.Auth.Authorization(
                 client,

--- a/sources/Google.Solutions.IapDesktop.Application/Windows/ViewBindingContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/ViewBindingContext.cs
@@ -70,7 +70,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows
             Debug.Assert(this.errorReportingOwner != null);
             this.exceptionDialog.Show(
                 this.errorReportingOwner,
-                command.ActivityText,
+                $"{command.ActivityText} failed",
                 exception);
         }
     }

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/IapTransportFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/IapTransportFactory.cs
@@ -280,9 +280,11 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport
                 catch (SshRelayDeniedException e)
                 {
                     throw new TransportFailedException(
-                        "You are not authorized to connect to this VM instance.\n\n" +
-                        $"Verify that the Cloud IAP API is enabled in the project {targetInstance.ProjectId} " +
-                        "and that your user has the 'IAP-secured Tunnel User' role.",
+                        "You do not have sufficient permissions to access this VM instance. " +
+                        "You need the 'IAP-secured Tunnel User' role (or an equivalent custom role) " +
+                        "to perform this action.\n\n" +
+                        "Note: If you've just been granted the role, it might take a few minutes " +
+                        "for the change to take effect.",
                         HelpTopics.IapAccess,
                         e);
                 }


### PR DESCRIPTION
Use HttpClientFactory to set user agent so that it's consistently applied across all clients, including the OIDC client.