### PR TITLE
b/296956322 Fix parenting of error dialog

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Windows/ViewBindingContext.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/ViewBindingContext.cs
@@ -65,9 +65,18 @@ namespace Google.Solutions.IapDesktop.Application.Windows
             Debug.WriteLine($"Binding added for {control.GetType().Name} ({control})");
         }
 
-        public void OnCommandFailed(ICommand command, Exception exception)
+        public void OnCommandFailed(
+            IWin32Window window,
+            ICommand command,
+            Exception exception)
         {
             Debug.Assert(this.errorReportingOwner != null);
+
+            //
+            // NB. We might not know the parent window if this is
+            // a menu command. 
+            //
+            var parent = window ?? this.errorReportingOwner;
 
             ApplicationEventSource.Log.CommandFailed(
                 command.Id,
@@ -75,7 +84,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows
                 exception.FullMessage());
 
             this.exceptionDialog.Show(
-                this.errorReportingOwner,
+                parent,
                 $"{command.ActivityText} failed",
                 exception);
         }

--- a/sources/Google.Solutions.Mvvm.Test/Binding/Commands/TestCommandBindingExtensions.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Binding/Commands/TestCommandBindingExtensions.cs
@@ -208,6 +208,7 @@ namespace Google.Solutions.Mvvm.Test.Binding.Commands
 
                 bindingContext.Verify(
                     ctx => ctx.OnCommandFailed(
+                        null,
                         It.Is<ICommand>(c => c == command),
                         It.IsAny<ArgumentException>()),
                     Times.Once);
@@ -244,6 +245,7 @@ namespace Google.Solutions.Mvvm.Test.Binding.Commands
 
                 bindingContext.Verify(
                     ctx => ctx.OnCommandFailed(
+                        null,
                         It.Is<ICommand>(c => c == command),
                         It.IsAny<TaskCanceledException>()),
                     Times.Never);

--- a/sources/Google.Solutions.Mvvm.Test/Binding/Commands/TestCommandBindingExtensions.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Binding/Commands/TestCommandBindingExtensions.cs
@@ -208,7 +208,7 @@ namespace Google.Solutions.Mvvm.Test.Binding.Commands
 
                 bindingContext.Verify(
                     ctx => ctx.OnCommandFailed(
-                        null,
+                        form,
                         It.Is<ICommand>(c => c == command),
                         It.IsAny<ArgumentException>()),
                     Times.Once);

--- a/sources/Google.Solutions.Mvvm.Test/Binding/Commands/TestCommandContainer.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Binding/Commands/TestCommandContainer.cs
@@ -408,6 +408,7 @@ namespace Google.Solutions.Mvvm.Test.Binding.Commands
 
                 bindingContext.Verify(
                     ctx => ctx.OnCommandFailed(
+                        null,
                         It.IsAny<ICommand>(),
                         It.IsAny<ArgumentException>()),
                     Times.Once);
@@ -436,6 +437,7 @@ namespace Google.Solutions.Mvvm.Test.Binding.Commands
 
                 bindingContext.Verify(
                     ctx => ctx.OnCommandFailed(
+                        null,
                         It.IsAny<ICommand>(),
                         It.IsAny<Exception>()),
                     Times.Never);
@@ -454,6 +456,7 @@ namespace Google.Solutions.Mvvm.Test.Binding.Commands
                 Exception exception = null;
                 bindingContext.Setup(
                     ctx => ctx.OnCommandFailed(
+                        null,
                         It.IsAny<ICommand>(),
                         It.IsAny<Exception>()))
                     .Callback<ICommand, Exception>((c, e) => exception = e);
@@ -509,6 +512,7 @@ namespace Google.Solutions.Mvvm.Test.Binding.Commands
 
                 bindingContext.Verify(
                     ctx => ctx.OnCommandFailed(
+                        null,
                         It.IsAny<ICommand>(),
                         It.IsAny<Exception>()),
                     Times.Never);

--- a/sources/Google.Solutions.Mvvm.Test/Binding/Commands/TestCommandContainer.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Binding/Commands/TestCommandContainer.cs
@@ -459,7 +459,7 @@ namespace Google.Solutions.Mvvm.Test.Binding.Commands
                         null,
                         It.IsAny<ICommand>(),
                         It.IsAny<Exception>()))
-                    .Callback<ICommand, Exception>((c, e) => exception = e);
+                    .Callback<IWin32Window, ICommand, Exception>((w, c, e) => exception = e);
 
                 container.AddCommand(
                     new ContextCommand<string>(

--- a/sources/Google.Solutions.Mvvm/Binding/BindingContext.cs
+++ b/sources/Google.Solutions.Mvvm/Binding/BindingContext.cs
@@ -22,6 +22,7 @@
 using Google.Solutions.Mvvm.Binding.Commands;
 using System;
 using System.ComponentModel;
+using System.Windows.Forms;
 
 namespace Google.Solutions.Mvvm.Binding
 {
@@ -38,7 +39,10 @@ namespace Google.Solutions.Mvvm.Binding
         /// <summary>
         /// Notify that a command failed.
         /// </summary>
-        void OnCommandFailed(ICommand command, Exception exception);
+        void OnCommandFailed(
+            IWin32Window window,
+            ICommand command, 
+            Exception exception);
 
         /// <summary>
         /// Notify that a new binding has been created. Implementing

--- a/sources/Google.Solutions.Mvvm/Binding/Commands/CommandBindingExtensions.Generated.cs
+++ b/sources/Google.Solutions.Mvvm/Binding/Commands/CommandBindingExtensions.Generated.cs
@@ -36,7 +36,7 @@ namespace Google.Solutions.Mvvm.Binding.Commands
             private IObservableCommand command;
             private readonly Control button;
 
-            private async void OnClickAsync(object _, EventArgs __)
+            private async void OnClickAsync(object sender, EventArgs __)
             {
                 button.Enabled = false;
                 try
@@ -69,7 +69,10 @@ namespace Google.Solutions.Mvvm.Binding.Commands
                 }
                 catch (Exception e)
                 {
-                    this.bindingContext.OnCommandFailed(command, e);
+                    this.bindingContext.OnCommandFailed(
+                        (sender as Control)?.FindForm(),
+                        command, 
+                        e);
                 }
                 finally
                 {
@@ -100,7 +103,7 @@ namespace Google.Solutions.Mvvm.Binding.Commands
             private IObservableCommand command;
             private readonly ToolStripItem button;
 
-            private async void OnClickAsync(object _, EventArgs __)
+            private async void OnClickAsync(object sender, EventArgs __)
             {
                 button.Enabled = false;
                 try
@@ -118,7 +121,10 @@ namespace Google.Solutions.Mvvm.Binding.Commands
                 }
                 catch (Exception e)
                 {
-                    this.bindingContext.OnCommandFailed(command, e);
+                    this.bindingContext.OnCommandFailed(
+                        (sender as Control)?.FindForm(),
+                        command, 
+                        e);
                 }
                 finally
                 {

--- a/sources/Google.Solutions.Mvvm/Binding/Commands/CommandBindingExtensions.Generated.tt
+++ b/sources/Google.Solutions.Mvvm/Binding/Commands/CommandBindingExtensions.Generated.tt
@@ -37,7 +37,7 @@ namespace Google.Solutions.Mvvm.Binding.Commands
             private IObservableCommand command;
             private readonly <#=controlType#> button;
 
-            private async void OnClickAsync(object _, EventArgs __)
+            private async void OnClickAsync(object sender, EventArgs __)
             {
                 button.Enabled = false;
                 try
@@ -72,7 +72,10 @@ namespace Google.Solutions.Mvvm.Binding.Commands
                 }
                 catch (Exception e)
                 {
-                    this.bindingContext.OnCommandFailed(command, e);
+                    this.bindingContext.OnCommandFailed(
+                        (sender as Control)?.FindForm(),
+                        command, 
+                        e);
                 }
                 finally
                 {

--- a/sources/Google.Solutions.Mvvm/Binding/Commands/CommandContainer.cs
+++ b/sources/Google.Solutions.Mvvm/Binding/Commands/CommandContainer.cs
@@ -387,7 +387,7 @@ namespace Google.Solutions.Mvvm.Binding.Commands
                 }
                 catch (Exception e)
                 {
-                    this.container.bindingContext.OnCommandFailed(this.command, e);
+                    this.container.bindingContext.OnCommandFailed(null, this.command, e);
                 }
             }
         }


### PR DESCRIPTION
Use the control's window as parent if possible. This fixes an issue where error dialogs triggered by the Options dialog were parented to the main window, not the Options dialog.