### PR TITLE
b/304140852 Disable Nagle's algorithm for relay

### DIFF
--- a/sources/Google.Solutions.Iap/IapListener.cs
+++ b/sources/Google.Solutions.Iap/IapListener.cs
@@ -192,6 +192,8 @@ namespace Google.Solutions.Iap
                                 continue;
                             }
 
+                            socket.NoDelay = true;
+
                             var clientStream = new SocketStream(socket, this.Statistics);
                             var serverStream = new SshRelayStream(this.server);
 


### PR DESCRIPTION
Nagle's algorithm isn't needed, but can possibly lead to undesired relaying delays.