### PR TITLE
b/341834296 Use double buffering when GDI scaling not active

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Theme/VSThemeRuleSet.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Theme/VSThemeRuleSet.cs
@@ -338,8 +338,8 @@ namespace Google.Solutions.IapDesktop.Application.Theme
                     ? this.theme.Palette.TextBox.BackgroundDisabled
                     : this.theme.Palette.TextBox.Background;
             }
-
-            if (DpiAwareness.ProcessMode != DpiAwarenessMode.DpiUnawareGdiScaled)
+            
+            if (!DeviceCapabilities.Current.IsGdiScalingActive)
             {
                 //
                 // When GDI scaling is active, SetControlBorder 

--- a/sources/Google.Solutions.Mvvm/Controls/CompositeForm.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/CompositeForm.cs
@@ -44,7 +44,7 @@ namespace Google.Solutions.Mvvm.Controls
                 //
                 var cp = base.CreateParams;
 
-                if (DpiAwareness.ProcessMode != DpiAwarenessMode.DpiUnawareGdiScaled)
+                if (!DeviceCapabilities.Current.IsGdiScalingActive)
                 {
                     //
                     // WS_EX_COMPOSITED can break scrolling if

--- a/sources/Google.Solutions.Mvvm/Theme/DeviceCapabilities.cs
+++ b/sources/Google.Solutions.Mvvm/Theme/DeviceCapabilities.cs
@@ -155,6 +155,27 @@ namespace Google.Solutions.Mvvm.Theme
         }
 
         //---------------------------------------------------------------------
+        // Derived capabilities.
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// Check if GDI scaling is enabled and currently active.
+        /// </summary>
+        public bool IsGdiScalingActive
+        {
+            get
+            {
+                //
+                // Ignore the current DPI awareness mode unless the current
+                // DPI is virtualized.
+                //
+                return 
+                    DpiAwareness.ProcessMode == DpiAwarenessMode.DpiUnawareGdiScaled &&
+                    this.Dpi != System.Dpi;
+            }
+        }
+
+        //---------------------------------------------------------------------
         // P/Invoke.
         //---------------------------------------------------------------------
 

--- a/sources/Google.Solutions.Mvvm/Theme/GdiScalingRuleset.cs
+++ b/sources/Google.Solutions.Mvvm/Theme/GdiScalingRuleset.cs
@@ -83,7 +83,7 @@ namespace Google.Solutions.Mvvm.Theme
         {
             controlTheme.ExpectNotNull(nameof(controlTheme));
 
-            if (DpiAwareness.ProcessMode == DpiAwarenessMode.DpiUnawareGdiScaled)
+            if (DeviceCapabilities.Current.IsGdiScalingActive)
             {
                 controlTheme.AddRule<Label>(DisableDoubleBufferingForLabel);
                 controlTheme.AddRule<CheckBox>(DisableDoubleBuffering);


### PR DESCRIPTION
Check if GDI scaling is actually in use before disabling double-buffering. This improves rendering performance in dark mode on systems that use the default DPI.