### PR TITLE
b/304359886 Include window details in bug report

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/Host/Diagnostics/TestBugReport.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Host/Diagnostics/TestBugReport.cs
@@ -23,6 +23,7 @@ using Google.Solutions.IapDesktop.Application.Host.Diagnostics;
 using NUnit.Framework;
 using System;
 using System.Reflection;
+using System.Windows.Forms;
 
 namespace Google.Solutions.IapDesktop.Application.Test.Host.Diagnostics
 {
@@ -63,6 +64,23 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host.Diagnostics
 
             StringAssert.Contains("inner#1", report.ToString());
             StringAssert.Contains("inner#2", report.ToString());
+        }
+
+        [Test]
+        public void WhenSourceWindowSetToControl_ThenToStringContainsWindowDetails()
+        {
+            using (var form = new Form()
+            {
+                Name = "TestForm",
+            })
+            {
+                var report = new BugReport(GetType(), new ApplicationException("test"))
+                {
+                    SourceWindow = form
+                };
+
+                StringAssert.Contains("Window: TestForm (Form)", report.ToString());
+            }
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Application/Host/Diagnostics/BugReport.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Host/Diagnostics/BugReport.cs
@@ -22,8 +22,10 @@
 using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.Common.Util;
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using System.Text;
+using System.Windows.Forms;
 
 namespace Google.Solutions.IapDesktop.Application.Host.Diagnostics
 {
@@ -44,6 +46,11 @@ namespace Google.Solutions.IapDesktop.Application.Host.Diagnostics
             this.source = source;
             this.exception = exception;
         }
+
+        /// <summary>
+        /// Window that produced the issue, if any.
+        /// </summary>
+        public IWin32Window SourceWindow { get; set; }
 
         public override string ToString()
         {
@@ -66,6 +73,22 @@ namespace Google.Solutions.IapDesktop.Application.Host.Diagnostics
                         text.Append("\n\n");
                     }
                 }
+            }
+
+            if (this.SourceWindow == null)
+            {
+                text.Append("Window: unknown\n");
+            }
+            else if (this.SourceWindow is Control control &&
+                control.FindForm() is var form &&
+                form != null)
+            {
+                text.Append($"Window: {form.Name} ({control.GetType().Name})\n");
+                text.Append($"Control: {control.Name} ({control.GetType().Name})\n");
+            }
+            else if (this.SourceWindow.Handle == Process.GetCurrentProcess().MainWindowHandle)
+            {
+                text.Append("Window: main\n");
             }
 
             var cpuArchitecture = Assembly.GetEntryAssembly()?.GetName().ProcessorArchitecture.ToString() ?? "unknown";

--- a/sources/Google.Solutions.IapDesktop.Application/Windows/Dialog/ExceptionDialog.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/Dialog/ExceptionDialog.cs
@@ -211,13 +211,20 @@ namespace Google.Solutions.IapDesktop.Application.Windows.Dialog
                     caption,
                     details);
 
+                var bugReport = ShouldShowBugReportLink(e)
+                    ? new BugReport(GetType(), e)
+                    {
+                        SourceWindow = parent
+                    }
+                    : null;
+
                 ShowErrorDialogWithHelp(
                     parent,
                     caption,
                     message,
                     details.ToString(),
                     (e as IExceptionWithHelpTopic)?.Help,
-                    ShouldShowBugReportLink(e) ? new BugReport(GetType(), e) : null);
+                    bugReport);
             }
         }
     }


### PR DESCRIPTION
Include the name and type of source window and
control, if known. This is to assist finding the source of unhandled exceptions.