### PR TITLE
b/341201732 Rename to IActivator.Activate()

### DIFF
--- a/sources/Google.Solutions.Common.Test/Runtime/TestInstanceActivator.cs
+++ b/sources/Google.Solutions.Common.Test/Runtime/TestInstanceActivator.cs
@@ -37,7 +37,7 @@ namespace Google.Solutions.Common.Test.Runtime
 
             Assert.AreSame(
                 instance,
-                activator.GetInstance());
+                activator.Activate());
         }
 
         [Test]
@@ -46,8 +46,8 @@ namespace Google.Solutions.Common.Test.Runtime
             var instance = new SomeClass();
             var activator = InstanceActivator.Create(() => new SomeClass());
             Assert.AreNotSame(
-                activator.GetInstance(),
-                activator.GetInstance());
+                activator.Activate(),
+                activator.Activate());
         }
     }
 }

--- a/sources/Google.Solutions.Common/Runtime/IActivator.cs
+++ b/sources/Google.Solutions.Common/Runtime/IActivator.cs
@@ -30,6 +30,6 @@ namespace Google.Solutions.Common.Runtime
         /// Activate an instance.
         /// </summary>
         /// <returns>existing or new instance</returns>
-        T GetInstance(); // TODO: rename to Activate
+        T Activate();
     }
 }

--- a/sources/Google.Solutions.Common/Runtime/InstanceActivator.cs
+++ b/sources/Google.Solutions.Common/Runtime/InstanceActivator.cs
@@ -53,7 +53,7 @@ namespace Google.Solutions.Common.Runtime
                 this.createInstance = createInstance;
             }
 
-            public T GetInstance()
+            public T Activate()
             {
                 return this.createInstance();
             }

--- a/sources/Google.Solutions.IapDesktop.Application/ToolWindows/ProjectExplorer/ProjectExplorerView.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ToolWindows/ProjectExplorer/ProjectExplorerView.cs
@@ -295,7 +295,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.ProjectExplorer
                     .SelectCloudProjects(
                         this,
                         "Add projects",
-                        this.resourceManagerAdapter.GetInstance(),
+                        this.resourceManagerAdapter.Activate(),
                         out var projects) == DialogResult.OK)
                 {
                     await this.viewModel

--- a/sources/Google.Solutions.IapDesktop.Application/Windows/Dialog/CredentialDialog.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/Dialog/CredentialDialog.cs
@@ -197,7 +197,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.Dialog
             {
                 try
                 {
-                    this.theme.GetInstance().ApplyTo(dialog);
+                    this.theme.Activate().ApplyTo(dialog);
                 }
                 catch (UnknownServiceException)
                 { }

--- a/sources/Google.Solutions.IapDesktop.Application/Windows/Dialog/InputDialog.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/Dialog/InputDialog.cs
@@ -106,7 +106,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.Dialog
             {
                 try
                 {
-                    this.theme.GetInstance().ApplyTo(dialog);
+                    this.theme.Activate().ApplyTo(dialog);
                 }
                 catch (UnknownServiceException)
                 { }

--- a/sources/Google.Solutions.IapDesktop.Core.Test/ObjectModel/TestService.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ObjectModel/TestService.cs
@@ -50,8 +50,8 @@ namespace Google.Solutions.IapDesktop.Core.Test.ObjectModel
 
             var service = registry.GetService<Service<ServiceWithDefaultConstructor>>();
             Assert.IsNotNull(service);
-            Assert.IsNotNull(service.GetInstance());
-            Assert.AreNotSame(service.GetInstance(), service.GetInstance());
+            Assert.IsNotNull(service.Activate());
+            Assert.AreNotSame(service.Activate(), service.Activate());
         }
 
         [Test]
@@ -62,8 +62,8 @@ namespace Google.Solutions.IapDesktop.Core.Test.ObjectModel
 
             var service = registry.GetService<Service<ServiceWithDefaultConstructor>>();
             Assert.IsNotNull(service);
-            Assert.IsNotNull(service.GetInstance());
-            Assert.AreSame(service.GetInstance(), service.GetInstance());
+            Assert.IsNotNull(service.Activate());
+            Assert.AreSame(service.Activate(), service.Activate());
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Core.Test/ObjectModel/TestServiceRegistry.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ObjectModel/TestServiceRegistry.cs
@@ -227,8 +227,8 @@ namespace Google.Solutions.IapDesktop.Core.Test.ObjectModel
             var service = registry.GetService<IActivator<ServiceWithDefaultConstructor>>();
             Assert.IsNotNull(service);
             Assert.IsInstanceOf<Service<ServiceWithDefaultConstructor>>(service);
-            Assert.IsNotNull(service.GetInstance());
-            Assert.AreNotSame(service.GetInstance(), service.GetInstance());
+            Assert.IsNotNull(service.Activate());
+            Assert.AreNotSame(service.Activate(), service.Activate());
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Core/ObjectModel/Service.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ObjectModel/Service.cs
@@ -37,7 +37,7 @@ namespace Google.Solutions.IapDesktop.Core.ObjectModel
             this.serviceProvider = serviceProvider.ExpectNotNull(nameof(serviceProvider));
         }
 
-        public TService GetInstance()
+        public TService Activate()
         {
             return (TService)this.serviceProvider.GetService(typeof(TService));
         }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/GuestOs/ActiveDirectory/DomainJoinService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/GuestOs/ActiveDirectory/DomainJoinService.cs
@@ -261,7 +261,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.GuestOs.ActiveDirect
                 using (var operation = new StartupScriptOperation(
                     instance,
                     MetadataKeys.JoinDomainGuard,
-                    this.computeClient.GetInstance()))
+                    this.computeClient.Activate()))
                 {
                     await JoinDomainAsync(
                             operation,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/ToolWindows/EventLog/EventLogViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/ToolWindows/EventLog/EventLogViewModel.cs
@@ -281,7 +281,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.ToolWindows.EventLog
                             {
                                 var model = new EventLogModel(displayName);
                                 await this.auditLogAdapter
-                                    .GetInstance()
+                                    .Activate()
                                     .ProcessInstanceEventsAsync(
                                         new[] { projectIdFilter },
                                         zonesFilter,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/ToolWindows/InstanceProperties/InstancePropertiesInspectorViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/ToolWindows/InstanceProperties/InstancePropertiesInspectorViewModel.cs
@@ -114,8 +114,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.ToolWindows.Instance
                                     return await InstancePropertiesInspectorModel
                                         .LoadAsync(
                                             vmNode.Instance,
-                                            this.computeClient.GetInstance(),
-                                            this.packageInventory.GetInstance(),
+                                            this.computeClient.Activate(),
+                                            this.packageInventory.Activate(),
                                             combinedTokenSource.Token)
                                         .ConfigureAwait(false);
                                 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/ToolWindows/PackageInventory/PackageInventoryViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/ToolWindows/PackageInventory/PackageInventoryViewModel.cs
@@ -181,7 +181,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.ToolWindows.PackageI
                         async jobToken =>
                         {
                             return await PackageInventoryModel.LoadAsync(
-                                    this.packageInventory.GetInstance(),
+                                    this.packageInventory.Activate(),
                                     this.InventoryType,
                                     node,
                                     jobToken)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management/ToolWindows/SerialOutput/SerialOutputViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management/ToolWindows/SerialOutput/SerialOutputViewModel.cs
@@ -209,7 +209,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.ToolWindows.SerialOu
                             {
                                 return await SerialOutputModel.LoadAsync(
                                     vmNode.Instance.Name,
-                                    this.computeClient.GetInstance(),
+                                    this.computeClient.Activate(),
                                     vmNode.Instance,
                                     this.SerialPortNumber,
                                     combinedTokenSource.Token)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/SshKeys/AuthorizedPublicKeysViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/SshKeys/AuthorizedPublicKeysViewModel.cs
@@ -190,7 +190,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.SshKeys
                     if (item.AuthorizationMethod == KeyAuthorizationMethods.Oslogin)
                     {
                         await AuthorizedPublicKeysModel.DeleteFromOsLoginAsync(
-                                this.osLoginService.GetInstance(),
+                                this.osLoginService.Activate(),
                                 item,
                                 cancellationToken)
                             .ConfigureAwait(true);
@@ -198,8 +198,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.SshKeys
                     else
                     {
                         await AuthorizedPublicKeysModel.DeleteFromMetadataAsync(
-                                this.computeClient.GetInstance(),
-                                this.resourceManagerAdapter.GetInstance(),
+                                this.computeClient.Activate(),
+                                this.resourceManagerAdapter.Activate(),
                                 this.ModelKey!,
                                 item,
                                 cancellationToken)
@@ -246,9 +246,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.SshKeys
                         {
                             return await AuthorizedPublicKeysModel
                                 .LoadAsync(
-                                    this.computeClient.GetInstance(),
-                                    this.resourceManagerAdapter.GetInstance(),
-                                    this.osLoginService.GetInstance(),
+                                    this.computeClient.Activate(),
+                                    this.resourceManagerAdapter.Activate(),
+                                    this.osLoginService.Activate(),
                                     node,
                                     jobToken)
                                 .ConfigureAwait(false);

--- a/sources/Google.Solutions.Mvvm/Binding/WindowActivator.cs
+++ b/sources/Google.Solutions.Mvvm/Binding/WindowActivator.cs
@@ -100,7 +100,7 @@ namespace Google.Solutions.Mvvm.Binding
         {
             return new DialogWindow<TView, TViewModel, TTheme>(
                 this.viewActivator,
-                this.viewModelActivator.GetInstance(),
+                this.viewModelActivator.Activate(),
                 this.theme,
                 this.bindingContext);
         }
@@ -109,12 +109,12 @@ namespace Google.Solutions.Mvvm.Binding
         {
             return new TopLevelWindow<TView, TViewModel, TTheme>(
                 this.viewActivator,
-                this.viewModelActivator.GetInstance(),
+                this.viewModelActivator.Activate(),
                 this.theme,
                 this.bindingContext);
         }
 
-        public IWindow<TViewModel> GetInstance()
+        public IWindow<TViewModel> Activate()
         {
             return CreateWindow();
         }
@@ -164,7 +164,7 @@ namespace Google.Solutions.Mvvm.Binding
             //
             // Create view, show, and dispose it.
             //
-            using (var view = this.viewActivator.GetInstance())
+            using (var view = this.viewActivator.Activate())
             {
                 view.SuspendLayout();
 
@@ -278,7 +278,7 @@ namespace Google.Solutions.Mvvm.Binding
                     //
                     // Create view and bind it.
                     //
-                    var view = this.viewActivator.GetInstance();
+                    var view = this.viewActivator.Activate();
                     if (view == null)
                     {
                         throw new BindingException($"No view of type {typeof(TView)} available");


### PR DESCRIPTION
Rename method Activate, which is neutral w.r.t.
whether it creates a new instance or reuses an
existing instance.