### PR TITLE
b/335741487 Retry session initialization when key exchange fails

### DIFF
--- a/sources/Google.Solutions.Ssh.Test/Native/TestLibssh2AuthenticatedSession.cs
+++ b/sources/Google.Solutions.Ssh.Test/Native/TestLibssh2AuthenticatedSession.cs
@@ -37,6 +37,7 @@ namespace Google.Solutions.Ssh.Test.Native
         //---------------------------------------------------------------------
 
         [Test]
+        [Repeat(300)]
         public async Task WhenConnected_ThenOpenShellChannelSucceeds(
             [LinuxInstance] ResourceTask<InstanceLocator> instanceLocatorTask,
             [Values(SshKeyType.Rsa3072, SshKeyType.EcdsaNistp256)] SshKeyType keyType)

--- a/sources/Google.Solutions.Ssh.Test/Native/TestLibssh2Session.cs
+++ b/sources/Google.Solutions.Ssh.Test/Native/TestLibssh2Session.cs
@@ -38,10 +38,17 @@ namespace Google.Solutions.Ssh.Test.Native
         private readonly IPEndPoint NonSshEndpoint =
             new IPEndPoint(IPAddress.Parse("8.8.8.8"), 53);
 
+        //---------------------------------------------------------------------
+        // Handle.
+        //---------------------------------------------------------------------
+
         [Test]
         public void WhenNotInitialized_ThenHandleThrowsException()
         {
-            Assert.Fail();
+            using (var session = CreateSession())
+            {
+                Assert.Throws<InvalidOperationException>(() => _ = session.Handle);
+            }
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.Ssh.Test/Native/TestLibssh2Session.cs
+++ b/sources/Google.Solutions.Ssh.Test/Native/TestLibssh2Session.cs
@@ -38,22 +38,10 @@ namespace Google.Solutions.Ssh.Test.Native
         private readonly IPEndPoint NonSshEndpoint =
             new IPEndPoint(IPAddress.Parse("8.8.8.8"), 53);
 
-        //---------------------------------------------------------------------
-        // Version.
-        //---------------------------------------------------------------------
-
         [Test]
-        public void WhenRequriedVersionIsHigher_ThenVersionReturnsNull()
+        public void WhenNotInitialized_ThenHandleThrowsException()
         {
-            var version = Libssh2Session.GetVersion(new Version(0xCC, 0xBB, 0xAA));
-            Assert.IsNull(version);
-        }
-
-        [Test]
-        public void WhenRequriedVersionIsLower_ThenVersionReturnsXxx()
-        {
-            var version = Libssh2Session.GetVersion(new Version(1, 0, 0));
-            Assert.IsNotNull(version);
+            Assert.Fail();
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.Ssh/Native/Libssh2Session.cs
+++ b/sources/Google.Solutions.Ssh/Native/Libssh2Session.cs
@@ -242,10 +242,6 @@ namespace Google.Solutions.Ssh.Native
             InitializeSession(false);
 
             this.sessionHandle!.CheckCurrentThreadOwnsHandle();
-            if (!Enum.IsDefined(typeof(LIBSSH2_METHOD), methodType))
-            {
-                throw new ArgumentException("The method is not supported");
-            }
 
             using (SshTraceSource.Log.TraceMethod().WithParameters(methodType))
             {

--- a/sources/Google.Solutions.Ssh/Native/Libssh2Session.cs
+++ b/sources/Google.Solutions.Ssh/Native/Libssh2Session.cs
@@ -23,7 +23,9 @@ using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.Common.Runtime;
 using Google.Solutions.Common.Util;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Drawing;
 using System.Linq;
 using System.Net;
 using System.Net.Sockets;
@@ -39,25 +41,32 @@ namespace Google.Solutions.Ssh.Native
     {
         internal const string BannerPrefix = "SSH-2.0-";
 
-        private readonly Libssh2SessionHandle sessionHandle;
+        private Libssh2SessionHandle? sessionHandle;
         private bool disposed = false;
 
-        internal Libssh2SessionHandle Handle => this.sessionHandle;
+        private string? banner = null;
+        private bool blocking;
+        private TimeSpan timeout = TimeSpan.Zero;
+        private NativeMethods.TraceHandler? traceHandlerDelegate;
+        private LIBSSH2_TRACE traceMask = (LIBSSH2_TRACE)0;
+        private readonly Dictionary<LIBSSH2_METHOD, string[]> preferredMethods 
+            = new Dictionary<LIBSSH2_METHOD, string[]>();
 
         internal static readonly NativeMethods.Alloc Alloc;
         internal static readonly NativeMethods.Free Free;
         internal static readonly NativeMethods.Realloc Realloc;
 
         //---------------------------------------------------------------------
-        // Ctor.
+        // Initialization.
         //---------------------------------------------------------------------
 
         static Libssh2Session()
         {
+            //
             // Store these delegates in fields to prevent them from being
             // garbage collected. Otherwise callbacks will suddenly
             // start hitting GC'ed memory.
-
+            //
             Alloc = (size, context) => Marshal.AllocHGlobal(size);
             Realloc = (ptr, size, context) => Marshal.ReAllocHGlobal(ptr, size);
             Free = (ptr, context) => Marshal.FreeHGlobal(ptr);
@@ -80,45 +89,114 @@ namespace Google.Solutions.Ssh.Native
 
         internal Libssh2Session()
         {
-            this.sessionHandle = NativeMethods.libssh2_session_init_ex(
-                Alloc,
-                Free,
-                Realloc,
-                IntPtr.Zero);
-
+            //
             // Use blocking I/O by default.
-            this.IsBlocking = true;
+            //
+            this.blocking = true;
         }
 
-        public static string GetVersion(Version requiredVersion)
+        /// <summary>
+        /// Lazily initialize a Libssh2 session.
+        /// </summary>
+        private void InitializeSession(bool force)
         {
-            using (SshTraceSource.Log.TraceMethod().WithParameters(requiredVersion))
+            using (SshTraceSource.Log.TraceMethod().WithParameters(force))
             {
-                var requiredVersionEncoded =
-                    (requiredVersion.Major << 16) |
-                    (requiredVersion.Minor << 8) |
-                    (requiredVersion.Build);
+                if (this.sessionHandle != null && force)
+                {
+                    //
+                    // Close existing session to force re-initialization.
+                    //
+                    this.sessionHandle.CheckCurrentThreadOwnsHandle();
+                    this.sessionHandle.Dispose();
+                    this.sessionHandle = null;
+                }
 
-                return Marshal.PtrToStringAnsi(
-                    NativeMethods.libssh2_version(
-                        requiredVersionEncoded));
+                if (this.sessionHandle == null)
+                {
+                    this.sessionHandle = NativeMethods.libssh2_session_init_ex(
+                        Alloc,
+                        Free,
+                        Realloc,
+                        IntPtr.Zero);
+
+                    if (this.traceHandlerDelegate != null)
+                    {
+                        //
+                        // NB. We must not pass a delegate to libssh2_trace_sethandler
+                        // as it might be garbage-collected while still being referenced
+                        // by native code.
+                        //
+
+                        NativeMethods.libssh2_trace_sethandler(
+                            this.sessionHandle,
+                            IntPtr.Zero,
+                            this.traceHandlerDelegate);
+
+                        NativeMethods.libssh2_trace(
+                            this.sessionHandle,
+                            this.traceMask);
+                    }
+
+                    NativeMethods.libssh2_session_set_timeout(
+                        this.sessionHandle,
+                        (int)this.timeout.TotalMilliseconds);
+
+                    NativeMethods.libssh2_session_set_blocking(
+                        this.sessionHandle,
+                        this.blocking ? 1 : 0);
+
+                    if (this.banner != null)
+                    {
+                        _ = NativeMethods.libssh2_session_banner_set(
+                            this.sessionHandle,
+                            this.banner);
+                    }
+
+                    foreach (var preferredMethod in this.preferredMethods)
+                    {
+                        var prefs = string.Join(",", preferredMethod.Value);
+                        var result = (LIBSSH2_ERROR)NativeMethods.libssh2_session_method_pref(
+                            this.sessionHandle,
+                            preferredMethod.Key,
+                            prefs);
+                        if (result != LIBSSH2_ERROR.NONE)
+                        {
+                            throw CreateException(result);
+                        }
+                    }
+                }
+
+                Debug.Assert(this.sessionHandle != null);
             }
         }
+
+        internal Libssh2SessionHandle Handle
+        {
+            get => this.sessionHandle ?? 
+                throw new InvalidOperationException("The session has not been initialized");
+        }
+
+        //---------------------------------------------------------------------
+        // Publics.
+        //---------------------------------------------------------------------
 
         public bool IsBlocking
         {
-            get
-            {
-                this.sessionHandle.CheckCurrentThreadOwnsHandle();
-                return NativeMethods.libssh2_session_get_blocking(
-                    this.sessionHandle) != 0;
-            }
+            get => this.blocking;
             private set
             {
-                this.sessionHandle.CheckCurrentThreadOwnsHandle();
-                NativeMethods.libssh2_session_set_blocking(
-                    this.sessionHandle,
-                    value ? 1 : 0);
+                this.blocking = value;
+                if (this.sessionHandle != null)
+                {
+                    //
+                    // Apply to existing session.
+                    //
+                    this.sessionHandle.CheckCurrentThreadOwnsHandle();
+                    NativeMethods.libssh2_session_set_blocking(
+                        this.sessionHandle,
+                        value ? 1 : 0);
+                }
             }
         }
 
@@ -151,9 +229,19 @@ namespace Google.Solutions.Ssh.Native
         // Algorithms.
         //---------------------------------------------------------------------
 
+        /// <summary>
+        /// Query the list of supported algorithms.
+        /// 
+        /// This forces the session to be initialized.
+        /// </summary>
         internal string[] GetSupportedAlgorithms(LIBSSH2_METHOD methodType)
         {
-            this.sessionHandle.CheckCurrentThreadOwnsHandle();
+            //
+            // Initialize session if that hasn't happened yet.
+            //
+            InitializeSession(false);
+
+            this.sessionHandle!.CheckCurrentThreadOwnsHandle();
             if (!Enum.IsDefined(typeof(LIBSSH2_METHOD), methodType))
             {
                 throw new ArgumentException("The method is not supported");
@@ -191,36 +279,24 @@ namespace Google.Solutions.Ssh.Native
             }
         }
 
+        
         internal void SetPreferredMethods(
             LIBSSH2_METHOD methodType,
             string[] methods)
         {
-            this.sessionHandle.CheckCurrentThreadOwnsHandle();
-
             Precondition.ExpectNotNullOrZeroSized(methods, nameof(methods));
+            Precondition.Expect(
+                this.sessionHandle != null,
+                "Method must be called before the session is initialized");
 
-            using (SshTraceSource.Log.TraceMethod().WithParameters(
-                methodType,
-                methods))
-            {
-                var prefs = string.Join(",", methods);
-
-                var result = (LIBSSH2_ERROR)NativeMethods.libssh2_session_method_pref(
-                    this.sessionHandle,
-                    methodType,
-                    prefs);
-                if (result != LIBSSH2_ERROR.NONE)
-                {
-                    throw CreateException(result);
-                }
-            }
+            this.preferredMethods[methodType] = methods;
         }
 
         //---------------------------------------------------------------------
         // Banner.
         //---------------------------------------------------------------------
 
-        public void SetLocalBanner(string banner)
+        public void SetLocalBanner(string banner) // TODO: Convert to property
         {
             if (!banner.StartsWith(BannerPrefix))
             {
@@ -228,15 +304,7 @@ namespace Google.Solutions.Ssh.Native
                     $"Banner must start with '{BannerPrefix}'");
             }
 
-            this.sessionHandle.CheckCurrentThreadOwnsHandle();
-            Precondition.ExpectNotEmpty(banner, nameof(banner));
-
-            using (SshTraceSource.Log.TraceMethod().WithParameters(banner))
-            {
-                _ = NativeMethods.libssh2_session_banner_set(
-                    this.sessionHandle,
-                    banner);
-            }
+            this.banner = banner;
         }
 
         //---------------------------------------------------------------------
@@ -248,20 +316,15 @@ namespace Google.Solutions.Ssh.Native
         /// </summary>
         public TimeSpan Timeout
         {
-            get
-            {
-                this.sessionHandle.CheckCurrentThreadOwnsHandle();
-
-                using (SshTraceSource.Log.TraceMethod().WithoutParameters())
-                {
-                    var millis = NativeMethods.libssh2_session_get_timeout(
-                        this.sessionHandle);
-                    return TimeSpan.FromMilliseconds(millis);
-                }
-            }
+            get => this.timeout;
             set
             {
-                using (SshTraceSource.Log.TraceMethod().WithParameters(value))
+                this.timeout = value;
+
+                //
+                // Update existing session.
+                //
+                if (this.sessionHandle != null)
                 {
                     this.sessionHandle.CheckCurrentThreadOwnsHandle();
 
@@ -291,8 +354,6 @@ namespace Google.Solutions.Ssh.Native
 
         public Libssh2ConnectedSession Connect(EndPoint remoteEndpoint)
         {
-            this.sessionHandle.CheckCurrentThreadOwnsHandle();
-
             using (SshTraceSource.Log.TraceMethod().WithParameters(remoteEndpoint))
             {
                 var socket = new Socket(
@@ -306,6 +367,12 @@ namespace Google.Solutions.Ssh.Native
                     //
                     NoDelay = true
                 };
+
+                //
+                // Initialize session if that hasn't happened yet.
+                //
+                InitializeSession(false);
+                this.sessionHandle!.CheckCurrentThreadOwnsHandle();
 
                 SshEventSource.Log.ConnectionHandshakeInitiated(remoteEndpoint.ToString());
 
@@ -335,76 +402,66 @@ namespace Google.Solutions.Ssh.Native
         {
             get
             {
-                this.sessionHandle.CheckCurrentThreadOwnsHandle();
+                if (this.sessionHandle == null)
+                {
+                    return LIBSSH2_ERROR.NONE;
+                }
+                else
+                {
+                    this.sessionHandle.CheckCurrentThreadOwnsHandle();
 
-                return (LIBSSH2_ERROR)NativeMethods.libssh2_session_last_errno(
-                    this.sessionHandle);
+                    return (LIBSSH2_ERROR)
+                        NativeMethods.libssh2_session_last_errno(this.sessionHandle);
+                }
             }
         }
 
         internal Libssh2Exception CreateException(LIBSSH2_ERROR error)
         {
-            var lastError = (LIBSSH2_ERROR)NativeMethods.libssh2_session_last_error(
-                this.sessionHandle,
-                out var errorMessage,
-                out var errorMessageLength,
-                0);
-
-            SshEventSource.Log.ConnectionErrorEncountered((int)error);
-
-            if (lastError == error)
+            if (this.sessionHandle != null)
             {
-                return new Libssh2Exception(
-                    error,
-                    Marshal.PtrToStringAnsi(errorMessage, errorMessageLength));
+                var lastError = (LIBSSH2_ERROR)NativeMethods.libssh2_session_last_error(
+                    this.sessionHandle,
+                    out var errorMessage,
+                    out var errorMessageLength,
+                    0);
+
+                SshEventSource.Log.ConnectionErrorEncountered((int)error);
+
+                if (lastError == error)
+                {
+                    return new Libssh2Exception(
+                        error,
+                        Marshal.PtrToStringAnsi(errorMessage, errorMessageLength));
+                }
             }
-            else
-            {
-                // The last error is something else, so create a generic
-                // exception
-                return new Libssh2Exception(
-                    error,
-                    $"SSH operation failed: {error}");
-            }
+
+            //
+            // Fall back to using a generic error message.
+            //
+            return new Libssh2Exception(
+                error,
+                $"SSH operation failed: {error}");
         }
 
         //---------------------------------------------------------------------
         // Tracing.
         //---------------------------------------------------------------------
 
-        private NativeMethods.TraceHandler? TraceHandlerDelegate;
-
         internal void SetTraceHandler(
             LIBSSH2_TRACE mask,
             Action<string> handler)
         {
-            this.sessionHandle.CheckCurrentThreadOwnsHandle();
-            Precondition.ExpectNotNull(handler, nameof(handler));
-
-            using (SshTraceSource.Log.TraceMethod().WithParameters(mask))
+            this.traceHandlerDelegate = (sessionPtr, contextPtr, dataPtr, length) =>
             {
-                // Store this delegate in a field to prevent it from being
-                // garbage collected. Otherwise callbacks will suddenly
-                // start hitting GC'ed memory.
-                this.TraceHandlerDelegate = (sessionPtr, contextPtr, dataPtr, length) =>
-                {
-                    Debug.Assert(contextPtr == IntPtr.Zero);
+                Debug.Assert(contextPtr == IntPtr.Zero);
 
-                    var data = new byte[length.ToInt32()];
-                    Marshal.Copy(dataPtr, data, 0, length.ToInt32());
+                var data = new byte[length.ToInt32()];
+                Marshal.Copy(dataPtr, data, 0, length.ToInt32());
 
-                    handler(Encoding.ASCII.GetString(data));
-                };
-
-                NativeMethods.libssh2_trace_sethandler(
-                    this.sessionHandle,
-                    IntPtr.Zero,
-                    this.TraceHandlerDelegate);
-
-                NativeMethods.libssh2_trace(
-                    this.sessionHandle,
-                    mask);
-            }
+                handler(Encoding.ASCII.GetString(data));
+            };
+            this.traceMask = mask;
         }
 
         //---------------------------------------------------------------------
@@ -417,7 +474,6 @@ namespace Google.Solutions.Ssh.Native
             GC.SuppressFinalize(this);
         }
 
-        // Protected implementation of Dispose pattern.
         protected virtual void Dispose(bool disposing)
         {
             if (this.disposed)
@@ -427,15 +483,18 @@ namespace Google.Solutions.Ssh.Native
 
             if (disposing)
             {
+                if (this.sessionHandle != null)
+                {
+                    this.sessionHandle.CheckCurrentThreadOwnsHandle();
 
-                this.sessionHandle.CheckCurrentThreadOwnsHandle();
+                    NativeMethods.libssh2_trace_sethandler(
+                        this.sessionHandle,
+                        IntPtr.Zero,
+                        null);
 
-                NativeMethods.libssh2_trace_sethandler(
-                    this.sessionHandle,
-                    IntPtr.Zero,
-                    null);
+                    this.sessionHandle.Dispose();
+                }
 
-                this.sessionHandle.Dispose();
                 this.disposed = true;
             }
         }

--- a/sources/Google.Solutions.Ssh/Native/NativeMethods.cs
+++ b/sources/Google.Solutions.Ssh/Native/NativeMethods.cs
@@ -160,10 +160,6 @@ namespace Google.Solutions.Ssh.Native
         [DllImport(Libssh2, CallingConvention = CallingConvention.Cdecl)]
         internal static extern Int32 libssh2_init(Int32 flags);
 
-        [DllImport(Libssh2, CallingConvention = CallingConvention.Cdecl)]
-        internal static extern IntPtr libssh2_version(
-            int requiredVersion);
-
         //---------------------------------------------------------------------
         // Session functions.
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.Ssh/SshWorkerThread.cs
+++ b/sources/Google.Solutions.Ssh/SshWorkerThread.cs
@@ -294,7 +294,7 @@ namespace Google.Solutions.Ssh
                                 //
                                 // NB. This method must not be called before the handshake has completed.
                                 //
-                                session.ConfigureKeepAlive(false, this.KeepAliveInterval);
+                                connectedSession.ConfigureKeepAlive(false, this.KeepAliveInterval);
 
                                 var waitHandles = new[]
                                 {
@@ -371,7 +371,7 @@ namespace Google.Solutions.Ssh
                                             // keepalive. Libssh2 will ignore the call if no
                                             // keepalive is due yet.
                                             // 
-                                            session.KeepAlive();
+                                            connectedSession.KeepAlive();
                                         }
                                         else if (waitResult == NativeMethods.WSA_WAIT_FAILED)
                                         {


### PR DESCRIPTION
When using the WinCNG backend, key exchanges can occasionally fail,
see https://github.com/libssh2/libssh2/issues/804. 
