### PR TITLE
b/298138274 Use ID for tracing command execution

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Host/Diagnostics/TestTelemetryListener.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Host/Diagnostics/TestTelemetryListener.cs
@@ -62,9 +62,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host.Diagnostics
             listener.Enabled = false;
             listener.Enabled = false;
 
-            ApplicationEventSource.Log.CommandExecuted(
-                "test-command",
-                "Test command");
+            ApplicationEventSource.Log.CommandExecuted("test-command");
 
             client.Verify(
                 c => c.CollectEventAsync(
@@ -88,9 +86,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host.Diagnostics
             listener.Enabled = true;
             listener.Enabled = true;
 
-            ApplicationEventSource.Log.CommandExecuted(
-                "test-command",
-                "Test command");
+            ApplicationEventSource.Log.CommandExecuted("test-command");
 
             client.Verify(
                 c => c.CollectEventAsync(

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Windows/TestMenuCommandAttribute.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Windows/TestMenuCommandAttribute.cs
@@ -52,6 +52,8 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows
         [MenuCommand(typeof(SampleMenu))]
         internal class NotContextCommand : IMenuCommand<SampleMenu>
         {
+            public string Id => throw new NotImplementedException();
+
             public string Text => throw new NotImplementedException();
 
             public string ActivityText => throw new NotImplementedException();

--- a/sources/Google.Solutions.IapDesktop.Application/ApplicationEventSource.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ApplicationEventSource.cs
@@ -42,16 +42,14 @@ namespace Google.Solutions.IapDesktop.Application
         public const int CommandFailedId = 2;
 
         [Event(CommandExecutedId, Level = EventLevel.Informational)]
-        internal void CommandExecuted(
-            string command,
-            string text)
-            => WriteEvent(CommandExecutedId, command, text);
+        internal void CommandExecuted(string id)
+            => WriteEvent(CommandExecutedId, id);
 
         [Event(CommandFailedId, Level = EventLevel.Warning)]
         internal void CommandFailed(
-            string command,
-            string text,
+            string id,
+            string type,
             string error)
-            => WriteEvent(CommandFailedId, command, text, error);
+            => WriteEvent(CommandFailedId, id, type, error);
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Application/ToolWindows/ProjectExplorer/ProjectExplorerView.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ToolWindows/ProjectExplorer/ProjectExplorerView.cs
@@ -193,6 +193,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.ProjectExplorer
                         : CommandState.Unavailable,
                     _ => UnloadProjectsAsync())
                 {
+                    Id = "UnloadProject",
                     ActivityText = "Unloading projects"
                 });
             this.contextMenuCommands.AddCommand(
@@ -203,6 +204,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.ProjectExplorer
                         : CommandState.Unavailable,
                     _ => this.viewModel.RefreshSelectedNodeAsync())
                 {
+                    Id = "RefreshProject",
                     Image = Resources.Refresh_16,
                     ActivityText = "Refreshing project"
                 });
@@ -214,6 +216,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.ProjectExplorer
                         : CommandState.Unavailable,
                     _ => this.viewModel.RefreshAsync(false))
                 {
+                    Id = "RefeshAllProjects",
                     Image = Resources.Refresh_16,
                     ActivityText = "Refreshing project"
                 });
@@ -225,6 +228,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.ProjectExplorer
                         : CommandState.Unavailable,
                     _ => this.viewModel.UnloadSelectedProjectAsync())
                 {
+                    Id = "UnloadProject",
                     ActivityText = "Unloading project"
                 });
 
@@ -237,6 +241,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.ProjectExplorer
                         : CommandState.Unavailable,
                     _ => this.viewModel.OpenInCloudConsole())
                 {
+                    Id = "OpenCloudConsole",
                     ActivityText = "Opening Cloud Console"
                 });
             this.contextMenuCommands.AddCommand(
@@ -249,6 +254,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.ProjectExplorer
                         () => this.viewModel.ConfigureIapAccess(),
                         "Opening Cloud Console"))
                 {
+                    Id = "ConfigureIapAccess",
                     ActivityText = "Opening Cloud Console"
                 });
             this.contextMenuCommands.AddSeparator();

--- a/sources/Google.Solutions.IapDesktop.Application/Windows/MenuCommandBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/MenuCommandBase.cs
@@ -129,6 +129,11 @@ namespace Google.Solutions.IapDesktop.Application.Windows
             this.isEnabledFunc = isEnabledFunc.ExpectNotNull(nameof(isEnabledFunc));
         }
 
+        public override string Id
+        {
+            get => $"OpenToolWindow.{typeof(TView).Name}";
+        }
+
         public override Task ExecuteAsync(TContext context)
         {
             Debug.Assert(IsAvailable(context) && IsEnabled(context));

--- a/sources/Google.Solutions.IapDesktop.Application/Windows/ViewBindingContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/ViewBindingContext.cs
@@ -70,8 +70,8 @@ namespace Google.Solutions.IapDesktop.Application.Windows
             Debug.Assert(this.errorReportingOwner != null);
 
             ApplicationEventSource.Log.CommandFailed(
+                command.Id,
                 command.GetType().FullName(),
-                command.Text.Replace("&", string.Empty),
                 exception.FullMessage());
 
             this.exceptionDialog.Show(
@@ -82,9 +82,10 @@ namespace Google.Solutions.IapDesktop.Application.Windows
 
         public void OnCommandExecuted(ICommand command)
         {
-            ApplicationEventSource.Log.CommandExecuted(
-                command.GetType().FullName(),
-                command.Text.Replace("&", string.Empty));
+            if (command.Id != null)
+            {
+                ApplicationEventSource.Log.CommandExecuted(command.Id);
+            }
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/ToolWindows/InstanceControlCommands.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/ToolWindows/InstanceControlCommands.cs
@@ -121,6 +121,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.ToolWindows
                 this.serviceProvider = serviceProvider;
             }
 
+            public override string Id
+            {
+                get => $"ControlInstance.{this.controlCommand}";
+            }
+
             protected override bool IsAvailable(IProjectModelNode context)
             {
                 return context is IProjectModelInstanceNode;
@@ -152,7 +157,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.ToolWindows
                 }
             }
 
-            public async override Task ExecuteAsync(IProjectModelNode context)
+            public override async Task ExecuteAsync(IProjectModelNode context)
             {
                 var instanceNode = (IProjectModelInstanceNode)context;
                 var instance = instanceNode.Instance;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/InitializeSessionExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/InitializeSessionExtension.cs
@@ -299,6 +299,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session
                     GetContextMenuCommandStateWhenRunningWindowsInstanceRequired,
                     GenerateCredentialsAsync)
                 {
+                    Id = "GenerateWindowsCredentials",
                     Image = Resources.AddCredentials_16,
                     ActivityText = "Generating Windows logon credentials"
                 },
@@ -310,6 +311,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session
                     GetToolbarCommandStateWhenRunningWindowsInstanceRequired,
                     GenerateCredentialsAsync)
                 {
+                    Id = "GenerateWindowsCredentials",
                     Image = Resources.AddCredentials_16,
                     ActivityText = "Generating Windows logon credentials"
                 });

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/App/OpenWithClientCommand.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/App/OpenWithClientCommand.cs
@@ -31,6 +31,7 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -179,6 +180,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.App
         //---------------------------------------------------------------------
         // Overrides.
         //---------------------------------------------------------------------
+
+        public override string Id
+        {
+            get => $"OpenWithClient.{this.contextFactory.Protocol.Name.Split(' ').FirstOrDefault()}";
+        }
 
         protected override bool IsAvailable(IProjectModelNode context)
         {

--- a/sources/Google.Solutions.Mvvm/Binding/Commands/CommandBase.cs
+++ b/sources/Google.Solutions.Mvvm/Binding/Commands/CommandBase.cs
@@ -30,6 +30,11 @@ namespace Google.Solutions.Mvvm.Binding.Commands
     {
         private string activityText;
 
+        public virtual string Id
+        {
+            get => GetType().Name;
+        }
+
         public string Text { get; protected set; }
 
         public string ActivityText

--- a/sources/Google.Solutions.Mvvm/Binding/Commands/ContextCommand.cs
+++ b/sources/Google.Solutions.Mvvm/Binding/Commands/ContextCommand.cs
@@ -31,6 +31,7 @@ namespace Google.Solutions.Mvvm.Binding.Commands
     /// </summary>
     public class ContextCommand<TContext> : CommandBase, IContextCommand<TContext>
     {
+        private string id;
         private readonly Func<TContext, Task> executeFunc;
         private readonly Func<TContext, CommandState> queryStateFunc;
 
@@ -59,8 +60,16 @@ namespace Google.Solutions.Mvvm.Binding.Commands
         {
         }
 
+        public new string Id 
+        {
+            get => this.id ?? base.Id;
+            set => this.id = value;
+        }
+
         public Image Image { get; set; }
+        
         public Keys ShortcutKeys { get; set; }
+
         public bool IsDefault { get; set; }
 
         public Task ExecuteAsync(TContext context)

--- a/sources/Google.Solutions.Mvvm/Binding/Commands/ICommand.cs
+++ b/sources/Google.Solutions.Mvvm/Binding/Commands/ICommand.cs
@@ -28,14 +28,18 @@ namespace Google.Solutions.Mvvm.Binding.Commands
     public interface ICommand
     {
         /// <summary>
-        /// Caption for command.
+        /// ID, used for tracing.
+        /// </summary>
+        string Id { get; }
+
+        /// <summary>
+        /// Caption, shown in UI.
         /// </summary>
         string Text { get; }
 
         /// <summary>
-        /// Caption when command is executing.
+        /// Caption when command is executing, shown in error dialogs.
         /// </summary>
         string ActivityText { get; }
     }
-
 }

--- a/sources/Google.Solutions.Mvvm/Binding/Commands/ObservableCommand.cs
+++ b/sources/Google.Solutions.Mvvm/Binding/Commands/ObservableCommand.cs
@@ -61,6 +61,8 @@ namespace Google.Solutions.Mvvm.Binding.Commands
             this.executeFunc = executeFunc;
         }
 
+        public override string Id => null;
+
         public IObservableProperty<bool> CanExecute { get; }
 
         public Task ExecuteAsync(CancellationToken cancellationToken)
@@ -88,6 +90,7 @@ namespace Google.Solutions.Mvvm.Binding.Commands
                 executeFunc,
                 canExecute ?? ObservableProperty.Build(true));
         }
+
         public static ObservableCommand Build(
             string text,
             Func<Task> executeFunc,


### PR DESCRIPTION
* Add an (optional) ID to commands and use this in ETW traces.
* Embed type/context information in ID where appropriate.