### PR TITLE
b/337703105 Download x64 installer by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 IAP Desktop is a Remote Desktop and SSH client that lets you connect to your Google Cloud VM instances from anywhere.
 
-[<img src="doc/images/download.png">](https://github.com/GoogleCloudPlatform/iap-desktop/releases/latest/download/IapDesktop.msi)
+[<img src="doc/images/download.png">](https://github.com/GoogleCloudPlatform/iap-desktop/releases/latest/download/IapDesktopX64.msi)
 [<img src="doc/images/documentation.png">](https://googlecloudplatform.github.io/iap-desktop/)
 
 <sub>

--- a/doc/site/sources/docs/index.md
+++ b/doc/site/sources/docs/index.md
@@ -7,7 +7,7 @@ description: IAP Desktop provides zero-trust Remote Desktop and SSH access to Li
 
 IAP Desktop is an open-source Remote Desktop and SSH client that lets you connect to your Google Cloud VM instances from anywhere.
 
-[Download IAP Desktop](https://github.com/GoogleCloudPlatform/iap-desktop/releases/latest/download/IapDesktop.msi){ .md-button }
+[Download IAP Desktop](https://github.com/GoogleCloudPlatform/iap-desktop/releases/latest/download/IapDesktopX64.msi){ .md-button }
 
 <sub>
 [x86 (32-bit)](https://github.com/GoogleCloudPlatform/iap-desktop/releases/latest/download/IapDesktopX86.msi) | 

--- a/doc/site/sources/mkdocs.yml
+++ b/doc/site/sources/mkdocs.yml
@@ -61,7 +61,7 @@ extra_css:
   
 repo_name: iap-desktop
 repo_url: https://github.com/GoogleCloudPlatform/iap-desktop
-download_url: https://github.com/GoogleCloudPlatform/iap-desktop/releases/latest/download/IapDesktop.msi
+download_url: https://github.com/GoogleCloudPlatform/iap-desktop/releases/latest/download/IapDesktopX64.msi
 copyright: |
     IAP Desktop is an open-source project developed and maintained by the Google Cloud Solutions Architects team.<br>
     The project is not an officially supported Google product.<br>


### PR DESCRIPTION
Change links in README and docs to download x64 installer by default