### PR TITLE
b/330223655 Turn IAnySetting into internal interface

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/ToolWindows/Properties/SettingsCollectionTypeDescriptor.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ToolWindows/Properties/SettingsCollectionTypeDescriptor.cs
@@ -22,6 +22,7 @@
 using Google.Solutions.Common.Security;
 using Google.Solutions.Settings;
 using Google.Solutions.Settings.Collection;
+using Google.Solutions.Settings.ComponentModel;
 using System;
 using System.ComponentModel;
 using System.Linq;
@@ -55,7 +56,7 @@ namespace Google.Solutions.IapDesktop.Application.ToolWindows.Properties
                     {
                         if (s is ISetting<SecureString> secureStringSetting)
                         {
-                            return new SecureStringSettingDescriptor(secureStringSetting);
+                            return new MaskedSettingDescriptor(secureStringSetting);
                         }
                         else
                         {
@@ -66,95 +67,8 @@ namespace Google.Solutions.IapDesktop.Application.ToolWindows.Properties
         }
 
         public override PropertyDescriptorCollection GetProperties(Attribute[] attributes)
-            => GetProperties();
-
-        private class SettingDescriptor : PropertyDescriptor
         {
-            private readonly IAnySetting setting;
-
-            public SettingDescriptor(IAnySetting setting)
-                : base(setting.Key, null)
-            {
-                this.setting = setting;
-            }
-
-            public override string Name => this.setting.Key;
-            public override string DisplayName => this.setting.DisplayName;
-            public override string Description => this.setting.Description;
-            public override string Category => this.setting.Category;
-            public override bool IsBrowsable => true;
-
-            public override Type ComponentType => null;
-
-            public override bool IsReadOnly => false;
-
-            public override Type PropertyType => this.setting.ValueType;
-
-            public override bool CanResetValue(object component)
-            {
-                return true;
-            }
-
-            public override object GetValue(object component)
-            {
-                return this.setting.AnyValue;
-            }
-
-            public override void ResetValue(object component)
-            {
-                this.setting.Reset();
-            }
-
-            public override void SetValue(object component, object value)
-            {
-                this.setting.AnyValue = value;
-            }
-
-            public override bool ShouldSerializeValue(object component)
-            {
-                return !this.setting.IsDefault;
-            }
-        }
-
-        private class SecureStringSettingDescriptor : SettingDescriptor
-        {
-            private readonly ISetting<SecureString> setting;
-
-            public SecureStringSettingDescriptor(ISetting<SecureString> setting)
-                : base(setting)
-            {
-                this.setting = setting;
-            }
-
-            public override Type PropertyType => typeof(string);
-
-            // Mask value as password.
-            public override AttributeCollection Attributes
-                => new AttributeCollection(new PasswordPropertyTextAttribute(true));
-
-            public override object GetValue(object component)
-            {
-                return this.setting.IsDefault
-                    ? null
-                    : "********";
-            }
-
-            public override void SetValue(object component, object value)
-            {
-                //
-                // NB. Avoid converting null to a SecureString as this results
-                // in an empty string - which would then be treated as non-default.
-                //
-
-                if (value == null)
-                {
-                    ResetValue(component);
-                }
-                else
-                {
-                    this.setting.Value = SecureStringExtensions.FromClearText((string)value);
-                }
-            }
+            return GetProperties();
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Application/ToolWindows/Properties/SettingsCollectionTypeDescriptor.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ToolWindows/Properties/SettingsCollectionTypeDescriptor.cs
@@ -60,7 +60,7 @@ namespace Google.Solutions.IapDesktop.Application.ToolWindows.Properties
                         }
                         else
                         {
-                            return new SettingDescriptor((IAnySetting)s);
+                            return new SettingDescriptor(s);
                         }
                     })
                     .ToArray());

--- a/sources/Google.Solutions.Settings.Test/ComponentModel/TestMaskedSettingDescriptor.cs
+++ b/sources/Google.Solutions.Settings.Test/ComponentModel/TestMaskedSettingDescriptor.cs
@@ -1,0 +1,74 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Settings.ComponentModel;
+using NUnit.Framework;
+using System.Net.Sockets;
+using System.Security;
+
+namespace Google.Solutions.Settings.Test.ComponentModel
+{
+    [TestFixture]
+    public class TestMaskedSettingDescriptor
+    {
+        [Test]
+        public void GetValueReturnsMaskedString()
+        {
+            var setting = DictionarySettingsStore
+                .Empty()
+                .Read<SecureString>("key", "display name", "description", "category", null);
+            setting.SetClearTextValue("secret");
+
+            var descriptor = new MaskedSettingDescriptor(setting);
+
+            Assert.AreEqual("********", descriptor.GetValue(setting));
+        }
+
+        [Test]
+        public void SetValue()
+        {
+            var setting = DictionarySettingsStore
+                .Empty()
+                .Read<SecureString>("key", "display name", "description", "category", null);
+
+            var descriptor = new MaskedSettingDescriptor(setting);
+            descriptor.SetValue(setting, "secret");
+
+            Assert.AreEqual("secret", setting.GetClearTextValue());
+        }
+
+        [Test]
+        public void ResetValue()
+        {
+            var setting = DictionarySettingsStore
+                .Empty()
+                .Read<SecureString>("key", "display name", "description", "category", null);
+            setting.SetClearTextValue("secret");
+
+            Assert.IsFalse(setting.IsDefault);
+
+            var descriptor = new MaskedSettingDescriptor(setting);
+            descriptor.SetValue(setting, null);
+
+            Assert.IsTrue(setting.IsDefault);
+        }
+    }
+}

--- a/sources/Google.Solutions.Settings.Test/ComponentModel/TestMaskedSettingDescriptor.cs
+++ b/sources/Google.Solutions.Settings.Test/ComponentModel/TestMaskedSettingDescriptor.cs
@@ -21,7 +21,6 @@
 
 using Google.Solutions.Settings.ComponentModel;
 using NUnit.Framework;
-using System.Net.Sockets;
 using System.Security;
 
 namespace Google.Solutions.Settings.Test.ComponentModel

--- a/sources/Google.Solutions.Settings.Test/ComponentModel/TestSettingDescriptor.cs
+++ b/sources/Google.Solutions.Settings.Test/ComponentModel/TestSettingDescriptor.cs
@@ -1,0 +1,99 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Settings.ComponentModel;
+using NUnit.Framework;
+
+namespace Google.Solutions.Settings.Test.ComponentModel
+{
+    [TestFixture]
+    public class TestSettingDescriptor
+    {
+        [Test]
+        public void BrowsableSetting()
+        {
+            var setting = DictionarySettingsStore
+                .Empty()
+                .Read<string>("key", "display name", "description", "category", "default");
+
+            var descriptor = new SettingDescriptor<string>(setting);
+
+            Assert.AreEqual("key", descriptor.Name);
+            Assert.AreEqual("display name", descriptor.DisplayName);
+            Assert.AreEqual("description", descriptor.Description);
+            Assert.AreEqual("category", descriptor.Category);
+
+            Assert.IsTrue(descriptor.IsBrowsable);
+            Assert.IsFalse(descriptor.IsReadOnly);
+
+            Assert.AreEqual(typeof(ISetting<string>), descriptor.ComponentType);
+            Assert.AreEqual(typeof(string), descriptor.PropertyType);
+        }
+
+        [Test]
+        public void NonBrowsableSetting()
+        {
+            var setting = DictionarySettingsStore
+                .Empty()
+                .Read<string>("key", null, null, null, "default");
+
+            var descriptor = new SettingDescriptor<string>(setting);
+
+            Assert.AreEqual("key", descriptor.Name);
+            Assert.IsNull(descriptor.DisplayName);
+            Assert.IsNull(descriptor.Description);
+            Assert.IsNull(descriptor.Category);
+
+            Assert.IsFalse(descriptor.IsBrowsable);
+        }
+
+        [Test]
+        public void ModifyValue()
+        {
+            var setting = DictionarySettingsStore
+                .Empty()
+                .Read<string>("key", "display name", "description", "category", "default");
+
+
+            var descriptor = new SettingDescriptor<string>(setting);
+            
+            //
+            // Set value.
+            //
+            descriptor.SetValue(setting, "value-1");
+            Assert.AreEqual("value-1", setting.Value);
+            Assert.IsTrue(descriptor.ShouldSerializeValue(setting));
+
+            //
+            // Get value.
+            //
+            Assert.AreEqual("value-1", descriptor.GetValue(setting));
+
+            //
+            // Reset.
+            //
+            Assert.IsTrue(descriptor.CanResetValue(setting));
+            descriptor.ResetValue(setting);
+            Assert.IsTrue(setting.IsDefault);
+            Assert.IsFalse(descriptor.ShouldSerializeValue(setting));
+        }
+    }
+}

--- a/sources/Google.Solutions.Settings.Test/ComponentModel/TestSettingDescriptor.cs
+++ b/sources/Google.Solutions.Settings.Test/ComponentModel/TestSettingDescriptor.cs
@@ -34,7 +34,7 @@ namespace Google.Solutions.Settings.Test.ComponentModel
                 .Empty()
                 .Read<string>("key", "display name", "description", "category", "default");
 
-            var descriptor = new SettingDescriptor<string>(setting);
+            var descriptor = new SettingDescriptor(setting);
 
             Assert.AreEqual("key", descriptor.Name);
             Assert.AreEqual("display name", descriptor.DisplayName);
@@ -44,7 +44,7 @@ namespace Google.Solutions.Settings.Test.ComponentModel
             Assert.IsTrue(descriptor.IsBrowsable);
             Assert.IsFalse(descriptor.IsReadOnly);
 
-            Assert.AreEqual(typeof(ISetting<string>), descriptor.ComponentType);
+            Assert.AreEqual(typeof(ISetting), descriptor.ComponentType);
             Assert.AreEqual(typeof(string), descriptor.PropertyType);
         }
 
@@ -55,7 +55,7 @@ namespace Google.Solutions.Settings.Test.ComponentModel
                 .Empty()
                 .Read<string>("key", null, null, null, "default");
 
-            var descriptor = new SettingDescriptor<string>(setting);
+            var descriptor = new SettingDescriptor(setting);
 
             Assert.AreEqual("key", descriptor.Name);
             Assert.IsNull(descriptor.DisplayName);
@@ -73,7 +73,7 @@ namespace Google.Solutions.Settings.Test.ComponentModel
                 .Read<string>("key", "display name", "description", "category", "default");
 
 
-            var descriptor = new SettingDescriptor<string>(setting);
+            var descriptor = new SettingDescriptor(setting);
             
             //
             // Set value.

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfBool.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfBool.cs
@@ -193,7 +193,7 @@ namespace Google.Solutions.Settings.Test
 
                 key.BackingKey.DeleteValue("test");
 
-                setting.AnyValue = null;
+                ((IAnySetting)setting).AnyValue = null;
                 key.Write(setting);
 
                 Assert.IsNull(key.BackingKey.GetValue("test"));
@@ -261,7 +261,7 @@ namespace Google.Solutions.Settings.Test
                     false);
 
                 setting.Value = true;
-                setting.AnyValue = null;
+                ((IAnySetting)setting).AnyValue = null;
 
                 Assert.AreEqual(false, setting.Value);
                 Assert.IsTrue(setting.IsDefault);
@@ -273,7 +273,7 @@ namespace Google.Solutions.Settings.Test
         {
             using (var key = CreateSettingsKey())
             {
-                var setting = key.Read(
+                var setting = (IAnySetting)key.Read(
                     "test",
                     "title",
                     "description",

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfEnum.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfEnum.cs
@@ -288,7 +288,7 @@ namespace Google.Solutions.Settings.Test
                     ConsoleColor.Blue);
 
                 setting.Value = ConsoleColor.Blue;
-                setting.AnyValue = null;
+                ((IAnySetting)setting).AnyValue = null;
 
                 Assert.AreEqual(ConsoleColor.Blue, setting.Value);
                 Assert.IsTrue(setting.IsDefault);
@@ -300,7 +300,7 @@ namespace Google.Solutions.Settings.Test
         {
             using (var key = CreateSettingsKey())
             {
-                var setting = key.Read(
+                var setting = (IAnySetting)key.Read(
                     "test",
                     "title",
                     "description",

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfEnumFlags.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfEnumFlags.cs
@@ -268,7 +268,7 @@ namespace Google.Solutions.Settings.Test
                     Toppings.None);
 
                 setting.Value = Toppings.None;
-                setting.AnyValue = null;
+                ((IAnySetting)setting).AnyValue = null;
 
                 Assert.AreEqual(Toppings.None, setting.Value);
                 Assert.IsTrue(setting.IsDefault);
@@ -280,7 +280,7 @@ namespace Google.Solutions.Settings.Test
         {
             using (var key = CreateSettingsKey())
             {
-                var setting = key.Read(
+                var setting = (IAnySetting)key.Read(
                     "test",
                     "title",
                     "description",

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfInt.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfInt.cs
@@ -311,7 +311,7 @@ namespace Google.Solutions.Settings.Test
                     Predicate.InRange(0, 100));
 
                 setting.Value = 1;
-                setting.AnyValue = null;
+                ((IAnySetting)setting).AnyValue = null;
 
                 Assert.AreEqual(17, setting.Value);
                 Assert.IsTrue(setting.IsDefault);
@@ -323,7 +323,7 @@ namespace Google.Solutions.Settings.Test
         {
             using (var key = CreateSettingsKey())
             {
-                var setting = key.Read(
+                var setting = (IAnySetting)key.Read(
                     "test",
                     "title",
                     "description",

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfLong.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfLong.cs
@@ -286,7 +286,7 @@ namespace Google.Solutions.Settings.Test
                     Predicate.InRange(0L, 100L));
 
                 setting.Value = 1L;
-                setting.AnyValue = null;
+                ((IAnySetting)setting).AnyValue = null;
 
                 Assert.AreEqual(17L, setting.Value);
                 Assert.IsTrue(setting.IsDefault);
@@ -298,7 +298,7 @@ namespace Google.Solutions.Settings.Test
         {
             using (var key = CreateSettingsKey())
             {
-                var setting = key.Read(
+                var setting = (IAnySetting)key.Read(
                     "test",
                     "title",
                     "description",

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfSecureString.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfSecureString.cs
@@ -300,7 +300,7 @@ namespace Google.Solutions.Settings.Test
         {
             using (var key = CreateSettingsKey())
             {
-                var setting = key.Read<SecureString>(
+                var setting = (IAnySetting)key.Read<SecureString>(
                     "test",
                     "title",
                     "description",

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfString.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfString.cs
@@ -242,7 +242,7 @@ namespace Google.Solutions.Settings.Test
                     _ => true);
 
                 setting.Value = "red";
-                setting.AnyValue = null;
+                ((IAnySetting)setting).AnyValue = null;
 
                 Assert.AreEqual("blue", setting.Value);
                 Assert.IsTrue(setting.IsDefault);
@@ -254,7 +254,7 @@ namespace Google.Solutions.Settings.Test
         {
             using (var key = CreateSettingsKey())
             {
-                var setting = key.Read(
+                var setting = (IAnySetting)key.Read(
                     "test",
                     "title",
                     "description",

--- a/sources/Google.Solutions.Settings/ComponentModel/MaskedSettingDescriptor.cs
+++ b/sources/Google.Solutions.Settings/ComponentModel/MaskedSettingDescriptor.cs
@@ -20,6 +20,7 @@
 //
 
 using Google.Solutions.Common.Security;
+using Google.Solutions.Common.Util;
 using System;
 using System.ComponentModel;
 using System.Security;
@@ -30,11 +31,14 @@ namespace Google.Solutions.Settings.ComponentModel
     /// Exposes a SecureString-typed setting as a masked
     /// property in the .NET component model.
     /// </summary>
-    public class MaskedSettingDescriptor : SettingDescriptor<SecureString>
+    public class MaskedSettingDescriptor : SettingDescriptor
     {
+        private readonly ISetting<SecureString> setting;
+
         public MaskedSettingDescriptor(ISetting<SecureString> setting)
             : base(setting)
         {
+            this.setting = setting.ExpectNotNull(nameof(setting));
         }
 
         public override Type PropertyType
@@ -52,7 +56,7 @@ namespace Google.Solutions.Settings.ComponentModel
 
         public override object GetValue(object component)
         {
-            return this.Setting.IsDefault
+            return this.setting.IsDefault
                 ? null
                 : "********";
         }
@@ -70,7 +74,7 @@ namespace Google.Solutions.Settings.ComponentModel
             }
             else
             {
-                this.Setting.Value = SecureStringExtensions.FromClearText((string)value);
+                this.setting.Value = SecureStringExtensions.FromClearText((string)value);
             }
         }
     }

--- a/sources/Google.Solutions.Settings/ComponentModel/MaskedSettingDescriptor.cs
+++ b/sources/Google.Solutions.Settings/ComponentModel/MaskedSettingDescriptor.cs
@@ -1,0 +1,77 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Security;
+using System;
+using System.ComponentModel;
+using System.Security;
+
+namespace Google.Solutions.Settings.ComponentModel
+{
+    /// <summary>
+    /// Exposes a SecureString-typed setting as a masked
+    /// property in the .NET component model.
+    /// </summary>
+    public class MaskedSettingDescriptor : SettingDescriptor<SecureString>
+    {
+        public MaskedSettingDescriptor(ISetting<SecureString> setting)
+            : base(setting)
+        {
+        }
+
+        public override Type PropertyType
+        {
+            get => typeof(string);
+        }
+
+        public override AttributeCollection Attributes
+        {
+            //
+            // Mask value as password.
+            //
+            get => new AttributeCollection(new PasswordPropertyTextAttribute(true));
+        }
+
+        public override object GetValue(object component)
+        {
+            return this.Setting.IsDefault
+                ? null
+                : "********";
+        }
+
+        public override void SetValue(object component, object value)
+        {
+            //
+            // NB. Avoid converting null to a SecureString as this results
+            // in an empty string - which would then be treated as non-default.
+            //
+
+            if (value == null)
+            {
+                ResetValue(component);
+            }
+            else
+            {
+                this.Setting.Value = SecureStringExtensions.FromClearText((string)value);
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.Settings/ComponentModel/SettingDescriptor.cs
+++ b/sources/Google.Solutions.Settings/ComponentModel/SettingDescriptor.cs
@@ -32,14 +32,14 @@ namespace Google.Solutions.Settings.ComponentModel
     /// This class can be used to expose one or more settings in a
     /// PropertyGrid.
     /// </summary>
-    public class SettingDescriptor<T> : PropertyDescriptor
+    public class SettingDescriptor : PropertyDescriptor
     {
-        protected ISetting<T> Setting { get; }
+        private readonly IAnySetting setting;
 
-        public SettingDescriptor(ISetting<T> setting)
+        public SettingDescriptor(ISetting setting)
             : base(setting.Key, null)
         {
-            this.Setting = setting.ExpectNotNull(nameof(setting));
+            this.setting = (IAnySetting)setting.ExpectNotNull(nameof(setting));
         }
 
         //---------------------------------------------------------------------
@@ -51,7 +51,7 @@ namespace Google.Solutions.Settings.ComponentModel
         /// </summary>
         public override string Name
         {
-            get => this.Setting.Key;
+            get => this.setting.Key;
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Google.Solutions.Settings.ComponentModel
         /// </summary>
         public override string DisplayName
         {
-            get => this.Setting.DisplayName;
+            get => this.setting.DisplayName;
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Google.Solutions.Settings.ComponentModel
         /// </summary>
         public override string Description
         {
-            get => this.Setting.Description;
+            get => this.setting.Description;
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace Google.Solutions.Settings.ComponentModel
         /// </summary>
         public override string Category
         {
-            get => this.Setting.Category;
+            get => this.setting.Category;
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace Google.Solutions.Settings.ComponentModel
         /// </summary>
         public override bool IsBrowsable
         {
-            get => this.Setting.DisplayName != null;
+            get => this.setting.DisplayName != null;
         }
 
         /// <summary>
@@ -91,7 +91,7 @@ namespace Google.Solutions.Settings.ComponentModel
         /// </summary>
         public override Type ComponentType
         {
-            get => typeof(ISetting<T>);
+            get => typeof(ISetting);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Google.Solutions.Settings.ComponentModel
         /// </summary>
         public override bool IsReadOnly
         {
-            get => this.Setting.IsReadOnly;
+            get => this.setting.IsReadOnly;
         }
 
         /// <summary>
@@ -107,37 +107,33 @@ namespace Google.Solutions.Settings.ComponentModel
         /// </summary>
         public override Type PropertyType
         {
-            get => this.Setting.ValueType;
+            get => this.setting.ValueType;
         }
 
         public override bool CanResetValue(object component)
         {
-            Debug.Assert(component == this.Setting);
+            Debug.Assert(component == this.setting);
             return true;
         }
 
         public override object GetValue(object component)
         {
-            Debug.Assert(component == this.Setting);
-            return this.Setting.AnyValue;
+            return this.setting.AnyValue;
         }
 
         public override void ResetValue(object component)
         {
-            Debug.Assert(component == this.Setting);
-            this.Setting.Reset();
+            this.setting.Reset();
         }
 
         public override void SetValue(object component, object value)
         {
-            Debug.Assert(component == this.Setting);
-            this.Setting.AnyValue = value;
+            this.setting.AnyValue = value;
         }
 
         public override bool ShouldSerializeValue(object component)
         {
-            Debug.Assert(component == this.Setting);
-            return !this.Setting.IsDefault;
+            return !this.setting.IsDefault;
         }
     }
 }

--- a/sources/Google.Solutions.Settings/ComponentModel/SettingDescriptor.cs
+++ b/sources/Google.Solutions.Settings/ComponentModel/SettingDescriptor.cs
@@ -1,0 +1,143 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Util;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace Google.Solutions.Settings.ComponentModel
+{
+    /// <summary>
+    /// Exposes a setting as a property in the .NET component model.
+    /// 
+    /// This class can be used to expose one or more settings in a
+    /// PropertyGrid.
+    /// </summary>
+    public class SettingDescriptor<T> : PropertyDescriptor
+    {
+        protected ISetting<T> Setting { get; }
+
+        public SettingDescriptor(ISetting<T> setting)
+            : base(setting.Key, null)
+        {
+            this.Setting = setting.ExpectNotNull(nameof(setting));
+        }
+
+        //---------------------------------------------------------------------
+        // Overrides.
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// Name (or key) of the setting, used for persistence.
+        /// </summary>
+        public override string Name
+        {
+            get => this.Setting.Key;
+        }
+
+        /// <summary>
+        /// Human-readable name of the setting.
+        /// </summary>
+        public override string DisplayName
+        {
+            get => this.Setting.DisplayName;
+        }
+
+        /// <summary>
+        /// Description, optional.
+        /// </summary>
+        public override string Description
+        {
+            get => this.Setting.Description;
+        }
+
+        /// <summary>
+        /// Category, optional.
+        /// </summary>
+        public override string Category
+        {
+            get => this.Setting.Category;
+        }
+
+        /// <summary>
+        /// Check if this setting should be displayed in a UI.
+        /// </summary>
+        public override bool IsBrowsable
+        {
+            get => this.Setting.DisplayName != null;
+        }
+
+        /// <summary>
+        /// Type of the component this property is bound to.
+        /// </summary>
+        public override Type ComponentType
+        {
+            get => typeof(ISetting<T>);
+        }
+
+        /// <summary>
+        /// Check whether this setting is read-only.
+        /// </summary>
+        public override bool IsReadOnly
+        {
+            get => this.Setting.IsReadOnly;
+        }
+
+        /// <summary>
+        /// Type of the property.
+        /// </summary>
+        public override Type PropertyType
+        {
+            get => this.Setting.ValueType;
+        }
+
+        public override bool CanResetValue(object component)
+        {
+            Debug.Assert(component == this.Setting);
+            return true;
+        }
+
+        public override object GetValue(object component)
+        {
+            Debug.Assert(component == this.Setting);
+            return this.Setting.AnyValue;
+        }
+
+        public override void ResetValue(object component)
+        {
+            Debug.Assert(component == this.Setting);
+            this.Setting.Reset();
+        }
+
+        public override void SetValue(object component, object value)
+        {
+            Debug.Assert(component == this.Setting);
+            this.Setting.AnyValue = value;
+        }
+
+        public override bool ShouldSerializeValue(object component)
+        {
+            Debug.Assert(component == this.Setting);
+            return !this.Setting.IsDefault;
+        }
+    }
+}

--- a/sources/Google.Solutions.Settings/ISetting.cs
+++ b/sources/Google.Solutions.Settings/ISetting.cs
@@ -79,20 +79,10 @@ namespace Google.Solutions.Settings
         bool IsReadOnly { get; }
     }
 
-    public interface IAnySetting : ISetting // TODO: make internal
-    {
-        /// <summary>
-        /// Assign value, converting data types if necessary.
-        /// </summary>
-        object AnyValue { get; set; }
-
-        /// <summary>
-        /// Returns the type of setting.
-        /// </summary>
-        Type ValueType { get; }
-    }
-
-    public interface ISetting<T> : ISetting, IAnySetting
+    /// <summary>
+    /// Typed setting.
+    /// </summary>
+    public interface ISetting<T> : ISetting
     {
         /// <summary>
         /// Return current value of setting.
@@ -103,6 +93,23 @@ namespace Google.Solutions.Settings
         /// Returns the default value, which might be inherited.
         /// </summary>
         T DefaultValue { get; }
+    }
+
+    /// <summary>
+    /// Internal helper interface that allows automatic
+    /// data type conversion.
+    /// </summary>
+    internal interface IAnySetting : ISetting
+    {
+        /// <summary>
+        /// Assign value, converting data types if necessary.
+        /// </summary>
+        object AnyValue { get; set; }
+
+        /// <summary>
+        /// Returns the type of setting.
+        /// </summary>
+        Type ValueType { get; }
     }
 
     public static class SecureStringSettingExtensions


### PR DESCRIPTION
* Move SettingDescriptor implementations to Settings assembly
* Make IAnySetting internal so that all usage of settings outside of the Settings assembly is strongly-typed