### PR TITLE
b/292444622 Fix error message for missing IAP role

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Windows/ViewBindingContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/ViewBindingContext.cs
@@ -70,7 +70,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows
             Debug.Assert(this.errorReportingOwner != null);
             this.exceptionDialog.Show(
                 this.errorReportingOwner,
-                command.ActivityText,
+                $"{command.ActivityText} failed",
                 exception);
         }
     }

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/IapTransportFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/IapTransportFactory.cs
@@ -280,9 +280,11 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport
                 catch (SshRelayDeniedException e)
                 {
                     throw new TransportFailedException(
-                        "You are not authorized to connect to this VM instance.\n\n" +
-                        $"Verify that the Cloud IAP API is enabled in the project {targetInstance.ProjectId} " +
-                        "and that your user has the 'IAP-secured Tunnel User' role.",
+                        "You do not have sufficient permissions to access this VM instance. " +
+                        "You need the 'IAP-secured Tunnel User' role (or an equivalent custom role) " +
+                        "to perform this action.\n\n" +
+                        "Note: If you've just been granted the role, it might take a few minutes " +
+                        "for the change to take effect.",
                         HelpTopics.IapAccess,
                         e);
                 }


### PR DESCRIPTION
It's not necessary to enable the IAP API, update error message to reflect this.