### PR TITLE
b/294784810 Add STS API to list of APIs that might need allow-listing

### DIFF
--- a/doc/site/sources/docs/proxy-configuration.md
+++ b/doc/site/sources/docs/proxy-configuration.md
@@ -55,7 +55,7 @@ use WebSockets. Make sure that your proxy server permits WebSocket communication
     Squid (and possibly other proxy servers) does not allow WebSocket
     connections when configured to perform TLS inspection (_bumping_). To allow
     WebSocket communication, exclude `tunnel.cloudproxy.app` from TLS termination
-    by letting Squid [splice :octicons-link-external-16:](https://wiki.squid-cache.org/Features/TLSPeekAndSplice)
+    by letting Squid [splice :octicons-link-external-16:](https://wiki.squid-cache.org/Features/SslPeekAndSplice)
     connections to this domain.
 
 
@@ -77,5 +77,5 @@ inspects TLS traffic, configure it to exclude the following domains from TLS ins
 
 ???+ Note
     If you use Squid, you can exclude domains from inspection by 
-    configuring them to use [splicing :octicons-link-external-16:](https://wiki.squid-cache.org/Features/TLSPeekAndSplice)
+    configuring them to use [splicing :octicons-link-external-16:](https://wiki.squid-cache.org/Features/SslPeekAndSplice)
     instead of _bumping_.

--- a/doc/site/sources/docs/proxy-configuration.md
+++ b/doc/site/sources/docs/proxy-configuration.md
@@ -21,58 +21,61 @@ and modified under **Tools > Options > Network**:
 ![Proxy settings](images/Proxy-Settings.png)
 
 
-## Filtering and SSL inspection
+## Filtering and TLS inspection
 
-If your organization uses a proxy server that performs filtering and SSL inspection, 
+If your organization uses a proxy server that performs filtering or TLS inspection, 
 some additional configuration might be required to allow users to use IAP Desktop.
 
 ### Proxy CA certificates
 
 IAP Desktop uses the Windows _Trusted Root Certification Authorities Certificate Store_
-for verifying TLS certificates. If your proxy server performs SSL inspection and therefore
+for verifying TLS certificates. If your proxy server performs TLS inspection and therefore
 re-encrypts traffic, make sure to add the proxy server's CA certiticate to this
 certificate store.
 
-### Allow-list for Domains accessed by IAP Desktop
+### Allow-list for domains accessed by IAP Desktop
 
 To let IAP Desktop communicate with Google Cloud APIs, make sure that your proxy server 
-permits HTTPS communication to the following domains:
+permits HTTPS connections to the following domains:
 
-* `https://oauth2.googleapis.com`
-* `https://openidconnect.googleapis.com`
-* `https://compute.googleapis.com`
-* `https://oslogin.googleapis.com`
-* `https://cloudresourcemanager.googleapis.com`
-* `https://logging.googleapis.com`
+* `oauth2.googleapis.com`
+* `openidconnect.googleapis.com`
+* `compute.googleapis.com`
+* `oslogin.googleapis.com`
+* `cloudresourcemanager.googleapis.com`
+* `logging.googleapis.com`
+* `sts.googleapis.com`
 
 The IAP TCP forwarding tunnels that IAP Desktop uses to create SSH and RDP connections
 use WebSockets. Make sure that your proxy server permits WebSocket communication to the following domain:
 
-* `https://tunnel.cloudproxy.app`
+* `tunnel.cloudproxy.app`
 
 ???+ Note
     Squid (and possibly other proxy servers) does not allow WebSocket
-    connections when configured to perform SSL inspection (_bumping_). To allow
-    WebSocket communication, exclude `tunnel.cloudproxy.app` from SSL termination
-    by letting Squid [splice :octicons-link-external-16:](https://wiki.squid-cache.org/Features/SslPeekAndSplice)
+    connections when configured to perform TLS inspection (_bumping_). To allow
+    WebSocket communication, exclude `tunnel.cloudproxy.app` from TLS termination
+    by letting Squid [splice :octicons-link-external-16:](https://wiki.squid-cache.org/Features/TLSPeekAndSplice)
     connections to this domain.
 
 
-## Endpoint Verification
+## BeyondCorp certificate-based access
 
-When you enable Endpoint Verification, IAP Desktop uses mutual TLS (mTLS) for all
-Google APIs and for IAP TCP forwarding. mTLS is not compatible with SSL inspection.
+When you enable BeyondCorp certificate-based access, IAP Desktop uses mutual TLS (mTLS) for all
+Google APIs and for IAP TCP forwarding. 
 
-To use Endpoint Verification, exclude the following domains from SSL inspection.
+mTLS is not compatible with TLS inspection. If you're using a proxy server that terminates and
+inspects TLS traffic, configure it to exclude the following domains from TLS inspection:
 
-* `https://oauth2.mtls.googleapis.com`
-* `https://compute.mtls.googleapis.com`
-* `https://oslogin.mtls.googleapis.com`
-* `https://cloudresourcemanager.mtls.googleapis.com`
-* `https://logging.mtls.googleapis.com`
-* `https://mtls.tunnel.cloudproxy.app`
+* `oauth2.mtls.googleapis.com`
+* `compute.mtls.googleapis.com`
+* `oslogin.mtls.googleapis.com`
+* `cloudresourcemanager.mtls.googleapis.com`
+* `logging.mtls.googleapis.com`
+* `mtls.tunnel.cloudproxy.app`
+* `sts.mtls.googleapis.com`
 
 ???+ Note
     If you use Squid, you can exclude domains from inspection by 
-    configuring them to use [splicing :octicons-link-external-16:](https://wiki.squid-cache.org/Features/SslPeekAndSplice)
+    configuring them to use [splicing :octicons-link-external-16:](https://wiki.squid-cache.org/Features/TLSPeekAndSplice)
     instead of _bumping_.

--- a/doc/site/sources/docs/security.md
+++ b/doc/site/sources/docs/security.md
@@ -16,11 +16,12 @@ The application uses the following Google APIs for this purpose:
 * [Resource Manager API  :octicons-link-external-16:](https://cloud.google.com/resource-manager/reference/rest)
 * [OS Login API  :octicons-link-external-16:](https://cloud.google.com/compute/docs/oslogin/rest)
 * [Logging API  :octicons-link-external-16:](https://cloud.google.com/logging/docs/reference/v2/rest)
+* [Security Token Service API :octicons-link-external-16:](https://cloud.google.com/iam/docs/reference/sts/rest)
 
-Periodically, IAP Desktop accesses the [GitHub API :octicons-link-external-16: ](https://docs.github.com/en/rest) to check
-for updates.
+Periodically, IAP Desktop accesses the [GitHub API :octicons-link-external-16:](https://docs.github.com/en/rest) to check
+for updates. After an upgrade, IAP Desktop also queries the GitHub API to download release notes.
 
-IAP Desktop does not disclose or transmit any data to APIs other than the
+IAP Desktop does not intentionally disclose or transmit any data to APIs other than the
 ones listed above. 
 
 ## Credential storage


### PR DESCRIPTION
IAP Desktop uses the STS API for workforce identity-based authentication.