### PR TITLE
b/331674228 Remove client credentials from POST paramaters

### DIFF
--- a/sources/Google.Solutions.IapDesktop/Properties/launchSettings.json
+++ b/sources/Google.Solutions.IapDesktop/Properties/launchSettings.json
@@ -1,7 +1,0 @@
-{
-  "profiles": {
-    "Google.Solutions.IapDesktop": {
-      "commandName": "Project"
-    }
-  }
-}


### PR DESCRIPTION
Previous versions of the oauthtoken endpoint ignored client credentials that were passed as POST parameter and only considered credentials passed as Basic auth header.

This recently changed and passing a "client_secret" POST- parameter now causes the server to reject the request.

Change client implementation to only send credentials as Basic auth header and remove the respective POST parameters.