### PR TITLE
b/346148567 Force usage of comctl32 6.0

### DIFF
--- a/sources/Google.Solutions.IapDesktop/app.manifest
+++ b/sources/Google.Solutions.IapDesktop/app.manifest
@@ -17,7 +17,6 @@
   </compatibility>
 
   <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
-  <!--
   <dependency>
     <dependentAssembly>
       <assemblyIdentity
@@ -26,10 +25,7 @@
           version="6.0.0.0"
           processorArchitecture="*"
           publicKeyToken="6595b64144ccf1df"
-          language="*"
-        />
+          language="*"/>
     </dependentAssembly>
   </dependency>
-  -->
-
 </assembly>


### PR DESCRIPTION
Add manifest entry to force the use of comctl32 6.0 across the application. Previously, the application loaded both 6.0 and a downlevel version -- which is unnecessary and a potential source of linking issues.