### PR TITLE
b/304382646 Skip ServiceLogin for Logs Viewer URLs

### DIFF
--- a/sources/Google.Solutions.Apis/Auth/Gaia/GaiaOidcSession.cs
+++ b/sources/Google.Solutions.Apis/Auth/Gaia/GaiaOidcSession.cs
@@ -109,7 +109,12 @@ namespace Google.Solutions.Apis.Auth.Gaia
 
         public override Uri CreateDomainSpecificServiceUri(Uri target)
         {
-            if (!string.IsNullOrEmpty(this.HostedDomain))
+            if (!string.IsNullOrEmpty(this.HostedDomain) &&
+
+                //
+                // ServiceLogin can't handle percent-encoded quotes.
+                //
+                !target.AbsoluteUri.Contains("%22"))
             {
                 //
                 // Sign in using same domain.


### PR DESCRIPTION
Logs Viewer URLs contain quotes, which is something ServiceLogin cannot handle.