### PR TITLE
b/304584429 Fall back to using process main window handle as parent

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Windows/Auth/AuthorizeView.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/Auth/AuthorizeView.cs
@@ -56,12 +56,6 @@ namespace Google.Solutions.IapDesktop.Application.Windows.Auth
         public void Bind(AuthorizeViewModel viewModel, IBindingContext bindingContext)
         {
             //
-            // Register this window with the binding context so that any
-            // error dialos can use this window as owner.
-            //
-            ((ViewBindingContext)bindingContext).SetCurrentMainWindow(this);
-
-            //
             // Bind controls.
             //
             this.BindReadonlyObservableProperty(

--- a/sources/Google.Solutions.IapDesktop/Properties/launchSettings.json
+++ b/sources/Google.Solutions.IapDesktop/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "Google.Solutions.IapDesktop": {
-      "commandName": "Project",
-      "commandLineArgs": "/profile \"Marge BYOID\""
+      "commandName": "Project"
     }
   }
 }

--- a/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
+++ b/sources/Google.Solutions.IapDesktop/Windows/MainForm.cs
@@ -94,12 +94,6 @@ namespace Google.Solutions.IapDesktop.Windows
             this.applicationSettings = this.serviceProvider.GetService<IRepository<IApplicationSettings>>();
             this.bindingContext = serviceProvider.GetService<IBindingContext>();
 
-            //
-            // Register this window with the binding context so that any
-            // error dialogs can use this window as owner.
-            //
-            ((ViewBindingContext)this.bindingContext).SetCurrentMainWindow(this);
-
             // 
             // Restore window settings.
             //


### PR DESCRIPTION
When no handle is provided, use the process main window handle as parent for error dialogs. This fixes an issue where the authorize dialog, after a reauth, registered itself as the default error window parent but was subsequently disposed.