### PR TITLE
b/320156813 Remove connection settings for bitmap persistence, deskto…

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Rdp/TestRdpParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Rdp/TestRdpParameters.cs
@@ -38,11 +38,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
             Assert.AreEqual(RdpParameters.DefaultPort, parameters.Port);
             Assert.AreEqual(RdpParameters.DefaultConnectionTimeout, parameters.ConnectionTimeout);
             Assert.AreEqual(RdpConnectionBarState._Default, parameters.ConnectionBar);
-            Assert.AreEqual(RdpDesktopSize._Default, parameters.DesktopSize);
             Assert.AreEqual(RdpAuthenticationLevel._Default, parameters.AuthenticationLevel);
             Assert.AreEqual(RdpColorDepth._Default, parameters.ColorDepth);
             Assert.AreEqual(RdpAudioMode._Default, parameters.AudioMode);
-            Assert.AreEqual(RdpBitmapPersistence._Default, parameters.BitmapPersistence);
             Assert.AreEqual(RdpNetworkLevelAuthentication._Default, parameters.NetworkLevelAuthentication);
             Assert.AreEqual(RdpUserAuthenticationBehavior._Default, parameters.UserAuthenticationBehavior);
             Assert.AreEqual(RdpRedirectClipboard._Default, parameters.RedirectClipboard);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestConnectionSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestConnectionSettingsRepository.cs
@@ -80,13 +80,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsTrue(settings.RdpPassword.IsDefault);
             Assert.IsTrue(settings.RdpDomain.IsDefault);
             Assert.IsTrue(settings.RdpConnectionBar.IsDefault);
-            Assert.IsTrue(settings.RdpDesktopSize.IsDefault);
             Assert.IsTrue(settings.RdpAuthenticationLevel.IsDefault);
             Assert.IsTrue(settings.RdpColorDepth.IsDefault);
             Assert.IsTrue(settings.RdpAudioMode.IsDefault);
             Assert.IsTrue(settings.RdpRedirectClipboard.IsDefault);
             Assert.IsTrue(settings.RdpUserAuthenticationBehavior.IsDefault);
-            Assert.IsTrue(settings.RdpBitmapPersistence.IsDefault);
             Assert.IsTrue(settings.RdpConnectionTimeout.IsDefault);
             Assert.IsTrue(settings.RdpPort.IsDefault);
             Assert.IsTrue(settings.RdpTransport.IsDefault);
@@ -175,13 +173,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsTrue(settings.RdpPassword.IsDefault);
             Assert.IsTrue(settings.RdpDomain.IsDefault);
             Assert.IsTrue(settings.RdpConnectionBar.IsDefault);
-            Assert.IsTrue(settings.RdpDesktopSize.IsDefault);
             Assert.IsTrue(settings.RdpAuthenticationLevel.IsDefault);
             Assert.IsTrue(settings.RdpColorDepth.IsDefault);
             Assert.IsTrue(settings.RdpAudioMode.IsDefault);
             Assert.IsTrue(settings.RdpRedirectClipboard.IsDefault);
             Assert.IsTrue(settings.RdpUserAuthenticationBehavior.IsDefault);
-            Assert.IsTrue(settings.RdpBitmapPersistence.IsDefault);
             Assert.IsTrue(settings.RdpConnectionTimeout.IsDefault);
             Assert.IsTrue(settings.RdpPort.IsDefault);
             Assert.IsTrue(settings.RdpTransport.IsDefault);
@@ -248,12 +244,10 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsTrue(settings.RdpPassword.IsDefault);
             Assert.IsTrue(settings.RdpDomain.IsDefault);
             Assert.IsTrue(settings.RdpConnectionBar.IsDefault);
-            Assert.IsTrue(settings.RdpDesktopSize.IsDefault);
             Assert.IsTrue(settings.RdpAuthenticationLevel.IsDefault);
             Assert.IsTrue(settings.RdpColorDepth.IsDefault);
             Assert.IsTrue(settings.RdpAudioMode.IsDefault);
             Assert.IsTrue(settings.RdpUserAuthenticationBehavior.IsDefault);
-            Assert.IsTrue(settings.RdpBitmapPersistence.IsDefault);
             Assert.IsTrue(settings.RdpConnectionTimeout.IsDefault);
             Assert.IsTrue(settings.RdpRedirectClipboard.IsDefault);
             Assert.IsTrue(settings.RdpRedirectPrinter.IsDefault);
@@ -274,7 +268,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             var originalSettings = this.repository.GetInstanceSettings(instance);
             originalSettings.RdpUsername.Value = "user-1";
             originalSettings.RdpConnectionBar.Value = RdpConnectionBarState.Pinned;
-            originalSettings.RdpDesktopSize.Value = RdpDesktopSize.ScreenSize;
             originalSettings.RdpAuthenticationLevel.Value = RdpAuthenticationLevel.RequireServerAuthentication;
             originalSettings.RdpColorDepth.Value = RdpColorDepth.DeepColor;
             originalSettings.RdpAudioMode.Value = RdpAudioMode.DoNotPlay;
@@ -294,7 +287,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
 
             Assert.AreEqual("user-1", settings.RdpUsername.Value);
             Assert.AreEqual(RdpConnectionBarState.Pinned, settings.RdpConnectionBar.Value);
-            Assert.AreEqual(RdpDesktopSize.ScreenSize, settings.RdpDesktopSize.Value);
             Assert.AreEqual(RdpAuthenticationLevel.RequireServerAuthentication, settings.RdpAuthenticationLevel.Value);
             Assert.AreEqual(RdpColorDepth.DeepColor, settings.RdpColorDepth.Value);
             Assert.AreEqual(RdpAudioMode.DoNotPlay, settings.RdpAudioMode.Value);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestIapRdpUrlConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestIapRdpUrlConnectionSettings.cs
@@ -87,7 +87,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             settings.RdpUsername.Value = "user";
             settings.RdpDomain.Value = "domain";
             settings.RdpConnectionBar.Value = RdpConnectionBarState.Off;
-            settings.RdpDesktopSize.Value = RdpDesktopSize.ScreenSize;
             settings.RdpAuthenticationLevel.Value = RdpAuthenticationLevel.RequireServerAuthentication;
             settings.RdpColorDepth.Value = RdpColorDepth.TrueColor;
             settings.RdpAudioMode.Value = RdpAudioMode.PlayOnServer;
@@ -102,7 +101,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.AreEqual("user", copy.RdpUsername.Value);
             Assert.AreEqual("domain", copy.RdpDomain.Value);
             Assert.AreEqual(RdpConnectionBarState.Off, copy.RdpConnectionBar.Value);
-            Assert.AreEqual(RdpDesktopSize.ScreenSize, copy.RdpDesktopSize.Value);
             Assert.AreEqual(RdpAuthenticationLevel.RequireServerAuthentication, copy.RdpAuthenticationLevel.Value);
             Assert.AreEqual(RdpColorDepth.TrueColor, copy.RdpColorDepth.Value);
             Assert.AreEqual(RdpAudioMode.PlayOnServer, copy.RdpAudioMode.Value);
@@ -123,7 +121,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsNull(settings.RdpPassword.Value);
             Assert.IsNull(settings.RdpDomain.Value);
             Assert.AreEqual(RdpConnectionBarState._Default, settings.RdpConnectionBar.Value);
-            Assert.AreEqual(RdpDesktopSize._Default, settings.RdpDesktopSize.Value);
             Assert.AreEqual(RdpAuthenticationLevel._Default, settings.RdpAuthenticationLevel.Value);
             Assert.AreEqual(RdpColorDepth._Default, settings.RdpColorDepth.Value);
             Assert.AreEqual(RdpAudioMode._Default, settings.RdpAudioMode.Value);
@@ -140,7 +137,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsNull(settings.RdpPassword.Value);
             Assert.IsNull(settings.RdpDomain.Value);
             Assert.AreEqual(RdpConnectionBarState._Default, settings.RdpConnectionBar.Value);
-            Assert.AreEqual(RdpDesktopSize._Default, settings.RdpDesktopSize.Value);
             Assert.AreEqual(RdpAuthenticationLevel._Default, settings.RdpAuthenticationLevel.Value);
             Assert.AreEqual(RdpColorDepth._Default, settings.RdpColorDepth.Value);
             Assert.AreEqual(RdpAudioMode._Default, settings.RdpAudioMode.Value);
@@ -160,7 +156,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsNull(settings.RdpPassword.Value);
             Assert.IsNull(settings.RdpDomain.Value);
             Assert.AreEqual(RdpConnectionBarState._Default, settings.RdpConnectionBar.Value);
-            Assert.AreEqual(RdpDesktopSize._Default, settings.RdpDesktopSize.Value);
             Assert.AreEqual(RdpAuthenticationLevel._Default, settings.RdpAuthenticationLevel.Value);
             Assert.AreEqual(RdpColorDepth._Default, settings.RdpColorDepth.Value);
             Assert.AreEqual(RdpAudioMode._Default, settings.RdpAudioMode.Value);
@@ -188,7 +183,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             var settings = new ConnectionSettings(url);
 
             Assert.AreEqual(RdpConnectionBarState.Pinned, settings.RdpConnectionBar.Value);
-            Assert.AreEqual(RdpDesktopSize.ScreenSize, settings.RdpDesktopSize.Value);
             Assert.AreEqual(RdpAuthenticationLevel.AttemptServerAuthentication, settings.RdpAuthenticationLevel.Value);
             Assert.AreEqual(RdpColorDepth.DeepColor, settings.RdpColorDepth.Value);
             Assert.AreEqual(RdpAudioMode.DoNotPlay, settings.RdpAudioMode.Value);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Rdp/TestRdpView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Rdp/TestRdpView.cs
@@ -130,8 +130,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Rdp
                 var rdpParameters = new RdpParameters()
                 {
                     AuthenticationLevel = RdpAuthenticationLevel.NoServerAuthentication,
-                    UserAuthenticationBehavior = RdpUserAuthenticationBehavior.AbortOnFailure,
-                    DesktopSize = RdpDesktopSize.ClientSize
+                    UserAuthenticationBehavior = RdpUserAuthenticationBehavior.AbortOnFailure
                 };
 
                 var broker = new InstanceSessionBroker(serviceProvider);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpParameters.cs
@@ -32,11 +32,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
         public ushort Port { get; set; } = DefaultPort;
         public TimeSpan ConnectionTimeout { get; set; } = DefaultConnectionTimeout;
         public RdpConnectionBarState ConnectionBar { get; set; } = RdpConnectionBarState._Default;
-        public RdpDesktopSize DesktopSize { get; set; } = RdpDesktopSize._Default; //TODO: remove
         public RdpAuthenticationLevel AuthenticationLevel { get; set; } = RdpAuthenticationLevel._Default;
         public RdpColorDepth ColorDepth { get; set; } = RdpColorDepth._Default;
         public RdpAudioMode AudioMode { get; set; } = RdpAudioMode._Default;
-        public RdpBitmapPersistence BitmapPersistence { get; set; } = RdpBitmapPersistence._Default; //TODO: remove
         public RdpNetworkLevelAuthentication NetworkLevelAuthentication { get; set; } = RdpNetworkLevelAuthentication._Default;
         public RdpUserAuthenticationBehavior UserAuthenticationBehavior { get; set; } = RdpUserAuthenticationBehavior._Default;
         public RdpRedirectClipboard RedirectClipboard { get; set; } = RdpRedirectClipboard._Default;
@@ -88,16 +86,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
 
         [Browsable(false)]
         _Default = AutoHide
-    }
-
-    public enum RdpDesktopSize
-    {
-        ClientSize = 0,
-        ScreenSize = 1,
-        AutoAdjust = 2,
-
-        [Browsable(false)]
-        _Default = AutoAdjust
     }
 
     public enum RdpAuthenticationLevel
@@ -152,15 +140,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
 
         [Browsable(false)]
         _Default = PromptOnFailure
-    }
-
-    public enum RdpBitmapPersistence
-    {
-        Disabled = 0,
-        Enabled = 1,
-
-        [Browsable(false)]
-        _Default = Disabled
     }
 
     public enum RdpCredentialGenerationBehavior

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextFactory.cs
@@ -156,11 +156,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol
             context.Parameters.TransportType = settings.RdpTransport.EnumValue;
             context.Parameters.ConnectionTimeout = TimeSpan.FromSeconds(settings.RdpConnectionTimeout.IntValue);
             context.Parameters.ConnectionBar = settings.RdpConnectionBar.EnumValue;
-            context.Parameters.DesktopSize = settings.RdpDesktopSize.EnumValue;
             context.Parameters.AuthenticationLevel = settings.RdpAuthenticationLevel.EnumValue;
             context.Parameters.ColorDepth = settings.RdpColorDepth.EnumValue;
             context.Parameters.AudioMode = settings.RdpAudioMode.EnumValue;
-            context.Parameters.BitmapPersistence = settings.RdpBitmapPersistence.EnumValue;
             context.Parameters.NetworkLevelAuthentication = settings.RdpNetworkLevelAuthentication.EnumValue;
             context.Parameters.UserAuthenticationBehavior = settings.RdpUserAuthenticationBehavior.EnumValue;
             context.Parameters.RedirectClipboard = settings.RdpRedirectClipboard.EnumValue;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
@@ -100,13 +100,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                 Categories.RdpDisplay,
                 RdpConnectionBarState._Default,
                 key);
-            this.RdpDesktopSize = RegistryEnumSetting<RdpDesktopSize>.FromKey(
-                "DesktopSize",
-                "Desktop size",
-                "Size of remote desktop.",
-                Categories.RdpDisplay,
-                Protocol.Rdp.RdpDesktopSize._Default,
-                key);
             this.RdpAuthenticationLevel = RegistryEnumSetting<RdpAuthenticationLevel>.FromKey(
                 "AuthenticationLevel",
                 "Server authentication",
@@ -134,13 +127,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                 null, // Hidden.
                 null, // Hidden.
                 Protocol.Rdp.RdpUserAuthenticationBehavior._Default,
-                key);
-            this.RdpBitmapPersistence = RegistryEnumSetting<RdpBitmapPersistence>.FromKey(
-                "BitmapPersistence",
-                "Bitmap caching",
-                "Use persistent bitmap cache. Enabling caching substantially increases memory usage.",
-                Categories.RdpDisplay,
-                Protocol.Rdp.RdpBitmapPersistence._Default,
                 key);
             this.RdpNetworkLevelAuthentication = RegistryEnumSetting<RdpNetworkLevelAuthentication>.FromKey(
                 "NetworkLevelAuthentication",
@@ -379,8 +365,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                 this.RdpDomain.OverlayBy(overlay.RdpDomain);
             merged.RdpConnectionBar = (RegistryEnumSetting<RdpConnectionBarState>)
                 this.RdpConnectionBar.OverlayBy(overlay.RdpConnectionBar);
-            merged.RdpDesktopSize = (RegistryEnumSetting<RdpDesktopSize>)
-                this.RdpDesktopSize.OverlayBy(overlay.RdpDesktopSize);
             merged.RdpAuthenticationLevel = (RegistryEnumSetting<RdpAuthenticationLevel>)
                 this.RdpAuthenticationLevel.OverlayBy(overlay.RdpAuthenticationLevel);
             merged.RdpColorDepth = (RegistryEnumSetting<RdpColorDepth>)
@@ -389,8 +373,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                 this.RdpAudioMode.OverlayBy(overlay.RdpAudioMode);
             merged.RdpUserAuthenticationBehavior = (RegistryEnumSetting<RdpUserAuthenticationBehavior>)
                 this.RdpUserAuthenticationBehavior.OverlayBy(overlay.RdpUserAuthenticationBehavior);
-            merged.RdpBitmapPersistence = (RegistryEnumSetting<RdpBitmapPersistence>)
-                this.RdpBitmapPersistence.OverlayBy(overlay.RdpBitmapPersistence);
             merged.RdpNetworkLevelAuthentication = (RegistryEnumSetting<RdpNetworkLevelAuthentication>)
                 this.RdpNetworkLevelAuthentication.OverlayBy(overlay.RdpNetworkLevelAuthentication);
             merged.RdpConnectionTimeout = (RegistryDwordSetting)
@@ -447,12 +429,10 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
         public RegistrySecureStringSetting RdpPassword { get; private set; }
         public RegistryStringSetting RdpDomain { get; private set; }
         public RegistryEnumSetting<RdpConnectionBarState> RdpConnectionBar { get; private set; }
-        public RegistryEnumSetting<RdpDesktopSize> RdpDesktopSize { get; private set; }
         public RegistryEnumSetting<RdpAuthenticationLevel> RdpAuthenticationLevel { get; private set; }
         public RegistryEnumSetting<RdpColorDepth> RdpColorDepth { get; private set; }
         public RegistryEnumSetting<RdpAudioMode> RdpAudioMode { get; private set; }
         public RegistryEnumSetting<RdpUserAuthenticationBehavior> RdpUserAuthenticationBehavior { get; private set; }
-        public RegistryEnumSetting<RdpBitmapPersistence> RdpBitmapPersistence { get; private set; }
         public RegistryEnumSetting<RdpNetworkLevelAuthentication> RdpNetworkLevelAuthentication { get; private set; }
         public RegistryDwordSetting RdpConnectionTimeout { get; private set; }
         public RegistryDwordSetting RdpPort { get; private set; }
@@ -480,9 +460,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
             this.RdpPassword,
             this.RdpDomain,
 
-            this.RdpBitmapPersistence,
             this.RdpColorDepth,
-            this.RdpDesktopSize,
             this.RdpConnectionBar,
 
             this.RdpAudioMode,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Diagnostics/DiagnosticsCommands.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Diagnostics/DiagnosticsCommands.cs
@@ -139,7 +139,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Diagnostics
                 WriteTextbox("RdpPort");
                 WriteTextbox("CredentialCallbackUrl");
                 WriteCombobox<RdpConnectionBarState>("ConnectionBar");
-                WriteCombobox<RdpDesktopSize>("DesktopSize");
                 WriteCombobox<RdpColorDepth>("ColorDepth");
                 WriteCombobox<RdpAudioMode>("AudioMode");
                 WriteCombobox<RdpRedirectClipboard>("RedirectClipboard");

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/RdpView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/RdpView.cs
@@ -46,7 +46,7 @@ using System.Windows.Forms;
 namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Rdp
 {
     [Service]
-    public partial class RdpView //TODO: Rename to RdpView
+    public partial class RdpView 
         : SessionViewBase, IRdpSession, IView<RdpViewModel>
     {
         private readonly IExceptionDialog exceptionDialog;


### PR DESCRIPTION
…p size

- Bitmap persistence has been problematic because of excessive memory usage
- Desktop size is obsolete now that full-screen mode doesn't require a reconnect anymore