### PR TITLE
b/309373652 Avoid pushing SSH key to project metadata if ActAs permission missing

### DIFF
--- a/sources/Google.Solutions.Apis.Test/Compute/TestComputeEngineClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Compute/TestComputeEngineClient.cs
@@ -341,7 +341,7 @@ namespace Google.Solutions.Apis.Test.Compute
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task WhenUserInRole_ThenIsGrantedPermissionReturnsTrue(
+        public async Task WhenUserInRole_ThenIsAccessGrantedReturnsTrue(
             [LinuxInstance] ResourceTask<InstanceLocator> testInstance,
             [Credential(Role = PredefinedRole.ComputeViewer)] ResourceTask<IAuthorization> auth)
         {
@@ -351,7 +351,7 @@ namespace Google.Solutions.Apis.Test.Compute
                 await auth,
                 TestProject.UserAgent);
 
-            var result = await client.IsGrantedPermission(
+            var result = await client.IsAccessGrantedAsync(
                     locator,
                     Permissions.ComputeInstancesGet)
                 .ConfigureAwait(false);
@@ -360,7 +360,7 @@ namespace Google.Solutions.Apis.Test.Compute
         }
 
         [Test]
-        public async Task WhenUserNotInRole_ThenIsGrantedPermissionReturnsFalse(
+        public async Task WhenUserNotInRole_ThenIsAccessGrantedReturnsFalse(
             [LinuxInstance] ResourceTask<InstanceLocator> testInstance,
             [Credential(Role = PredefinedRole.ComputeViewer)] ResourceTask<IAuthorization> auth)
         {
@@ -370,7 +370,7 @@ namespace Google.Solutions.Apis.Test.Compute
                 await auth,
                 TestProject.UserAgent);
 
-            var result = await client.IsGrantedPermission(
+            var result = await client.IsAccessGrantedAsync(
                     locator,
                     Permissions.ComputeInstancesSetMetadata)
                 .ConfigureAwait(false);
@@ -379,7 +379,7 @@ namespace Google.Solutions.Apis.Test.Compute
         }
 
         [Test]
-        public async Task WhenUserLacksInstanceListPermission_ThenIsGrantedPermissionFailsOpenAndReturnsTrue(
+        public async Task WhenUserLacksInstanceListPermission_ThenIsAccessGrantedFailsOpenAndReturnsTrue(
             [LinuxInstance] ResourceTask<InstanceLocator> testInstance,
             [Credential(Role = PredefinedRole.IapTunnelUser)] ResourceTask<IAuthorization> auth)
         {
@@ -389,7 +389,7 @@ namespace Google.Solutions.Apis.Test.Compute
                 await auth,
                 TestProject.UserAgent);
 
-            var result = await client.IsGrantedPermission(
+            var result = await client.IsAccessGrantedAsync(
                     locator,
                     Permissions.ComputeInstancesSetMetadata)
                 .ConfigureAwait(false);

--- a/sources/Google.Solutions.Apis.Test/Crm/TestResourceManagerClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Crm/TestResourceManagerClient.cs
@@ -70,38 +70,38 @@ namespace Google.Solutions.Apis.Test.Crm
             Assert.AreEqual(TestProject.ProjectId, project.Name);
         }
 
+        //---------------------------------------------------------------------
+        // IsAccessGranted.
+        //---------------------------------------------------------------------
+
         [Test]
-        public async Task WhenUserInRole_ThenIsGrantedPermissionReturnsTrue(
+        public async Task WhenUserHasPermission_ThenIsAccessGrantedReturnsTrue(
             [Credential(Role = PredefinedRole.ComputeViewer)] ResourceTask<IAuthorization> auth)
         {
             var client = new ResourceManagerClient(
                 ResourceManagerClient.CreateEndpoint(),
                 await auth,
                 TestProject.UserAgent);
-            var result = await client.IsGrantedPermissionAsync(
+            var result = await client.IsAccessGrantedAsync(
                     TestProject.ProjectId,
-                    Permissions.ComputeInstancesGet,
+                    new[] { Permissions.ComputeInstancesGet },
                     CancellationToken.None)
                 .ConfigureAwait(false);
 
             Assert.IsTrue(result);
         }
 
-        //---------------------------------------------------------------------
-        // IsGrantedPermission.
-        //---------------------------------------------------------------------
-
         [Test]
-        public async Task WhenUserNotInRole_ThenIsGrantedPermissionReturnsFalse(
+        public async Task WhenUserLacksOnePermission_ThenIsAccessGrantedReturnsFalse(
             [Credential(Role = PredefinedRole.ComputeViewer)] ResourceTask<IAuthorization> auth)
         {
             var client = new ResourceManagerClient(
                 ResourceManagerClient.CreateEndpoint(),
                 await auth,
                 TestProject.UserAgent);
-            var result = await client.IsGrantedPermissionAsync(
+            var result = await client.IsAccessGrantedAsync(
                     TestProject.ProjectId,
-                    "compute.disks.create",
+                    new[] { "compute.disks.create", Permissions.ComputeInstancesGet },
                     CancellationToken.None)
                 .ConfigureAwait(false);
 

--- a/sources/Google.Solutions.Apis/Compute/ComputeEngineClient.cs
+++ b/sources/Google.Solutions.Apis/Compute/ComputeEngineClient.cs
@@ -378,7 +378,7 @@ namespace Google.Solutions.Apis.Compute
         // Permission check.
         //---------------------------------------------------------------------
 
-        public async Task<bool> IsGrantedPermission(
+        public async Task<bool> IsAccessGrantedAsync(
             InstanceLocator instanceLocator,
             string permission)
         {
@@ -386,7 +386,8 @@ namespace Google.Solutions.Apis.Compute
             {
                 try
                 {
-                    var response = await this.service.Instances.TestIamPermissions(
+                    var response = await this.service.Instances
+                        .TestIamPermissions(
                             new TestPermissionsRequest
                             {
                                 Permissions = new[] { permission }

--- a/sources/Google.Solutions.Apis/Compute/IComputeEngineClient.cs
+++ b/sources/Google.Solutions.Apis/Compute/IComputeEngineClient.cs
@@ -103,7 +103,10 @@ namespace Google.Solutions.Apis.Compute
         // Permission check.
         //---------------------------------------------------------------------
 
-        Task<bool> IsGrantedPermission(
+        /// <summary>
+        /// Test if a permission has been granted.
+        /// </summary>
+        Task<bool> IsAccessGrantedAsync(
             InstanceLocator instanceRef,
             string permission);
     }

--- a/sources/Google.Solutions.Apis/Compute/Permissions.cs
+++ b/sources/Google.Solutions.Apis/Compute/Permissions.cs
@@ -26,5 +26,6 @@ namespace Google.Solutions.Apis.Compute
         public const string ComputeInstancesSetMetadata = "compute.instances.setMetadata";
         public const string ComputeInstancesGet = "compute.instances.get";
         public const string ComputeProjectsSetCommonInstanceMetadata = "compute.projects.setCommonInstanceMetadata";
+        public const string ServiceAccountsActAs = "iam.serviceAccounts.actAs";
     }
 }

--- a/sources/Google.Solutions.Apis/Compute/WindowsCredentialGenerator.cs
+++ b/sources/Google.Solutions.Apis/Compute/WindowsCredentialGenerator.cs
@@ -340,7 +340,7 @@ namespace Google.Solutions.Apis.Compute
             //
             // For performance reasons, only check (1).
             //
-            return this.computeClient.IsGrantedPermission(
+            return this.computeClient.IsAccessGrantedAsync(
                 instanceRef,
                 Permissions.ComputeInstancesSetMetadata);
         }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestInstanceMetadataAuthorizedPublicKeyProcessor.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestInstanceMetadataAuthorizedPublicKeyProcessor.cs
@@ -31,6 +31,7 @@ using Google.Solutions.Testing.Apis;
 using Moq;
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -132,9 +133,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
         {
             var adapter = new Mock<IResourceManagerClient>();
             adapter
-                .Setup(a => a.IsGrantedPermissionAsync(
+                .Setup(a => a.IsAccessGrantedAsync(
                         It.IsAny<string>(),
-                        It.IsAny<string>(),
+                        It.IsAny<IReadOnlyCollection<string>>(),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(allowSetCommonInstanceMetadata);
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestInstanceMetadataAuthorizedPublicKeyProcessor.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestInstanceMetadataAuthorizedPublicKeyProcessor.cs
@@ -135,7 +135,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
             adapter
                 .Setup(a => a.IsAccessGrantedAsync(
                         It.IsAny<string>(),
-                        It.IsAny<IReadOnlyCollection<string>>(),
+                        It.Is<IReadOnlyCollection<string>>(
+                            c => c.Contains(Permissions.ComputeProjectsSetCommonInstanceMetadata) &&
+                                 c.Contains(Permissions.ServiceAccountsActAs)),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(allowSetCommonInstanceMetadata);
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Ssh/MetadataAuthorizedPublicKeyProcessor.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Ssh/MetadataAuthorizedPublicKeyProcessor.cs
@@ -362,9 +362,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Ssh
                 // - we do not have the permission to update project metadata.
                 //
                 var canUpdateProjectMetadata = await this.resourceManagerAdapter
-                    .IsGrantedPermissionAsync(
+                    .IsAccessGrantedAsync(
                         this.instance.ProjectId,
-                        Permissions.ComputeProjectsSetCommonInstanceMetadata,
+                        new[] { Permissions.ComputeProjectsSetCommonInstanceMetadata },
                         cancellationToken)
                     .ConfigureAwait(false);
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Ssh/MetadataAuthorizedPublicKeyProcessor.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Ssh/MetadataAuthorizedPublicKeyProcessor.cs
@@ -364,7 +364,10 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Ssh
                 var canUpdateProjectMetadata = await this.resourceManagerAdapter
                     .IsAccessGrantedAsync(
                         this.instance.ProjectId,
-                        new[] { Permissions.ComputeProjectsSetCommonInstanceMetadata },
+                        new[] { 
+                            Permissions.ComputeProjectsSetCommonInstanceMetadata,
+                            Permissions.ServiceAccountsActAs
+                        },
                         cancellationToken)
                     .ConfigureAwait(false);
 


### PR DESCRIPTION
* Verify that the user has the `iam.serviceAccounts.actAs` permission on the project before pushing to project metadata
* Fall back to instance metadata if permission is not held