### PR TITLE
b/342952290 Add mitigation for user controls anchoring bug in NetFx

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Windows/ProjectPicker/ProjectPickerView.Designer.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/ProjectPicker/ProjectPickerView.Designer.cs
@@ -103,6 +103,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.ProjectPicker
             this.projectList.SearchTerm = "";
             this.projectList.Size = new System.Drawing.Size(450, 351);
             this.projectList.TabIndex = 1;
+            this.projectList.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             // 
             // statusLabel
             // 

--- a/sources/Google.Solutions.IapDesktop.Application/Windows/ProjectPicker/ProjectPickerView.Designer.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/ProjectPicker/ProjectPickerView.Designer.cs
@@ -103,7 +103,6 @@ namespace Google.Solutions.IapDesktop.Application.Windows.ProjectPicker
             this.projectList.SearchTerm = "";
             this.projectList.Size = new System.Drawing.Size(450, 351);
             this.projectList.TabIndex = 1;
-            this.projectList.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
             // 
             // statusLabel
             // 

--- a/sources/Google.Solutions.Mvvm/Controls/DpiAwareUserControl.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/DpiAwareUserControl.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Google.Solutions.Mvvm.Controls
+{
+    public class DpiAwareUserControl : UserControl
+    {
+        //private Size? unscaledSize;
+
+        //internal bool Rescaled { get; private set; } = false;
+
+        //public new Size Size
+        //{
+        //    get => base.Size;
+        //    set
+        //    {
+        //        this.unscaledSize = value;
+
+        //        base.Size = value;
+        //    }
+        //}
+
+
+
+        private AnchorStyles anchor;
+
+        public override AnchorStyles Anchor 
+        {
+            get => AnchorStyles.None;
+            set => this.anchor = value; 
+        }
+
+
+        public void MitigateWinformsBug()
+        {
+
+
+            //if (!this.Rescaled && this.unscaledSize != null && this.Size != this.unscaledSize)
+            //{
+            //    //
+            //    // Disable anchors and force the control back to its original size.
+            //    //
+            //    var originalAnchor = this.Anchor;
+            //    this.Anchor = AnchorStyles.None;
+            //    this.AutoScaleMode = AutoScaleMode.None;
+
+            //    var scaledSize = this.Size;
+            //    this.Size = this.unscaledSize.Value;
+
+            //    //
+            //    // Turn on anchor again and force rescale.
+            //    //
+            //    this.Anchor = originalAnchor;
+            //    this.Size = scaledSize;
+                
+            //    // TODO: only when anchored?
+
+
+            //    this.Rescaled = true;
+            //}
+        }
+    }
+}

--- a/sources/Google.Solutions.Mvvm/Controls/DpiAwareUserControl.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/DpiAwareUserControl.cs
@@ -25,15 +25,79 @@ namespace Google.Solutions.Mvvm.Controls
         //    }
         //}
 
+        //protected override void OnHandleCreated(EventArgs e)
+        //{
+        //    base.OnHandleCreated(e);
+        //}
 
+        //protected override void OnLayout(LayoutEventArgs e)
+        //{
+        //    base.OnLayout(e);
+        //}
 
-        private AnchorStyles anchor;
-
-        public override AnchorStyles Anchor 
+        protected override void OnParentChanged(EventArgs e)
         {
-            get => AnchorStyles.None;
-            set => this.anchor = value; 
+            base.OnParentChanged(e);
         }
+
+        //protected override void OnResize(EventArgs e)
+        //{
+        //    base.OnResize(e);
+        //}
+
+        private bool rescalingDone = false;
+
+        protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
+        {
+            if (this.Parent == null)
+            {
+                //
+                // Not parented yet, bug doesn't apply.
+                //
+                base.ScaleControl(factor, specified);
+            }
+            else
+            {
+                var horizontallyAnchoredControls = this.Controls
+                    .OfType<Control>()
+                    .Where(c => c.Anchor.HasFlag(AnchorStyles.Left | AnchorStyles.Right))
+                    .Select(c => new {
+                        Control = c,
+                        RightMargin = this.Width - c.Location.X - c.Width
+                    })
+                    .ToList();
+                var verticallyAnchoredControls = this.Controls
+                    .OfType<Control>()
+                    .Where(c => c.Anchor.HasFlag(AnchorStyles.Top | AnchorStyles.Bottom))
+                    .Select(c => new {
+                        Control = c,
+                        BottomMargin = this.Width - c.Location.X - c.Width
+                    })
+                    .ToList();
+
+                base.ScaleControl(factor, specified);
+
+                foreach (var c in horizontallyAnchoredControls)
+                {
+                    c.Control.Width = this.Width - c.Control.Location.X - c.RightMargin;
+                }
+
+                foreach (var c in verticallyAnchoredControls)
+                {
+                    c.Control.Height = this.Height - c.Control.Location.Y - c.BottomMargin;
+                }
+
+                this.rescalingDone = true;
+            }
+        }
+
+        //private AnchorStyles anchor;
+
+        //public override AnchorStyles Anchor 
+        //{
+        //    get => AnchorStyles.None;
+        //    set => this.anchor = value; 
+        //}
 
 
         public void MitigateWinformsBug()

--- a/sources/Google.Solutions.Mvvm/Controls/DpiAwareUserControl.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/DpiAwareUserControl.cs
@@ -1,52 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
+﻿using System.Drawing;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace Google.Solutions.Mvvm.Controls
 {
     public class DpiAwareUserControl : UserControl
     {
-        //private Size? unscaledSize;
-
-        //internal bool Rescaled { get; private set; } = false;
-
-        //public new Size Size
-        //{
-        //    get => base.Size;
-        //    set
-        //    {
-        //        this.unscaledSize = value;
-
-        //        base.Size = value;
-        //    }
-        //}
-
-        //protected override void OnHandleCreated(EventArgs e)
-        //{
-        //    base.OnHandleCreated(e);
-        //}
-
-        //protected override void OnLayout(LayoutEventArgs e)
-        //{
-        //    base.OnLayout(e);
-        //}
-
-        protected override void OnParentChanged(EventArgs e)
-        {
-            base.OnParentChanged(e);
-        }
-
-        //protected override void OnResize(EventArgs e)
-        //{
-        //    base.OnResize(e);
-        //}
-
-        private bool rescalingDone = false;
-
         protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
         {
             if (this.Parent == null)
@@ -58,6 +17,12 @@ namespace Google.Solutions.Mvvm.Controls
             }
             else
             {
+                //
+                // Resize anchored controls.
+                //
+
+                // TODO: Consider Dock = Fill
+
                 var horizontallyAnchoredControls = this.Controls
                     .OfType<Control>()
                     .Where(c => c.Anchor.HasFlag(AnchorStyles.Left | AnchorStyles.Right))
@@ -86,47 +51,7 @@ namespace Google.Solutions.Mvvm.Controls
                 {
                     c.Control.Height = this.Height - c.Control.Location.Y - c.BottomMargin;
                 }
-
-                this.rescalingDone = true;
             }
-        }
-
-        //private AnchorStyles anchor;
-
-        //public override AnchorStyles Anchor 
-        //{
-        //    get => AnchorStyles.None;
-        //    set => this.anchor = value; 
-        //}
-
-
-        public void MitigateWinformsBug()
-        {
-
-
-            //if (!this.Rescaled && this.unscaledSize != null && this.Size != this.unscaledSize)
-            //{
-            //    //
-            //    // Disable anchors and force the control back to its original size.
-            //    //
-            //    var originalAnchor = this.Anchor;
-            //    this.Anchor = AnchorStyles.None;
-            //    this.AutoScaleMode = AutoScaleMode.None;
-
-            //    var scaledSize = this.Size;
-            //    this.Size = this.unscaledSize.Value;
-
-            //    //
-            //    // Turn on anchor again and force rescale.
-            //    //
-            //    this.Anchor = originalAnchor;
-            //    this.Size = scaledSize;
-                
-            //    // TODO: only when anchored?
-
-
-            //    this.Rescaled = true;
-            //}
         }
     }
 }

--- a/sources/Google.Solutions.Mvvm/Controls/DpiAwareUserControl.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/DpiAwareUserControl.cs
@@ -1,56 +1,82 @@
-﻿using System.Drawing;
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Mvvm.Theme;
+using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 
 namespace Google.Solutions.Mvvm.Controls
 {
+    /// <summary>
+    /// UserControl that implements a workaround for 
+    // https://github.com/dotnet/winforms/issues/6381.
+    /// </summary>
     public class DpiAwareUserControl : UserControl
     {
         protected override void ScaleControl(SizeF factor, BoundsSpecified specified)
         {
-            if (this.Parent == null)
+            if (this.Parent == null || !DeviceCapabilities.Current.IsHighDpi)
             {
-                //
-                // Not parented yet, bug doesn't apply.
-                //
                 base.ScaleControl(factor, specified);
+                return;
             }
-            else
+
+            //
+            // UserControl has been parented and we're in High-DPI mode. Winforms
+            // autoscales the UserControl and _should_ resize any nested controls
+            // that are anchored to scale horizontaly or vertically. But that doesn't
+            // happen due to  https://github.com/dotnet/winforms/issues/6381.
+            //
+            // As a workaround, we look for affected controls and resize them
+            // explicitly.
+            //
+
+            var horizontallyAnchoredControls = this.Controls
+                .OfType<Control>()
+                .Where(c => c.Anchor.HasFlag(AnchorStyles.Left | AnchorStyles.Right))
+                .Select(c => new {
+                    Control = c,
+                    RightMargin = this.Width - c.Location.X - c.Width
+                })
+                .ToList();
+            var verticallyAnchoredControls = this.Controls
+                .OfType<Control>()
+                .Where(c => c.Anchor.HasFlag(AnchorStyles.Top | AnchorStyles.Bottom))
+                .Select(c => new {
+                    Control = c,
+                    BottomMargin = this.Width - c.Location.X - c.Width
+                })
+                .ToList();
+
+            base.ScaleControl(factor, specified);
+
+            foreach (var c in horizontallyAnchoredControls)
             {
-                //
-                // Resize anchored controls.
-                //
+                c.Control.Width = this.Width - c.Control.Location.X - c.RightMargin;
+            }
 
-                // TODO: Consider Dock = Fill
-
-                var horizontallyAnchoredControls = this.Controls
-                    .OfType<Control>()
-                    .Where(c => c.Anchor.HasFlag(AnchorStyles.Left | AnchorStyles.Right))
-                    .Select(c => new {
-                        Control = c,
-                        RightMargin = this.Width - c.Location.X - c.Width
-                    })
-                    .ToList();
-                var verticallyAnchoredControls = this.Controls
-                    .OfType<Control>()
-                    .Where(c => c.Anchor.HasFlag(AnchorStyles.Top | AnchorStyles.Bottom))
-                    .Select(c => new {
-                        Control = c,
-                        BottomMargin = this.Width - c.Location.X - c.Width
-                    })
-                    .ToList();
-
-                base.ScaleControl(factor, specified);
-
-                foreach (var c in horizontallyAnchoredControls)
-                {
-                    c.Control.Width = this.Width - c.Control.Location.X - c.RightMargin;
-                }
-
-                foreach (var c in verticallyAnchoredControls)
-                {
-                    c.Control.Height = this.Height - c.Control.Location.Y - c.BottomMargin;
-                }
+            foreach (var c in verticallyAnchoredControls)
+            {
+                c.Control.Height = this.Height - c.Control.Location.Y - c.BottomMargin;
             }
         }
     }

--- a/sources/Google.Solutions.Mvvm/Controls/SearchableList.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/SearchableList.cs
@@ -30,7 +30,7 @@ using System.Windows.Forms;
 namespace Google.Solutions.Mvvm.Controls
 {
     [SkipCodeCoverage("Pure UI code")]
-    public partial class SearchableList<TModelItem> : UserControl
+    public partial class SearchableList<TModelItem> : DpiAwareUserControl
     {
         public event EventHandler? LoadingChanged;
         public event EventHandler? SearchTermChanged;

--- a/sources/Google.Solutions.Mvvm/Theme/DpiAwarenessRuleset.cs
+++ b/sources/Google.Solutions.Mvvm/Theme/DpiAwarenessRuleset.cs
@@ -20,6 +20,7 @@
 //
 
 using Google.Solutions.Common.Util;
+using Google.Solutions.Mvvm.Controls;
 using System.Diagnostics;
 using System.Windows.Forms;
 
@@ -90,7 +91,14 @@ namespace Google.Solutions.Mvvm.Theme
                     // This is a known and unfixed bug in NetFx, see
                     // https://github.com/dotnet/winforms/issues/6381.
                     //
-                    Debug.Assert(false, "User control auto-scaling is not implemented on NetFx");
+                    if (userControl is DpiAwareUserControl dpiAware)
+                    {
+                        dpiAware.MitigateWinformsBug();
+                    }
+                    else
+                    {
+                        Debug.Assert(false, "User control auto-scaling is not implemented on NetFx");
+                    }
                 }
             }
             else if (c is PropertyGrid)

--- a/sources/Google.Solutions.Mvvm/Theme/DpiAwarenessRuleset.cs
+++ b/sources/Google.Solutions.Mvvm/Theme/DpiAwarenessRuleset.cs
@@ -80,9 +80,10 @@ namespace Google.Solutions.Mvvm.Theme
                 Debug.Assert(userControl.CurrentAutoScaleDimensions.Width >= DpiAwareness.DefaultDpi.Width);
                 Debug.Assert(userControl.CurrentAutoScaleDimensions.Width == userControl.CurrentAutoScaleDimensions.Height);
 
-                if (userControl.Dock == DockStyle.Fill ||
-                    userControl.Anchor.HasFlag(AnchorStyles.Top | AnchorStyles.Bottom) ||
-                    userControl.Anchor.HasFlag(AnchorStyles.Left | AnchorStyles.Right))
+                if (!(userControl is DpiAwareUserControl) &&
+                    (userControl.Dock == DockStyle.Fill ||
+                     userControl.Anchor.HasFlag(AnchorStyles.Top | AnchorStyles.Bottom) ||)
+                     userControl.Anchor.HasFlag(AnchorStyles.Left | AnchorStyles.Right)))
                 {
                     //
                     // Winforms scales user controls, but doesn't rearrange
@@ -91,14 +92,7 @@ namespace Google.Solutions.Mvvm.Theme
                     // This is a known and unfixed bug in NetFx, see
                     // https://github.com/dotnet/winforms/issues/6381.
                     //
-                    if (userControl is DpiAwareUserControl dpiAware)
-                    {
-                        dpiAware.MitigateWinformsBug();
-                    }
-                    else
-                    {
-                        Debug.Assert(false, "User control auto-scaling is not implemented on NetFx");
-                    }
+                    Debug.Assert(false, "User control must be derived from " + nameof(DpiAwareUserControl));
                 }
             }
             else if (c is PropertyGrid)

--- a/sources/Google.Solutions.Mvvm/Theme/DpiAwarenessRuleset.cs
+++ b/sources/Google.Solutions.Mvvm/Theme/DpiAwarenessRuleset.cs
@@ -76,23 +76,25 @@ namespace Google.Solutions.Mvvm.Theme
                 // the conventions for ContainerControls.
                 //
 
-                Debug.Assert(userControl.AutoScaleMode == AutoScaleMode.Dpi);
-                Debug.Assert(userControl.CurrentAutoScaleDimensions.Width >= DpiAwareness.DefaultDpi.Width);
-                Debug.Assert(userControl.CurrentAutoScaleDimensions.Width == userControl.CurrentAutoScaleDimensions.Height);
+                Debug.Assert(userControl.AutoScaleMode == AutoScaleMode.Dpi ||
+                             userControl.AutoScaleMode == AutoScaleMode.Inherit);
 
+                if (userControl.AutoScaleMode == AutoScaleMode.Dpi)
+                {
+                    Debug.Assert(userControl.CurrentAutoScaleDimensions.Width >= DpiAwareness.DefaultDpi.Width);
+                    Debug.Assert(userControl.CurrentAutoScaleDimensions.Width == userControl.CurrentAutoScaleDimensions.Height);
+                }
+
+                //
+                // If the UserControl is anchored, then it must
+                // use the DpiAwareUserControl mitigation.
+                //
                 if (!(userControl is DpiAwareUserControl) &&
                     (userControl.Dock == DockStyle.Fill ||
-                     userControl.Anchor.HasFlag(AnchorStyles.Top | AnchorStyles.Bottom) ||)
+                     userControl.Anchor.HasFlag(AnchorStyles.Top | AnchorStyles.Bottom) ||
                      userControl.Anchor.HasFlag(AnchorStyles.Left | AnchorStyles.Right)))
                 {
-                    //
-                    // Winforms scales user controls, but doesn't rearrange
-                    // nested controls.
-                    //
-                    // This is a known and unfixed bug in NetFx, see
-                    // https://github.com/dotnet/winforms/issues/6381.
-                    //
-                    Debug.Assert(false, "User control must be derived from " + nameof(DpiAwareUserControl));
+                    Debug.Assert(false, "User control should be derived from " + nameof(DpiAwareUserControl));
                 }
             }
             else if (c is PropertyGrid)

--- a/sources/Google.Solutions.Mvvm/Theme/DpiAwarenessRuleset.cs
+++ b/sources/Google.Solutions.Mvvm/Theme/DpiAwarenessRuleset.cs
@@ -78,6 +78,20 @@ namespace Google.Solutions.Mvvm.Theme
                 Debug.Assert(userControl.AutoScaleMode == AutoScaleMode.Dpi);
                 Debug.Assert(userControl.CurrentAutoScaleDimensions.Width >= DpiAwareness.DefaultDpi.Width);
                 Debug.Assert(userControl.CurrentAutoScaleDimensions.Width == userControl.CurrentAutoScaleDimensions.Height);
+
+                if (userControl.Dock == DockStyle.Fill ||
+                    userControl.Anchor.HasFlag(AnchorStyles.Top | AnchorStyles.Bottom) ||
+                    userControl.Anchor.HasFlag(AnchorStyles.Left | AnchorStyles.Right))
+                {
+                    //
+                    // Winforms scales user controls, but doesn't rearrange
+                    // nested controls.
+                    //
+                    // This is a known and unfixed bug in NetFx, see
+                    // https://github.com/dotnet/winforms/issues/6381.
+                    //
+                    Debug.Assert(false, "User control auto-scaling is not implemented on NetFx");
+                }
             }
             else if (c is PropertyGrid)
             {


### PR DESCRIPTION
When a UserControl has been parented and we're in High-DPI mode. Winforms
autoscales the UserControl and _should_ resize any nested controls
that are anchored to scale horizontaly or vertically. But that doesn't
happen due to issue 6381.

As a workaround, we look for affected controls and resize them explicitly.