### PR TITLE
b/325757513 Ignore double-clicks when no file selected

### DIFF
--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -288,7 +288,8 @@ namespace Google.Solutions.Mvvm.Controls
                 throw new InvalidOperationException("Control is not bound");
             }
 
-            if (this.fileList.SelectedModelItem.Type.IsFile)
+            if (this.fileList.SelectedModelItem == null ||
+                this.fileList.SelectedModelItem.Type.IsFile)
             {
                 return;
             }


### PR DESCRIPTION
This fixes a spuriuous source of NullReferenceExceptions.