### PR TITLE
b/322255942 Disable, but don't hide commands if context is null

### DIFF
--- a/sources/Google.Solutions.Mvvm/Binding/Commands/CommandContainer.cs
+++ b/sources/Google.Solutions.Mvvm/Binding/Commands/CommandContainer.cs
@@ -324,7 +324,13 @@ namespace Google.Solutions.Mvvm.Binding.Commands
                 var context = this.container.ContextSource.Context;
                 if (context == null)
                 {
-                    this.IsVisible = false;
+                    //
+                    // Assume all commands are unavailable. Hiding
+                    // all menu items looks awkward though, so disable
+                    // them.
+                    //
+                    this.IsVisible = true;
+                    this.IsEnabled = false;
                     return;
                 }
 


### PR DESCRIPTION
When the context is null, we have to assume that all commands are unavailable. Hiding all menu items looks awkward though, so disable them.