### PR TITLE
b/285032643 Support rsa-sha2-256 and rsa-sha2-512 

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Ssh/SshTerminalViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Ssh/SshTerminalViewModel.cs
@@ -234,17 +234,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Ssh
             catch (SshNativeException e) when (
                 e.ErrorCode == LIBSSH2_ERROR.AUTHENTICATION_FAILED)
             {
-                var keyPairWarning = string.Empty;
-                if (this.AuthorizedKey.KeyPair is RsaSshKeyPair)
-                {
-                    keyPairWarning =
-                        "Some Linux distributions also no longer support the " +
-                        $"'{this.AuthorizedKey.KeyPair.Type}' algorithm that you're " +
-                        "currently using for SSH authentication. To use a more modern " +
-                        "algorithm, go to Tools > Options > SSH and " +
-                        "configure IAP Desktop to use ECDSA instead of RSA.";
-                }
-
                 if (this.AuthorizedKey.AuthorizationMethod == KeyAuthorizationMethods.Oslogin)
                 {
                     throw new OsLoginAuthenticationFailedException(
@@ -252,8 +241,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Ssh
                         "To perform this action, you need the following roles (or an equivalent custom role):\n\n" +
                         " 1. 'Compute OS Login' or 'Compute OS Admin Login'\n" +
                         " 2. 'Service Account User' (if the VM uses a service account)\n" +
-                        " 3. 'Compute OS Login External User' (if the VM belongs to a different GCP organization)\n\n" +
-                        keyPairWarning,
+                        " 3. 'Compute OS Login External User' (if the VM belongs to a different GCP organization)",
                         e,
                         HelpTopics.GrantingOsLoginRoles);
                 }
@@ -261,8 +249,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Ssh
                 {
                     throw new MetadataKeyAuthenticationFailedException(
                         "Authentication failed. Verify that the Compute Engine guest environment " +
-                        "is installed on the VM and that the agent is running.\n\n" +
-                        keyPairWarning,
+                        "is installed on the VM and that the agent is running.",
                         e,
                         HelpTopics.ManagingMetadataAuthorizedKeys);
                 }

--- a/sources/Google.Solutions.Ssh.Test/Cryptography/TestRsaSshKeyPair.cs
+++ b/sources/Google.Solutions.Ssh.Test/Cryptography/TestRsaSshKeyPair.cs
@@ -120,5 +120,67 @@ namespace Google.Solutions.Ssh.Test.Cryptography
                     key.PublicKeyString);
             }
         }
+
+        //---------------------------------------------------------------------
+        // Sign.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void WhenChallengeRequiresSha512_ThenSignReturnsSignature()
+        {
+            var challengeBlob = Convert.FromBase64String(
+                "AAAAIEVr/Hy4lWvHE87XI+c+jchQ4kkz/gCEpWzdIYU+PLvjMgAAAAh0ZX" +
+                "N0dXNlcgAAAA5zc2gtY29ubmVjdGlvbgAAAAlwdWJsaWNrZXkBAAAADHJz" +
+                "YS1zaGEyLTUxMgAAAZcAAAAHc3NoLXJzYQAAAAMBAAEAAAGBAN1l+hknPO" +
+                "InaZOAYM6Y6dDf9fZFE1nZntCT53HF8zSNhVv3cDaIgtODzyvd3IsUnCZQ" +
+                "VSVQJ0tlcmlKodKpo5Xu0MzQA1y+XjIfnSU8udjY6wwSSp4mGRQ7aeYAQH" +
+                "e5zo4kSDrAgcRLgV/teHpHy4l00qMWUFbFRfcnu0gaIXPMr00p1xk/1GJH" +
+                "Rd+1Hucd+RPTTFq2AVNqtT2+UcVYi1EzeXsjbJ+Pv6oovF2yScRuJFfK5C" +
+                "+OSEJKCPg1QcZHHUq62Mu3A5hxsomk02ZW42xmgIACUpE317mvuu5DkS/V" +
+                "isVy63M236lF5vyMbFSpJH1ze00sZh3l027qGD0VdjpV/V/5C6dTNzAYiF" +
+                "vghcxmuAJ/VszYQ6fTPnPpkan+aMWm2w+bWo/q3nRNmgjtQjUQoVM0/TNN" +
+                "W+r+/Us0iPG+jgWQO27TUROaFkeiX/epRXYAmT68w6uTU4CCv9oXY93mKN" +
+                "xn839ZTP+RzKaVZytKQLuCkh3u0Re8xZl0JM+pAQ==");
+
+            var challenge = new AuthenticationChallenge(challengeBlob);
+            Assert.AreEqual("rsa-sha2-512", challenge.Algorithm);
+
+            using (var cngKey = new RSACng())
+            using (var key = RsaSshKeyPair.FromKey(cngKey))
+            {
+                CollectionAssert.AreEqual(
+                    cngKey.SignData(challengeBlob, HashAlgorithmName.SHA512, RSASignaturePadding.Pkcs1),
+                    key.Sign(challenge));
+            }
+        }
+
+        [Test]
+        public void WhenChallengeRequiresSha256_ThenSignReturnsSignature()
+        {
+            var challengeBlob = Convert.FromBase64String(
+                "AAAAIEVr/Hy4lWvHE87XI+c+jchQ4kkz/gCEpWzdIYU+PLvjMgAAAAh0ZX" +
+                "N0dXNlcgAAAA5zc2gtY29ubmVjdGlvbgAAAAlwdWJsaWNrZXkBAAAADHJz" +
+                "YS1zaGEyLTI1NgAAAZcAAAAHc3NoLXJzYQAAAAMBAAEAAAGBAN1l+hknPO" +
+                "InaZOAYM6Y6dDf9fZFE1nZntCT53HF8zSNhVv3cDaIgtODzyvd3IsUnCZQ" +
+                "VSVQJ0tlcmlKodKpo5Xu0MzQA1y+XjIfnSU8udjY6wwSSp4mGRQ7aeYAQH" +
+                "e5zo4kSDrAgcRLgV/teHpHy4l00qMWUFbFRfcnu0gaIXPMr00p1xk/1GJH" +
+                "Rd+1Hucd+RPTTFq2AVNqtT2+UcVYi1EzeXsjbJ+Pv6oovF2yScRuJFfK5C" +
+                "+OSEJKCPg1QcZHHUq62Mu3A5hxsomk02ZW42xmgIACUpE317mvuu5DkS/V" +
+                "isVy63M236lF5vyMbFSpJH1ze00sZh3l027qGD0VdjpV/V/5C6dTNzAYiF" +
+                "vghcxmuAJ/VszYQ6fTPnPpkan+aMWm2w+bWo/q3nRNmgjtQjUQoVM0/TNN" +
+                "W+r+/Us0iPG+jgWQO27TUROaFkeiX/epRXYAmT68w6uTU4CCv9oXY93mKN" +
+                "xn839ZTP+RzKaVZytKQLuCkh3u0Re8xZl0JM+pAQ==");
+
+            var challenge = new AuthenticationChallenge(challengeBlob);
+            Assert.AreEqual("rsa-sha2-256", challenge.Algorithm);
+
+            using (var cngKey = new RSACng())
+            using (var key = RsaSshKeyPair.FromKey(cngKey))
+            {
+                CollectionAssert.AreEqual(
+                    cngKey.SignData(challengeBlob, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1),
+                    key.Sign(challenge));
+            }
+        }
     }
 }

--- a/sources/Google.Solutions.Ssh.Test/Google.Solutions.Ssh.Test.csproj
+++ b/sources/Google.Solutions.Ssh.Test/Google.Solutions.Ssh.Test.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Google.Apis.Auth" Version="1.61.0" />
     <PackageReference Include="Google.Apis.Compute.v1" Version="1.61.0.3103" />
     <PackageReference Include="Google.Apis.Core" Version="1.61.0" />
-    <PackageReference Include="libssh2" Version="1.10.0.31" />
+    <PackageReference Include="libssh2" Version="1.11.0.32" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit" Version="3.13.3" />

--- a/sources/Google.Solutions.Ssh/Cryptography/AuthenticationChallenge.cs
+++ b/sources/Google.Solutions.Ssh/Cryptography/AuthenticationChallenge.cs
@@ -29,9 +29,9 @@ namespace Google.Solutions.Ssh.Cryptography
     /// Challenge sent by server that the client must create
     /// a signature for.
     /// </summary>
-    internal struct AuthenticationChallenge
+    public struct AuthenticationChallenge
     {
-        public AuthenticationChallenge(byte[] value)
+        internal AuthenticationChallenge(byte[] value)
         {
             this.Value = value.ExpectNotNull(nameof(value));
 
@@ -75,7 +75,11 @@ namespace Google.Solutions.Ssh.Cryptography
                 reader.ReadBoolean();
 
                 this.Algorithm = reader.ReadString();
-                this.PublicKey = reader.ReadString();
+
+                //
+                // We can stop here, there's no need to read and decode
+                // the public key.
+                //
             }
         }
 
@@ -103,10 +107,5 @@ namespace Google.Solutions.Ssh.Cryptography
         /// Algorithm such as 'rsa-sha2-512'.
         /// </summary>
         public string Algorithm { get; private set; }
-
-        /// <summary>
-        /// Encoded public key.
-        /// </summary>
-        public string PublicKey { get; private set; }
     }
 }

--- a/sources/Google.Solutions.Ssh/Cryptography/ECDsaSshKeyPair.cs
+++ b/sources/Google.Solutions.Ssh/Cryptography/ECDsaSshKeyPair.cs
@@ -109,8 +109,10 @@ namespace Google.Solutions.Ssh.Cryptography
 
         public uint KeySize => (uint)this.key.KeySize;
 
-        public byte[] SignData(byte[] data)
+        public byte[] Sign(AuthenticationChallenge challenge)
         {
+            Debug.Assert(challenge.Algorithm == this.Type);
+
             //
             // NB. The signature returned by CNG is formatted according to
             // ISO/IEC 7816-8 / IEEE P1363. This is not the format SSH uses.
@@ -120,7 +122,7 @@ namespace Google.Solutions.Ssh.Cryptography
             //
             var signature = ECDsaSignature.FromIeee1363(
                 this.key.SignData(
-                    data,
+                    challenge.Value,
                     this.HashAlgorithm));
 
             return signature.ToSshBlob();

--- a/sources/Google.Solutions.Ssh/Cryptography/ISshKeyPair.cs
+++ b/sources/Google.Solutions.Ssh/Cryptography/ISshKeyPair.cs
@@ -45,9 +45,9 @@ namespace Google.Solutions.Ssh.Cryptography
         string PublicKeyString { get; }
 
         /// <summary>
-        /// Sign data and return signature in SSH format.
+        /// Sign an authentication challenge.
         /// </summary>
-        byte[] SignData(byte[] data);
+        byte[] Sign(AuthenticationChallenge challenge);
 
         /// <summary>
         /// Size of underlying key.

--- a/sources/Google.Solutions.Ssh/Google.Solutions.Ssh.csproj
+++ b/sources/Google.Solutions.Ssh/Google.Solutions.Ssh.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Google.Apis.Core" Version="1.61.0" />
-    <PackageReference Include="libssh2" Version="1.10.0.31" />
+    <PackageReference Include="libssh2" Version="1.11.0.32" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/sources/Google.Solutions.Ssh/Native/SshConnectedSession.cs
+++ b/sources/Google.Solutions.Ssh/Native/SshConnectedSession.cs
@@ -270,24 +270,7 @@ namespace Google.Solutions.Ssh.Native
                 Marshal.Copy(challengePtr, challengeBuffer, 0, challengeBuffer.Length);
 
                 var challenge = new AuthenticationChallenge(challengeBuffer);
-
-                //
-                // As of v1.11, libssh2 may attempt to auto-upgrade
-                // from ssh-rsa to ssh-rsa2-*.
-                //
-                if (challenge.Algorithm != authenticator.KeyPair.Type)
-                {
-                    signatureLength = IntPtr.Zero;
-                    signaturePtr = IntPtr.Zero;
-
-                    //
-                    // Reject and request a retry with the algorithm we
-                    // requested.
-                    //
-                    return (int)LIBSSH2_ERROR.ALGO_UNSUPPORTED;
-                }
-
-                var signature = authenticator.KeyPair.SignData(challengeBuffer);
+                var signature = authenticator.KeyPair.Sign(challenge);
 
                 //
                 // Copy data back to a buffer that libssh2 can free using


### PR DESCRIPTION
* Upgrade to libssh2 1.11 (which added support for rsa-sha2-256 and rsa-sha2-512)
* Handle RFC 8332-style algorithm updates where we authenticate using an ssh-rsa
  key but are subsequently challenged for an rsa-sha2-256 or rsa-sha2-512 signature