### PR TITLE
Add project references to Extension DLLs

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Diagnostics/Google.Solutions.IapDesktop.Extensions.Diagnostics.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Diagnostics/Google.Solutions.IapDesktop.Extensions.Diagnostics.csproj
@@ -7,9 +7,6 @@
     
     <Nullable>disable</Nullable>
   </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>copy /Y $(MSBuildProjectDirectory)\$(OutputPath)\$(TargetFramework)\$(AssemblyName).* $(SolutionDir)\Google.Solutions.IapDesktop\$(OutputPath)\$(TargetFramework)\</PostBuildEvent>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DockPanelSuite" Version="3.0.6.5" />
     <PackageReference Include="Google.Apis" Version="1.61.0" />

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/Google.Solutions.IapDesktop.Extensions.Management.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/Google.Solutions.IapDesktop.Extensions.Management.csproj
@@ -10,11 +10,6 @@
   <PropertyGroup>
     <RunPostBuildEvent>Always</RunPostBuildEvent>
   </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>
-      copy /Y $(MSBuildProjectDirectory)\$(OutputPath)\$(TargetFramework)\$(AssemblyName).* $(SolutionDir)\Google.Solutions.IapDesktop\$(OutputPath)\$(TargetFramework)\
-    </PostBuildEvent>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DockPanelSuite" Version="3.0.6.5" />
     <PackageReference Include="Google.Apis" Version="1.61.0" />

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Google.Solutions.IapDesktop.Extensions.Session.csproj
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Google.Solutions.IapDesktop.Extensions.Session.csproj
@@ -9,15 +9,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>disable</Nullable>
   </PropertyGroup>
-  <PropertyGroup>
-    <PostBuildEvent>
-      copy /Y $(MSBuildProjectDirectory)\$(OutputPath)\$(TargetFramework)\$(AssemblyName).* $(SolutionDir)\Google.Solutions.IapDesktop\$(OutputPath)\$(TargetFramework)\
-      copy /Y $(MSBuildProjectDirectory)\$(OutputPath)\$(TargetFramework)\*ssh* $(SolutionDir)\Google.Solutions.IapDesktop\$(OutputPath)\$(TargetFramework)\
-      copy /Y $(MSBuildProjectDirectory)\$(OutputPath)\$(TargetFramework)\*oslogin* $(SolutionDir)\Google.Solutions.IapDesktop\$(OutputPath)\$(TargetFramework)\
-      copy /Y $(MSBuildProjectDirectory)\$(OutputPath)\$(TargetFramework)\vtnetcore.* $(SolutionDir)\Google.Solutions.IapDesktop\$(OutputPath)\$(TargetFramework)\
-      copy /Y $(MSBuildProjectDirectory)\$(OutputPath)\$(TargetFramework)\*tsc* $(SolutionDir)\Google.Solutions.IapDesktop\$(OutputPath)\$(TargetFramework)\
-    </PostBuildEvent>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DockPanelSuite" Version="3.0.6.5" />
     <PackageReference Include="Google.Apis" Version="1.61.0" />

--- a/sources/Google.Solutions.IapDesktop/Google.Solutions.IapDesktop.csproj
+++ b/sources/Google.Solutions.IapDesktop/Google.Solutions.IapDesktop.csproj
@@ -89,6 +89,9 @@
     <ProjectReference Include="..\Google.Solutions.Common\Google.Solutions.Common.csproj" />
     <ProjectReference Include="..\Google.Solutions.IapDesktop.Application\Google.Solutions.IapDesktop.Application.csproj" />
     <ProjectReference Include="..\Google.Solutions.IapDesktop.Core\Google.Solutions.IapDesktop.Core.csproj" />
+    <ProjectReference Include="..\Google.Solutions.IapDesktop.Extensions.Diagnostics\Google.Solutions.IapDesktop.Extensions.Diagnostics.csproj" />
+    <ProjectReference Include="..\Google.Solutions.IapDesktop.Extensions.Management\Google.Solutions.IapDesktop.Extensions.Management.csproj" />
+    <ProjectReference Include="..\Google.Solutions.IapDesktop.Extensions.Session\Google.Solutions.IapDesktop.Extensions.Session.csproj" />
     <ProjectReference Include="..\Google.Solutions.Iap\Google.Solutions.Iap.csproj" />
     <ProjectReference Include="..\Google.Solutions.Mvvm\Google.Solutions.Mvvm.csproj" />
     <ProjectReference Include="..\Google.Solutions.Platform\Google.Solutions.Platform.csproj" />


### PR DESCRIPTION
Using a post-build copy operation is providing to be unreliable, so use a project reference to force extension DLLs (and their dependencies) to be copied to the main output folder.