### PR TITLE
b/325545018 Re-enable tests affected by b/325544415

### DIFF
--- a/sources/Google.Solutions.Apis.Test/Compute/TestOsLoginClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Compute/TestOsLoginClient.cs
@@ -295,7 +295,6 @@ namespace Google.Solutions.Apis.Test.Compute
         //---------------------------------------------------------------------
 
         [Test]
-        [Ignore("b/325544415")]
         public async Task WhenUsingGaiaSession_ThenSignPublicKeyThrowsException(
             [Credential(Role = PredefinedRole.ComputeViewer)]
             ResourceTask<IAuthorization> authorizationTask)
@@ -334,7 +333,6 @@ namespace Google.Solutions.Apis.Test.Compute
         }
 
         [Test]
-        [Ignore("b/325544415")]
         public async Task WhenUsingWorkforceSessionAndUserInRole_ThenSignPublicKeySucceeds(
             [Credential(Type = PrincipalType.WorkforceIdentity, Role = PredefinedRole.ServiceUsageConsumer)]
             ResourceTask<IAuthorization> authorizationTask)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestPlatformCredentialAuthentication.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestPlatformCredentialAuthentication.cs
@@ -246,7 +246,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
         }
 
         [Test]
-        [Ignore("b/325544415")]
         public async Task WhenUsingWorkforceSessionAndInRole_ThenAuthenticationWithOsLoginSucceeds(
             [Values(SshKeyType.Rsa3072, SshKeyType.EcdsaNistp256)] SshKeyType keyType,
             [LinuxInstance(EnableOsLogin = true)] ResourceTask<InstanceLocator> instance,


### PR DESCRIPTION
Update tests to reflect latest API changes:

* Re-enable WFIF/OSLogin tests
* Change test to expect SignSshPublicKey to succeed when using Gaia credentials