### PR TITLE
b/314874064 Wait for descendent processes before closing tunnel

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/App/ConnectAppProtocolCommandBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/App/ConnectAppProtocolCommandBase.cs
@@ -84,10 +84,17 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.App
 
                 //
                 // Client app launched successfully. Keep the transport
-                // open until the app is closed, but don't await.
+                // open until the app terminates, but don't await.
                 //
-                _ = process //TODO: Wait on job (if any)
-                    .WaitAsync(TimeSpan.MaxValue, CancellationToken.None)
+                // NB. Some executables launch a child process and terminate
+                // immediately. To deal with such cases, we wait for all
+                // processes in the job to finish.
+                //
+                Task processTerminatedTask = process.Job != null
+                    ? process.Job.WaitForProcessesAsync(TimeSpan.MaxValue, CancellationToken.None)
+                    : process.WaitAsync(TimeSpan.MaxValue, CancellationToken.None);
+
+                _ = processTerminatedTask
                     .ContinueWith(_ =>
                     {
                         transport.Dispose();

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/App/ConnectAppProtocolCommandBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/App/ConnectAppProtocolCommandBase.cs
@@ -86,7 +86,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.App
                 // Client app launched successfully. Keep the transport
                 // open until the app is closed, but don't await.
                 //
-                _ = process
+                _ = process //TODO: Wait on job (if any)
                     .WaitAsync(TimeSpan.MaxValue, CancellationToken.None)
                     .ContinueWith(_ =>
                     {

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ChildProcessFactory.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ChildProcessFactory.cs
@@ -34,6 +34,22 @@ namespace Google.Solutions.Platform.Test.Dispatch
             = $"{Environment.GetFolderPath(Environment.SpecialFolder.System)}\\cmd.exe";
 
         //---------------------------------------------------------------------
+        // Job.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void Job()
+        {
+            using (var factory = new Win32ChildProcessFactory(true))
+            using (var process = factory.CreateProcess(CmdExe, null))
+            {
+                Assert.IsNotNull(process.Job);
+                Assert.IsTrue(process.Job!.Contains(process));
+                Assert.IsTrue(process.Job!.Contains(process.Id));
+            }
+        }
+
+        //---------------------------------------------------------------------
         // Contains.
         //---------------------------------------------------------------------
 

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ChildProcessFactory.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ChildProcessFactory.cs
@@ -49,6 +49,17 @@ namespace Google.Solutions.Platform.Test.Dispatch
             }
         }
 
+        [Test]
+        public void JobsArePerProcess()
+        {
+            using (var factory = new Win32ChildProcessFactory(true))
+            using (var process1 = factory.CreateProcess(CmdExe, null))
+            using (var process2 = factory.CreateProcess(CmdExe, null))
+            {
+                Assert.AreNotSame(process1.Job, process2.Job);
+            }
+        }
+
         //---------------------------------------------------------------------
         // Contains.
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Job.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Job.cs
@@ -155,7 +155,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
             using (var job = new Win32Job(true))
             {
                 await job
-                    .WaitAsync(TimeSpan.MaxValue, CancellationToken.None)
+                    .WaitForProcessesAsync(TimeSpan.MaxValue, CancellationToken.None)
                     .ConfigureAwait(false);
             }
         }
@@ -172,7 +172,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
 
                 ExceptionAssert.ThrowsAggregateException<TimeoutException>(
                     () => job
-                    .WaitAsync(TimeSpan.FromMilliseconds(1), CancellationToken.None)
+                    .WaitForProcessesAsync(TimeSpan.FromMilliseconds(1), CancellationToken.None)
                     .Wait());
             }
         }
@@ -187,7 +187,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
             {
                 job.Add(process);
 
-                var waitTask = job.WaitAsync(TimeSpan.MaxValue, CancellationToken.None);
+                var waitTask = job.WaitForProcessesAsync(TimeSpan.MaxValue, CancellationToken.None);
                 Assert.IsFalse(waitTask.IsCompleted);
 
                 process.Resume();

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ProcessFactory.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ProcessFactory.cs
@@ -36,7 +36,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         {
             public event EventHandler<IWin32Process>? ProcessCreated;
 
-            protected override void OnProcessCreated(IWin32Process process)
+            private protected override void OnProcessCreated(Win32Process process)
             {
                 this.ProcessCreated?.Invoke(this, process);
                 base.OnProcessCreated(process);
@@ -64,6 +64,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
             {
                 Assert.IsNotNull(process.Handle);
                 Assert.IsFalse(process.Handle.IsInvalid);
+                Assert.IsNull(process.Job);
 
                 process.Terminate(1);
             }
@@ -104,6 +105,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
             {
                 Assert.IsNotNull(process.Handle);
                 Assert.IsFalse(process.Handle.IsInvalid);
+                Assert.IsNull(process.Job);
 
                 process.Terminate(1);
             }

--- a/sources/Google.Solutions.Platform/Dispatch/Win32ChildProcessFactory.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32ChildProcessFactory.cs
@@ -29,7 +29,11 @@ using System.Threading.Tasks;
 namespace Google.Solutions.Platform.Dispatch
 {
     /// <summary>
-    /// Factory for Win32 processes that uses jobs to track child processes
+    /// Factory for Win32 processes. For each process, the factory
+    /// creates a separate job and associates the job with the process.
+    /// 
+    /// This allows keeping track of the processes themselves, plus all
+    /// the child processes that they spawn.
     /// </summary>
     public class Win32ChildProcessFactory : Win32ProcessFactory, IWin32ProcessSet, IDisposable
     {
@@ -49,8 +53,11 @@ namespace Google.Solutions.Platform.Dispatch
         //
         // To work around this limitations, we place each process in its
         // own job, and maintain a collection of jobs. This is more complex,
-        // but it ensures that we're compatible with theq quirky
+        // but it ensures that we're compatible with the quirky
         // CreateProcessAsUser behavior and also capture child processes.
+        //
+        // Additionally, this approach lets us track if each "process tree"
+        // separately.
         //
 
         private readonly ConcurrentBag<ChildProcess> children = new ConcurrentBag<ChildProcess>();

--- a/sources/Google.Solutions.Platform/Dispatch/Win32ChildProcessFactory.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32ChildProcessFactory.cs
@@ -51,7 +51,7 @@ namespace Google.Solutions.Platform.Dispatch
         // using CreateProcessAsUser, and try to add it to the same job,
         // then AssignProcessToJob fails with an access-denied error.
         //
-        // To work around this limitations, we place each process in its
+        // To work around this limitation, we place each process in its
         // own job, and maintain a collection of jobs. This is more complex,
         // but it ensures that we're compatible with the quirky
         // CreateProcessAsUser behavior and also capture child processes.

--- a/sources/Google.Solutions.Platform/Dispatch/Win32ChildProcessFactory.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32ChildProcessFactory.cs
@@ -21,6 +21,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -102,12 +103,16 @@ namespace Google.Solutions.Platform.Dispatch
         // Overrides.
         //---------------------------------------------------------------------
 
-        protected override void OnProcessCreated(IWin32Process process)
+        private protected override void OnProcessCreated(Win32Process process)
         {
+            Debug.Assert(process.Job == null);
+
             var job = new Win32Job(this.TerminateOnClose);
             try
             {
                 job.Add(process);
+                process.Job = job;
+
                 this.children.Add(new ChildProcess
                 {
                     Process = process,

--- a/sources/Google.Solutions.Platform/Dispatch/Win32Job.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32Job.cs
@@ -56,7 +56,7 @@ namespace Google.Solutions.Platform.Dispatch
         /// <summary>
         /// Wait for all processes to terminate.
         /// </summary>
-        Task WaitAsync(
+        Task WaitForProcessesAsync(
             TimeSpan timeout,
             CancellationToken cancellationToken);
     }
@@ -230,9 +230,9 @@ namespace Google.Solutions.Platform.Dispatch
             }
         }
 
-        public Task WaitAsync(
+        public Task WaitForProcessesAsync(
             TimeSpan timeout,
-            CancellationToken cancellationToken) // TODO: test
+            CancellationToken cancellationToken)
         {
             if (!this.ProcessIds.Any())
             {

--- a/sources/Google.Solutions.Platform/Dispatch/Win32Job.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32Job.cs
@@ -268,6 +268,7 @@ namespace Google.Solutions.Platform.Dispatch
                 ref associationInfo,
                 (uint)Marshal.SizeOf<NativeMethods.JOBOBJECT_ASSOCIATE_COMPLETION_PORT>()))
             {
+                completionPort.Dispose();
                 throw new Win32Exception(
                     Marshal.GetLastWin32Error(),
                     $"Quering job completion status failed");

--- a/sources/Google.Solutions.Platform/Dispatch/Win32Job.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32Job.cs
@@ -27,6 +27,9 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Linq;
 
 namespace Google.Solutions.Platform.Dispatch
 {
@@ -49,6 +52,13 @@ namespace Google.Solutions.Platform.Dispatch
         /// Return the IDs of processes in this job.
         /// </summary>
         IEnumerable<uint> ProcessIds { get; }
+
+        /// <summary>
+        /// Wait for all processes to terminate.
+        /// </summary>
+        Task WaitAsync(
+            TimeSpan timeout,
+            CancellationToken cancellationToken);
     }
 
     public class Win32Job : DisposableBase, IWin32Job
@@ -220,6 +230,91 @@ namespace Google.Solutions.Platform.Dispatch
             }
         }
 
+        public Task WaitAsync(
+            TimeSpan timeout,
+            CancellationToken cancellationToken) // TODO: test
+        {
+            //
+            // NB. Job objects aren't signaled when all processes
+            // have exited. We have to listen for a completion port
+            // notification instead.
+            //
+            if (!this.ProcessIds.Any())
+            {
+                return Task.CompletedTask;
+            }
+
+            //
+            // There's no great way to await a completion port notification,
+            // so we have to sacrifice a thread for it.
+            //
+            return Task.Factory.StartNew(() =>
+            {
+                using (var completionPort = NativeMethods.CreateIoCompletionPort(
+                    NativeMethods.INVALID_HANDLE_VALUE,
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    1))
+                {
+                    var associationInfo = new NativeMethods.JOBOBJECT_ASSOCIATE_COMPLETION_PORT()
+                    {
+                        CompletionKey = this.handle,
+                        CompletionPort = completionPort
+                    };
+
+                    if (!NativeMethods.SetInformationJobObject(
+                        this.handle,
+                        NativeMethods.JOBOBJECTINFOCLASS.JobObjectAssociateCompletionPortInformation,
+                        ref associationInfo,
+                        (uint)Marshal.SizeOf<NativeMethods.JOBOBJECT_ASSOCIATE_COMPLETION_PORT>()))
+                    {
+                        throw new Win32Exception(
+                            Marshal.GetLastWin32Error(),
+                            $"Quering job completion status failed");
+                    }
+
+                    while (NativeMethods.GetQueuedCompletionStatus(
+                        completionPort,
+                        out var completionCode,
+                        out var completionKey,
+                        out var overlapped,
+                        (uint)timeout.TotalSeconds))
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            throw new TaskCanceledException();
+                        }
+                        else if (completionCode == NativeMethods.JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO)
+                        {
+                            //
+                            // Active process count has dropped to 0.
+                            //
+                            return;
+                        }
+                        else
+                        {
+                            //
+                            // Keep going.
+                            //
+                        }
+                    }
+
+                    var lastError = Marshal.GetLastWin32Error();
+                    if (lastError == NativeMethods.WAIT_TIMEOUT)
+                    {
+                        throw new TimeoutException();
+                    }
+                    else
+                    {
+                        throw new Win32Exception(
+                            lastError,
+                            $"Quering job completion status failed");
+                    }
+                }
+            },
+            TaskCreationOptions.LongRunning);
+        }
+
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);
@@ -233,10 +328,14 @@ namespace Google.Solutions.Platform.Dispatch
 
         private static class NativeMethods
         {
+            internal static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
+
             internal const uint PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
             internal const uint SYNCHRONIZE = 0x00100000;
 
             internal const int ERROR_NO_TOKEN = 1008;
+            internal const int WAIT_TIMEOUT = 0x102;
+            internal const uint JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO = 4;
 
             [StructLayout(LayoutKind.Sequential)]
             internal struct SECURITY_ATTRIBUTES
@@ -258,6 +357,13 @@ namespace Google.Solutions.Platform.Dispatch
                 ref JOBOBJECT_EXTENDED_LIMIT_INFORMATION lpJobObjectInfo,
                 uint cbJobObjectInfoLength);
 
+            [DllImport("kernel32.dll")]
+            internal static extern bool SetInformationJobObject(
+                SafeJobHandle hJob,
+                JOBOBJECTINFOCLASS infoClass,
+                ref JOBOBJECT_ASSOCIATE_COMPLETION_PORT lpJobObjectInfo,
+                uint cbJobObjectInfoLength);
+
             [DllImport("kernel32.dll", SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
             internal static extern bool AssignProcessToJobObject(
@@ -271,28 +377,44 @@ namespace Google.Solutions.Platform.Dispatch
                 SafeJobHandle job, out bool result);
 
             [DllImport("kernel32.dll", SetLastError = true)]
-            public static extern SafeProcessHandle OpenProcess(
+            internal static extern SafeProcessHandle OpenProcess(
                 uint processAccess,
                 bool bInheritHandle,
                 uint processId);
 
             [DllImport("kernel32.dll", SetLastError = true)]
             [return: MarshalAs(UnmanagedType.Bool)]
-            public static extern bool QueryInformationJobObject(
+            internal static extern bool QueryInformationJobObject(
                 SafeJobHandle hJob,
                 JOBOBJECTINFOCLASS infoClass,
                 IntPtr lpJobObjectInfo,
                 uint cbJobObjectInfoLength,
                 out uint lpReturnLength);
 
+            [DllImport("kernel32.dll", SetLastError = true)]
+            internal static extern SafeCompletionPortHandle CreateIoCompletionPort(
+                IntPtr fileHandle,
+                IntPtr existingCompletionPort, 
+                IntPtr completionKey, 
+                int numberOfConcurrentThreads);
+
+            [DllImport("Kernel32.dll", SetLastError = true)]
+            internal static extern bool GetQueuedCompletionStatus(
+                SafeCompletionPortHandle completionPort, 
+                out int lpNumberOfBytesTransferred, 
+                out IntPtr lpCompletionKey, 
+                out IntPtr lpOverlapped, 
+                uint dwMilliseconds);
+
             internal enum JOB_OBJECT_LIMIT
             {
                 KILL_ON_JOB_CLOSE = 0x00002000
             }
 
-            public enum JOBOBJECTINFOCLASS
+            internal enum JOBOBJECTINFOCLASS
             {
                 JobObjectBasicProcessIdList = 3,
+                JobObjectAssociateCompletionPortInformation = 7,
                 JobObjectExtendedLimitInformation = 9
             }
 
@@ -339,6 +461,13 @@ namespace Google.Solutions.Platform.Dispatch
                 public uint NumberOfProcessIdsInList;
                 public UIntPtr ProcessIdListStart;
             }
+
+            [StructLayout(LayoutKind.Sequential)]
+            internal struct JOBOBJECT_ASSOCIATE_COMPLETION_PORT
+            {
+                public SafeJobHandle CompletionKey;
+                public SafeCompletionPortHandle CompletionPort;
+            }
         }
 
         private class SafeJobHandle : SafeWin32Handle
@@ -349,6 +478,19 @@ namespace Google.Solutions.Platform.Dispatch
             }
 
             public SafeJobHandle(IntPtr handle, bool ownsHandle)
+                : base(handle, ownsHandle)
+            {
+            }
+        }
+
+        private class SafeCompletionPortHandle : SafeWin32Handle
+        {
+            public SafeCompletionPortHandle()
+                : base(true)
+            {
+            }
+
+            public SafeCompletionPortHandle(IntPtr handle, bool ownsHandle)
                 : base(handle, ownsHandle)
             {
             }

--- a/sources/Google.Solutions.Platform/Dispatch/Win32Process.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32Process.cs
@@ -75,9 +75,8 @@ namespace Google.Solutions.Platform.Dispatch
 
         /// <summary>
         /// Wait for process to terminate.
-        /// 
-        /// Returns the exit code.
         /// </summary>
+        /// <returns>the exit code.</returns>
         Task<uint> WaitAsync(
             TimeSpan timeout,
             CancellationToken cancellationToken);

--- a/sources/Google.Solutions.Platform/Dispatch/Win32Process.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32Process.cs
@@ -59,6 +59,11 @@ namespace Google.Solutions.Platform.Dispatch
         SafeProcessHandle Handle { get; }
 
         /// <summary>
+        /// Get job this process is associated with, if any.
+        /// </summary>
+        IWin32Job? Job { get; }
+
+        /// <summary>
         /// Resume the process.
         /// </summary>
         void Resume();
@@ -180,6 +185,8 @@ namespace Google.Solutions.Platform.Dispatch
         public WaitHandle WaitHandle => this.process.ToWaitHandle(false);
 
         public uint Id => this.processId;
+
+        public IWin32Job? Job { get; internal set; }
 
         public IWtsSession Session => WtsSession.FromProcessId(this.processId);
 

--- a/sources/Google.Solutions.Platform/Dispatch/Win32ProcessFactory.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32ProcessFactory.cs
@@ -77,10 +77,10 @@ namespace Google.Solutions.Platform.Dispatch
         /// Allow deriving classes to do something with the process
         /// before the factory returns it.
         /// </summary>
-        protected virtual void OnProcessCreated(IWin32Process process)
+        private protected virtual void OnProcessCreated(Win32Process process)
         { }
 
-        private void InvokeOnProcessCreated(IWin32Process process)
+        private void InvokeOnProcessCreated(Win32Process process)
         {
             try
             {


### PR DESCRIPTION
When launching a client app, wait for all its child processes to terminate before tearing down the tunnel.