### PR TITLE
b/292462051 Pass VM name as hint to SSMS

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Transport/TestDirectTransportFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ClientModel/Transport/TestDirectTransportFactory.cs
@@ -70,6 +70,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ClientModel.Transport
                 Assert.AreSame(protocol.Object, transport.Protocol);
                 Assert.AreSame(address, transport.Endpoint.Address);
                 Assert.AreEqual(22, transport.Endpoint.Port);
+                Assert.AreSame(SampleInstance, transport.Target);
             }
         }
     }

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/DirectTransportFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/DirectTransportFactory.cs
@@ -80,7 +80,8 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport
 
                 return new Transport(
                     protocol,
-                    new IPEndPoint(address, port));
+                    new IPEndPoint(address, port),
+                    instance);
             }
         }
 
@@ -90,10 +91,14 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport
 
         private class Transport : DisposableBase, ITransport
         {
-            public Transport(IProtocol protocol, IPEndPoint endpoint)
+            public Transport(
+                IProtocol protocol, 
+                IPEndPoint endpoint,
+                InstanceLocator target)
             {
                 this.Protocol = protocol.ExpectNotNull(nameof(protocol));
                 this.Endpoint = endpoint.ExpectNotNull(nameof(endpoint));
+                this.Target = target.ExpectNotNull(nameof(target));
             }
 
             //-----------------------------------------------------------------
@@ -103,6 +108,8 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport
             public IProtocol Protocol { get; }
 
             public IPEndPoint Endpoint { get; }
+
+            public ResourceLocator Target { get; }
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/ITransport.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/ITransport.cs
@@ -19,6 +19,7 @@
 // under the License.
 //
 
+using Google.Solutions.Apis.Locator;
 using Google.Solutions.IapDesktop.Core.ClientModel.Protocol;
 using System;
 using System.Net;
@@ -37,5 +38,10 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport
         /// be a localhost endpoint.
         /// </summary>
         IPEndPoint Endpoint { get; }
+
+        /// <summary>
+        /// Target instance or destination group.
+        /// </summary>
+        ResourceLocator Target { get; }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/IapTransportFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ClientModel/Transport/IapTransportFactory.cs
@@ -275,7 +275,8 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport
 
                     return new Transport(
                         tunnel,
-                        protocol);
+                        protocol,
+                        targetInstance);
                 }
                 catch (SshRelayDeniedException e)
                 {
@@ -323,10 +324,12 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport
 
             internal Transport(
                 IapTunnel relay,
-                IProtocol protocol)
+                IProtocol protocol,
+                InstanceLocator target)
             {
                 this.Tunnel = relay.ExpectNotNull(nameof(relay));
                 this.Protocol = protocol.ExpectNotNull(nameof(protocol));
+                this.Target = target.ExpectNotNull(nameof(target));
             }
 
             //-----------------------------------------------------------------
@@ -336,6 +339,8 @@ namespace Google.Solutions.IapDesktop.Core.ClientModel.Transport
             public IProtocol Protocol { get; }
 
             public IPEndPoint Endpoint => this.Tunnel.LocalEndpoint;
+
+            public ResourceLocator Target { get; } //TODO: test
 
             //-----------------------------------------------------------------
             // DisposableBase.

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/App/TestSsmsClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/App/TestSsmsClient.cs
@@ -20,6 +20,7 @@
 //
 
 
+using Google.Solutions.Apis.Locator;
 using Google.Solutions.IapDesktop.Core.ClientModel.Protocol;
 using Google.Solutions.IapDesktop.Core.ClientModel.Transport;
 using Google.Solutions.IapDesktop.Extensions.Session.Protocol.App;
@@ -33,6 +34,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
     [TestFixture]
     public class TestSsmsClient
     {
+        private static readonly InstanceLocator SampleInstance
+            = new InstanceLocator("project-1", "zone-1", "instance-1");
+
         //---------------------------------------------------------------------
         // Properties.
         //---------------------------------------------------------------------
@@ -60,6 +64,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
             [Values("", " ", null)] string emptyish)
         {
             var transport = new Mock<ITransport>();
+            transport.SetupGet(t => t.Target).Returns(SampleInstance);
             transport
                 .SetupGet(t => t.Endpoint)
                 .Returns(new IPEndPoint(IPAddress.Parse("127.0.0.2"), 11443));
@@ -72,7 +77,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
             };
 
             Assert.AreEqual(
-                "-S 127.0.0.2,11443 -U sa",
+                "-S 127.0.0.2\\instance-1.zone-1.c.project-1.internal,11443 -U sa",
                 client.FormatArguments(transport.Object, parameters));
         }
 
@@ -80,6 +85,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
         public void WhenNlaDisabledAndUsernameSet_ThenFormatArgumentsReturnsStringForSqlAuth()
         {
             var transport = new Mock<ITransport>();
+            transport.SetupGet(t => t.Target).Returns(SampleInstance);
             transport
                 .SetupGet(t => t.Endpoint)
                 .Returns(new IPEndPoint(IPAddress.Parse("127.0.0.2"), 11443));
@@ -92,7 +98,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
             };
 
             Assert.AreEqual(
-                "-S 127.0.0.2,11443 -U \"username\"",
+                "-S 127.0.0.2\\instance-1.zone-1.c.project-1.internal,11443 -U \"username\"",
                 client.FormatArguments(transport.Object, parameters));
         }
 
@@ -101,6 +107,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
             [Values("user\"", "''")] string username)
         {
             var transport = new Mock<ITransport>();
+            transport.SetupGet(t => t.Target).Returns(SampleInstance);
             transport
                 .SetupGet(t => t.Endpoint)
                 .Returns(new IPEndPoint(IPAddress.Parse("127.0.0.2"), 11443));
@@ -120,6 +127,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
         public void WhenNlaEnabled_ThenFormatArgumentsReturnsStringForWindowsAuth()
         {
             var transport = new Mock<ITransport>();
+            transport.SetupGet(t => t.Target).Returns(SampleInstance);
             transport
                 .SetupGet(t => t.Endpoint)
                 .Returns(new IPEndPoint(IPAddress.Parse("127.0.0.2"), 11443));
@@ -131,7 +139,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.App
             };
 
             Assert.AreEqual(
-                "-S 127.0.0.2,11443 -E",
+                "-S 127.0.0.2\\instance-1.zone-1.c.project-1.internal,11443 -E",
                 client.FormatArguments(transport.Object, parameters));
         }
     }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Rdp/IapTransport.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Rdp/IapTransport.cs
@@ -39,12 +39,19 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Rdp
 
         public IProtocol Protocol { get; }
 
+        public ResourceLocator Target { get; }
+
         public IPEndPoint Endpoint => this.Tunnel.LocalEndpoint;
 
-        private IapTransport(IapTunnel tunnel, IProtocol protocol)
+        
+        private IapTransport(
+            IapTunnel tunnel, 
+            IProtocol protocol,
+            InstanceLocator target)
         {
             this.Tunnel = tunnel;
             this.Protocol = protocol;
+            this.Target = target;
         }
 
         public static IapTransport ForRdp(
@@ -77,7 +84,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Rdp
                     listener,
                     profile,
                     IapTunnelFlags.None),
-                RdpProtocol.Protocol);
+                RdpProtocol.Protocol,
+                instance);
         }
 
         protected override void Dispose(bool disposing)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/App/SsmsClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/App/SsmsClient.cs
@@ -19,6 +19,9 @@
 // under the License.
 //
 
+using Google.Apis.Compute.v1;
+using Google.Solutions.Apis.Compute;
+using Google.Solutions.Apis.Locator;
 using Google.Solutions.IapDesktop.Core.ClientModel.Protocol;
 using Google.Solutions.IapDesktop.Core.ClientModel.Transport;
 using System;
@@ -119,8 +122,18 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.App
             // to pass a "human readable" name of the VM to SSMS so that it's easier
             // to recognize the server in Object Explorer.
             // 
+            string instancePart;
+            if (transport.Target is InstanceLocator instance)
+            {
+                instancePart = new InternalDnsName.ZonalName(instance).Name;
+            }
+            else
+            {
+                instancePart = transport.Target.Name;
+            }
+
             var endpoint = transport.Endpoint;
-            return $"-S {endpoint.Address}\\{transport.Target.Name},{endpoint.Port} {authFlag}";
+            return $"-S {endpoint.Address}\\{instancePart},{endpoint.Port} {authFlag}";
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/App/SsmsClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/App/SsmsClient.cs
@@ -106,8 +106,21 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.App
                 authFlag = "-U sa";
             }
 
+            //
+            // NB. SSMS uses the notation `host,port` instead of the more common
+            // notation `host:port`.
+            //
+            // In case there is more than one SQL Server instance running on the
+            // host, the port number uniquely identifies one of them. Therefore,
+            // adding an instance name (like `host\instance,port`) isn't necessary 
+            // and if we do anyway, SSMS ignores it.
+            //
+            // We take advantage of this behavior here by using the `\instance` part
+            // to pass a "human readable" name of the VM to SSMS so that it's easier
+            // to recognize the server in Object Explorer.
+            // 
             var endpoint = transport.Endpoint;
-            return $"-S {endpoint.Address},{endpoint.Port} {authFlag}";
+            return $"-S {endpoint.Address}\\{transport.Target.Name},{endpoint.Port} {authFlag}";
         }
     }
 }


### PR DESCRIPTION
Pass the target VM's internal DNS name as "instance name"
to SSMS so that the VM can be identified more easily
in Object Explorer.

Ref #1071