### PR TITLE
b/304847158 Apply standard title, icon when splitting float window

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Options/TestGeneralOptionsViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Options/TestGeneralOptionsViewModel.cs
@@ -237,7 +237,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Options
 
             this.protocolRegistryMock.Verify(r => r.Register(
                     It.Is<string>(s => s == IapRdpUrl.Scheme),
-                    It.Is<string>(s => s == Install.FriendlyName),
+                    It.Is<string>(s => s == Install.ProductName),
                     It.IsAny<string>()),
                 Times.Once);
         }

--- a/sources/Google.Solutions.IapDesktop.Application/Host/Install.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Host/Install.cs
@@ -21,9 +21,11 @@
 
 using Google.Solutions.Apis.Client;
 using Google.Solutions.Common.Util;
+using Google.Solutions.IapDesktop.Application.Properties;
 using Microsoft.Win32;
 using System;
 using System.Diagnostics;
+using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -75,8 +77,6 @@ namespace Google.Solutions.IapDesktop.Application.Host
 
     public class Install : IInstall
     {
-        public const string FriendlyName = "IAP Desktop";
-
         private const string VersionHistoryValueName = "InstalledVersionHistory";
 
         public const string DefaultBaseKeyPath = @"Software\Google\IapDesktop";
@@ -87,6 +87,16 @@ namespace Google.Solutions.IapDesktop.Application.Host
         //---------------------------------------------------------------------
         // Static properties (based on assembly metadata).
         //---------------------------------------------------------------------
+
+        /// <summary>
+        /// Friendly name.
+        /// </summary>
+        public const string ProductName = "IAP Desktop";
+
+        /// <summary>
+        /// Default product icon to use for windows.
+        /// </summary>
+        public static Icon ProductIcon => Resources.logo;
 
         /// <summary>
         /// User agent to use in all HTTP requests.

--- a/sources/Google.Solutions.IapDesktop.Application/Theme/VSThemeExtensions.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Theme/VSThemeExtensions.cs
@@ -18,6 +18,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+using Google.Solutions.IapDesktop.Application.Host;
 using Google.Solutions.IapDesktop.Application.Windows;
 using Google.Solutions.Mvvm.Interop;
 using Google.Solutions.Mvvm.Theme;
@@ -150,6 +151,25 @@ namespace Google.Solutions.IapDesktop.Application.Theme
                 else
                 {
                     base.WndProc(ref m);
+                }
+            }
+
+            protected override void OnLayout(LayoutEventArgs levent)
+            {
+                base.OnLayout(levent);
+
+                //
+                // When a float window is split, the base class resets
+                // the icon and sets the title to " ".
+                //
+                // When that happens, apply the standard title and
+                // icon again so that we avoid showing a windows with a
+                // standard icon and empty title.
+                //
+                if (string.IsNullOrWhiteSpace(this.Text))
+                {
+                    this.Text = Install.ProductName;
+                    this.Icon = Install.ProductIcon;
                 }
             }
 

--- a/sources/Google.Solutions.IapDesktop.Application/Windows/Auth/AuthorizeViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/Auth/AuthorizeViewModel.cs
@@ -70,7 +70,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.Auth
             // NB. Properties are accessed from a non-GUI thread, so
             // they must be thread-safe.
             //
-            this.WindowTitle = ObservableProperty.Build($"Sign in - {Install.FriendlyName}");
+            this.WindowTitle = ObservableProperty.Build($"Sign in - {Install.ProductName}");
             this.IntroductionText = ObservableProperty.Build(
                 "Sign in to access your \r\nGoogle Cloud VMs.");
             this.Version = ObservableProperty.Build($"Version {install.CurrentVersion}");

--- a/sources/Google.Solutions.IapDesktop.Application/Windows/Options/GeneralOptionsViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/Options/GeneralOptionsViewModel.cs
@@ -100,7 +100,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.Options
             {
                 this.protocolRegistry.Register(
                     IapRdpUrl.Scheme,
-                    Install.FriendlyName,
+                    Install.ProductName,
                     ExecutableLocation);
             }
             else

--- a/sources/Google.Solutions.IapDesktop/Windows/MainFormViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop/Windows/MainFormViewModel.cs
@@ -48,7 +48,7 @@ namespace Google.Solutions.IapDesktop.Windows
         private readonly LinkedList<BackgroundJob> backgroundJobs
             = new LinkedList<BackgroundJob>();
 
-        private string windowTitle = Install.FriendlyName;
+        private string windowTitle = Install.ProductName;
         private bool isBackgroundJobStatusVisible = false;
         private string profileState = null;
 
@@ -191,8 +191,8 @@ namespace Google.Solutions.IapDesktop.Windows
             // Update window title so that it shows the current document.
             //
             var newTitle = title == null
-                ? Install.FriendlyName
-                : $"{title} - {Install.FriendlyName}";
+                ? Install.ProductName
+                : $"{title} - {Install.ProductName}";
 
             if (!this.profile.IsDefault)
             {


### PR DESCRIPTION
When a float window is split, the library resets
the icon and sets the title to " ".

When that happens, apply the standard title and
icon again so that we avoid showing a windows with a standard icon and empty title.