### PR TITLE
b/309816619 Handle dynamic port reservations conflicts

### DIFF
--- a/sources/Google.Solutions.Iap.Test/Protocol/Mocks.cs
+++ b/sources/Google.Solutions.Iap.Test/Protocol/Mocks.cs
@@ -132,6 +132,8 @@ namespace Google.Solutions.Iap.Test.Protocol
         public int ConnectCount { get; private set; } = 0;
         public int ReconnectCount { get; private set; } = 0;
 
+        public bool IsMutualTlsEnabled => false;
+
         public Task<INetworkStream> ConnectAsync(CancellationToken token)
         {
             var result = Task.FromResult(this.ExpectedStreams[this.ConnectCount + this.ReconnectCount]);

--- a/sources/Google.Solutions.Iap.Test/Protocol/TestSshRelayStream.SocketHandling.cs
+++ b/sources/Google.Solutions.Iap.Test/Protocol/TestSshRelayStream.SocketHandling.cs
@@ -64,6 +64,8 @@ namespace Google.Solutions.Iap.Test.Protocol
 
             public ServerWebSocketConnection Server => this.connection.Server;
 
+            public bool IsMutualTlsEnabled => false;
+
             public Endpoint(
                 WebSocketServer server,
                 WebSocketConnection connection)

--- a/sources/Google.Solutions.Iap/Net/PortFinder.cs
+++ b/sources/Google.Solutions.Iap/Net/PortFinder.cs
@@ -106,6 +106,7 @@ namespace Google.Solutions.Iap.Net
                     // Preferred port is available.
                     //
                     isPreferred = true;
+                    
                     return preferredPort;
                 }
             }

--- a/sources/Google.Solutions.Iap/Protocol/SshRelaySession.cs
+++ b/sources/Google.Solutions.Iap/Protocol/SshRelaySession.cs
@@ -35,6 +35,8 @@ namespace Google.Solutions.Iap.Protocol
     /// </summary>
     public interface ISshRelayTarget
     {
+        bool IsMutualTlsEnabled { get; }
+
         Task<INetworkStream> ConnectAsync(CancellationToken token);
 
         Task<INetworkStream> ReconnectAsync(


### PR DESCRIPTION
When a dynamically allocated port can't be used because of a persistent port reservation, allocate a different port and try again.