### PR TITLE
b/335741487 Refine minimum version requirement

### DIFF
--- a/sources/Google.Solutions.IapDesktop/App.config
+++ b/sources/Google.Solutions.IapDesktop/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7" />
     </startup>
 </configuration>

--- a/sources/installer/Product.wxs
+++ b/sources/installer/Product.wxs
@@ -77,18 +77,19 @@
         Type="raw" />
     </Property>
 
-    <Condition Message="This version of IAP Desktop requires Windows 10, Windows Server 2016, or higher.">
+    <Condition Message="This version of IAP Desktop requires Windows 10 (1607), Windows Server 2016, or higher.">
       <!-- 
         - The WebSocket implementation is only available in Windows 8/2012 and higher,
           see https://docs.microsoft.com/en-us/dotnet/api/system.net.websockets.clientwebsocket?view=netframework-4.8.
         - Libssh2 CNG/ECDSA support requires Windows 10 or later.
-
-        Plus, older versions of Windows are out of support by now anyway.
+        - .NET 4.7 requires requires Windows 10 1607 (which excludes 1507, 1511).
+        
+        This makes Windows 10 "Anniversary Update" 1611 (build 14393) the minium supported version.
 
         NB. Windows 10 still uses VersionNT=603 and WindowsBuild=9600, so 
-        we need to check the build number from the registry.
+            we need to check the build number from the registry.
       -->
-      <![CDATA[Installed OR (VersionNT >= 603 AND WINDOWS_CURRENTBUILDNUMBER >= 10000)]]>
+      <![CDATA[Installed OR (VersionNT >= 603 AND WINDOWS_CURRENTBUILDNUMBER >= 14393)]]>
     </Condition>
     <Condition Message="You need administrative privileges to install IAP Desktop on Windows Server. For more details, see https://bit.ly/iapdesktop-install.">
       <!-- 


### PR DESCRIPTION
Check for Windows 10 1607 as minimum version, which is the first version to support .NET 4.7.