### PR TITLE
b/360927073 Include tag in DockPanelSuite file versions

### DIFF
--- a/dependencies/sources/dockpanelsuite/makefile
+++ b/dependencies/sources/dockpanelsuite/makefile
@@ -21,7 +21,7 @@
 CONFIGURATION = Release
 
 # The tag should be increased whenever one of the dependencies is changed
-TAG = 10
+TAG = 11
 
 DOCKPANELSUITE_TAG = Release_3.0.6
 DOCKPANELSUITE_URL = https://github.com/dockpanelsuite/dockpanelsuite.git
@@ -61,6 +61,10 @@ $(MAKEDIR)\obj\WinFormsUI\bin\$(CONFIGURATION)\$(DOCKPANELSUITE_PACKAGE_ID).$(DO
 	@echo "=== Building dockpanelsuite                          ==="
 	@echo "========================================================"
 	cd $(MAKEDIR)\obj
+    
+	powershell -Command "(Get-Content $(MAKEDIR)\obj\WinFormsUI\Properties\AssemblyInfo.cs) \
+		-replace 'Version\(.*\)', 'Version(""$(DOCKPANELSUITE_VERSION)"""")' | \
+		Out-File $(MAKEDIR)\obj\WinFormsUI\Properties\AssemblyInfo.cs -Encoding ascii"
 
 	msbuild \
 		/t:Restore;Build \


### PR DESCRIPTION
Include tag to force Windows Installer to replace existing/ older versions of the file.

This is to address b/359613390, b/360704492, b/360802226