### PR TITLE
b/292444274 Remove InsertInstanceEvent.Image property

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/Auditing/Events/Lifecycle/TestInsertInstanceEvent.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/Auditing/Events/Lifecycle/TestInsertInstanceEvent.cs
@@ -176,9 +176,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Test.Auditing.Events
             Assert.AreEqual(
                 new InstanceLocator("project-1", "us-central1-a", "instance-1"),
                 e.InstanceReference);
-            Assert.AreEqual(
-                new ImageLocator("project-1", "image-1"),
-                e.Image);
         }
 
         [Test]
@@ -242,7 +239,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Test.Auditing.Events
             Assert.AreEqual(
                 new InstanceLocator("project-1", "us-central1-a", "instance-1"),
                 e.InstanceReference);
-            Assert.IsNull(e.Image);
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Auditing/Events/Lifecycle/InsertInstanceEvent.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Auditing/Events/Lifecycle/InsertInstanceEvent.cs
@@ -19,9 +19,7 @@
 // under the License.
 //
 
-using Google.Solutions.Apis.Locator;
 using Google.Solutions.IapDesktop.Extensions.Management.Auditing.Logs;
-using Newtonsoft.Json.Linq;
 using System.Diagnostics;
 
 namespace Google.Solutions.IapDesktop.Extensions.Management.Auditing.Events.Lifecycle
@@ -35,32 +33,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Auditing.Events.Life
         protected override string SuccessMessage => "Instance created";
         protected override string ErrorMessage => "Creating instance failed";
 
-        public ImageLocator Image { get; }
-
         internal InsertInstanceEvent(LogRecord logRecord) : base(logRecord)
         {
             Debug.Assert(IsInsertInstanceEvent(logRecord));
-
-            var request = logRecord.ProtoPayload.Request;
-            if (request != null)
-            {
-                var disks = request["disks"];
-                if (disks != null)
-                {
-                    foreach (var disk in ((JArray)disks))
-                    {
-                        if (disk["boot"] != null && (bool)disk["boot"])
-                        {
-                            var initializeParams = disk["initializeParams"];
-                            if (initializeParams != null)
-                            {
-                                this.Image = ImageLocator.FromString(
-                                    initializeParams["sourceImage"].Value<string>());
-                            }
-                        }
-                    }
-                }
-            }
         }
 
         public static bool IsInsertInstanceEvent(LogRecord record)


### PR DESCRIPTION
This fixes an issue where the usage of an image view caused the event parsing to fail. Remove property as it isn't used anymore.