### PR TITLE
b/372091044 Weak EventQueue subscriptions

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/ToolWindows/ProjectExplorer/TestProjectExplorerViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/ToolWindows/ProjectExplorer/TestProjectExplorerViewModel.cs
@@ -891,13 +891,17 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.ProjectExplor
 
             // Capture event handlers that the view model will register.
             Action<SessionStartedEvent>? sessionStartedEventHandler = null;
-            eventQueue.Setup(e => e.Subscribe(
-                    It.IsAny<Action<SessionStartedEvent>>()))
+            eventQueue
+                .Setup(e => e.Subscribe(
+                    It.IsAny<Action<SessionStartedEvent>>(),
+                    SubscriptionOptions.None))
                 .Callback<Action<SessionStartedEvent>>(e => sessionStartedEventHandler = e);
 
             Action<SessionEndedEvent>? sessionEndedEventHandler = null;
-            eventQueue.Setup(e => e.Subscribe(
-                    It.IsAny<Action<SessionEndedEvent>>()))
+            eventQueue
+                .Setup(e => e.Subscribe(
+                    It.IsAny<Action<SessionEndedEvent>>(),
+                    SubscriptionOptions.None))
                 .Callback<Action<SessionEndedEvent>>(e => sessionEndedEventHandler = e);
 
             var viewModel = CreateViewModel(
@@ -1019,7 +1023,9 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.ProjectExplor
 
             Func<InstanceStateChangedEvent, Task>? eventHandler = null;
             eventQueue
-                .Setup(e => e.Subscribe(It.IsAny<Func<InstanceStateChangedEvent, Task>>()))
+                .Setup(e => e.Subscribe(
+                    It.IsAny<Func<InstanceStateChangedEvent, Task>>(),
+                    SubscriptionOptions.None))
                 .Callback<Func<InstanceStateChangedEvent, Task>>(e => eventHandler = e);
 
             var computeClient = CreateComputeEngineClient();

--- a/sources/Google.Solutions.IapDesktop.Application.Test/ToolWindows/ProjectExplorer/TestProjectExplorerViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/ToolWindows/ProjectExplorer/TestProjectExplorerViewModel.cs
@@ -895,7 +895,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.ProjectExplor
                 .Setup(e => e.Subscribe(
                     It.IsAny<Action<SessionStartedEvent>>(),
                     SubscriptionOptions.None))
-                .Callback<Action<SessionStartedEvent>>(e => sessionStartedEventHandler = e);
+                .Callback<Action<SessionStartedEvent>, SubscriptionOptions>((e, _) => sessionStartedEventHandler = e);
 
             Action<SessionEndedEvent>? sessionEndedEventHandler = null;
             eventQueue
@@ -1026,7 +1026,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.ProjectExplor
                 .Setup(e => e.Subscribe(
                     It.IsAny<Func<InstanceStateChangedEvent, Task>>(),
                     SubscriptionOptions.None))
-                .Callback<Func<InstanceStateChangedEvent, Task>>(e => eventHandler = e);
+                .Callback<Func<InstanceStateChangedEvent, Task>, SubscriptionOptions>((e, _) => eventHandler = e);
 
             var computeClient = CreateComputeEngineClient();
             var viewModel = CreateViewModel(

--- a/sources/Google.Solutions.IapDesktop.Application.Test/ToolWindows/ProjectExplorer/TestProjectExplorerViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/ToolWindows/ProjectExplorer/TestProjectExplorerViewModel.cs
@@ -902,7 +902,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.ProjectExplor
                 .Setup(e => e.Subscribe(
                     It.IsAny<Action<SessionEndedEvent>>(),
                     SubscriptionOptions.None))
-                .Callback<Action<SessionEndedEvent>>(e => sessionEndedEventHandler = e);
+                .Callback<Action<SessionEndedEvent>, SubscriptionOptions>((e, _) => sessionEndedEventHandler = e);
 
             var viewModel = CreateViewModel(
                 CreateComputeEngineClient().Object,

--- a/sources/Google.Solutions.IapDesktop.Core.Test/ObjectModel/TestEventQueue.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ObjectModel/TestEventQueue.cs
@@ -40,11 +40,35 @@ namespace Google.Solutions.IapDesktop.Core.Test.ObjectModel
         //---------------------------------------------------------------------
 
         [Test]
-        public void Subscribe()
+        public void Subscribe_StrongSubscriberReference()
         {
             var queue = new EventQueue(new Mock<ISynchronizeInvoke>().Object);
-            using (queue.Subscribe<EventOne>(e => { }))
-            using (queue.Subscribe<EventOne>(e => { }))
+            using (queue.Subscribe<EventOne>(e => { }, SubscriptionOptions.None))
+            {
+                var sub = queue.GetSubscriptions<EventOne>().First();
+                Assert.IsInstanceOf<EventQueue.Subscription<EventOne>>(sub);
+            }
+        }
+
+        [Test]
+        public void Subscribe_WeakSubscriberReference()
+        {
+            var queue = new EventQueue(new Mock<ISynchronizeInvoke>().Object);
+            using (queue.Subscribe<EventOne>(e => { }, SubscriptionOptions.WeakSubscriberReference))
+            {
+                var sub = queue.GetSubscriptions<EventOne>().First();
+                Assert.IsInstanceOf<EventQueue.WeakSubscription<EventOne>>(sub);
+            }
+        }
+
+        [Test]
+        public void Subscribe(
+            [Values(SubscriptionOptions.None, SubscriptionOptions.WeakSubscriberReference)]
+            SubscriptionOptions options)
+        {
+            var queue = new EventQueue(new Mock<ISynchronizeInvoke>().Object);
+            using (queue.Subscribe<EventOne>(e => { }, options))
+            using (queue.Subscribe<EventOne>(e => { }, options))
             {
                 Assert.AreEqual(2, queue.GetSubscriptions<EventOne>().Count());
                 Assert.AreEqual(0, queue.GetSubscriptions<EventTwo>().Count());

--- a/sources/Google.Solutions.IapDesktop.Core.Test/ObjectModel/TestEventQueue.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ObjectModel/TestEventQueue.cs
@@ -77,7 +77,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ObjectModel
                 queue.Subscribe<EventOne>(e => { invoked = true; });
             sub.Dispose();
 
-            sub.Invoke(new EventOne());
+            sub.InvokeAsync(new EventOne());
             Assert.IsFalse(invoked);
         }
 

--- a/sources/Google.Solutions.IapDesktop.Core/ObjectModel/EventQueue.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ObjectModel/EventQueue.cs
@@ -28,6 +28,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Google.Solutions.IapDesktop.Core.ObjectModel
@@ -38,6 +39,10 @@ namespace Google.Solutions.IapDesktop.Core.ObjectModel
         private readonly object subscriptionsLock;
         private readonly IDictionary<Type, List<ISubscription>> subscriptionsByEvent;
 
+        /// <summary>
+        /// Create an event queue.
+        /// </summary>
+        /// <param name="invoker">Invoker to use for publishing events</param>
         public EventQueue(ISynchronizeInvoke invoker)
         {
             this.invoker = invoker.ExpectNotNull(nameof(invoker));
@@ -59,7 +64,7 @@ namespace Google.Solutions.IapDesktop.Core.ObjectModel
             }
         }
 
-        internal IEnumerable<ISubscription<TEvent>> GetSubscriptions<TEvent>()
+        internal IEnumerable<Subscription<TEvent>> GetSubscriptions<TEvent>()
         {
             lock (this.subscriptionsLock)
             {
@@ -69,12 +74,12 @@ namespace Google.Solutions.IapDesktop.Core.ObjectModel
                     // Create a snapshot that remains valid when
                     // we leave the lock.
                     //
-                    return new List<ISubscription<TEvent>>(
-                        subscriptions.OfType<ISubscription<TEvent>>());
+                    return new List<Subscription<TEvent>>(
+                        subscriptions.OfType<Subscription<TEvent>>());
                 }
                 else
                 {
-                    return Enumerable.Empty<ISubscription<TEvent>>();
+                    return Enumerable.Empty<Subscription<TEvent>>();
                 }
             }
         }
@@ -95,14 +100,14 @@ namespace Google.Solutions.IapDesktop.Core.ObjectModel
                     this.subscriptionsByEvent.Add(typeof(TEvent), subscriptions);
                 }
 
-                ISubscription<TEvent> subsciption;
+                Subscription<TEvent> subsciption;
                 if (lifecycle == SubscriptionOptions.WeakSubscriberReference)
                 {
-                    subsciption = new WeakSubscription<TEvent>(handler);
+                    subsciption = new WeakSubscription<TEvent>(this, handler);
                 }
                 else
                 {
-                    subsciption = new Subscription<TEvent>(this, handler);
+                    subsciption = new StrongSubscription<TEvent>(this, handler);
                 }
 
                 subscriptions.Add(subsciption);
@@ -144,9 +149,6 @@ namespace Google.Solutions.IapDesktop.Core.ObjectModel
                 });
         }
 
-        /// <summary>
-        /// Publish an event without awaiting subcribers.
-        /// </summary>
         public void Publish<TEvent>(TEvent eventObject)
         {
             _ = PublishAsync(eventObject)
@@ -158,38 +160,33 @@ namespace Google.Solutions.IapDesktop.Core.ObjectModel
                             "One or more subscribers failed to handle an event: " + t.Exception);
                         CoreTraceSource.Log.TraceError(t.Exception);
                     },
-                    TaskContinuationOptions.OnlyOnFaulted);
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnFaulted,
+                    TaskScheduler.Default);
         }
 
         //---------------------------------------------------------------------
         // Inner classes.
         //---------------------------------------------------------------------
 
-        internal interface ISubscription<TEvent> : ISubscription
-        {
-            Task InvokeAsync(TEvent e);
-        }
-
         /// <summary>
-        /// Normal subscription that remains valid until disposed.
+        /// Base class for subscriptions.
         /// </summary>
-        internal sealed class Subscription<TEvent> : ISubscription<TEvent>
+        internal abstract class Subscription<TEvent> : ISubscription
         {
-            private bool unsubscribed = false;
+            private bool disposed = false;
             private readonly EventQueue queue;
-            private readonly Func<TEvent, Task> callback;
 
-            public Subscription(
-                EventQueue queue,
-                Func<TEvent, Task> callback)
+            protected Subscription(EventQueue queue)
             {
                 this.queue = queue.ExpectNotNull(nameof(queue));
-                this.callback = callback.ExpectNotNull(nameof(callback));
             }
+
+            protected abstract Task InvokeCoreAsync(TEvent e);
 
             public Task InvokeAsync(TEvent e)
             {
-                if (this.unsubscribed)
+                if (this.disposed)
                 {
                     //
                     // Subscription is stale, ignore.
@@ -197,33 +194,59 @@ namespace Google.Solutions.IapDesktop.Core.ObjectModel
                     return Task.CompletedTask;
                 }
 
-                return this.callback.Invoke(e);
+                return InvokeCoreAsync(e);
             }
 
             public void Dispose()
             {
-                var removed = this.queue.Unsubscribe<TEvent>(this);
-                Debug.Assert(removed);
+                if (!this.disposed)
+                {
+                    var removed = this.queue.Unsubscribe<TEvent>(this);
+                    Debug.Assert(removed);
 
-                this.unsubscribed = true;
+                    this.disposed = true;
+                }
             }
         }
 
         /// <summary>
-        /// Weak subscription that remains valid until the callback
-        /// delegate is garbage-collected.
+        /// Normal subscription that uses a strong reference to the subscriber.
         /// </summary>
-        internal sealed class WeakSubscription<TEvent> : ISubscription<TEvent>
+        internal sealed class StrongSubscription<TEvent> : Subscription<TEvent>
+        {
+            private readonly Func<TEvent, Task> callback;
+
+            public StrongSubscription(
+                EventQueue queue,
+                Func<TEvent, Task> callback)
+                : base(queue)
+            {
+                this.callback = callback.ExpectNotNull(nameof(callback));
+            }
+
+            protected override Task InvokeCoreAsync(TEvent e)
+            {
+                return this.callback.Invoke(e);
+            }
+        }
+
+        /// <summary>
+        /// Weak subscription that avoids keeping the subscriber alive.
+        /// </summary>
+        internal sealed class WeakSubscription<TEvent> : Subscription<TEvent>
         {
             private readonly WeakReference<Func<TEvent, Task>> callback;
 
-            public WeakSubscription(Func<TEvent, Task> callback)
+            public WeakSubscription(
+                EventQueue queue, 
+                Func<TEvent, Task> callback)
+                : base(queue)
             {
                 this.callback = new WeakReference<Func<TEvent, Task>>(
                     callback.ExpectNotNull(nameof(callback)));
             }
 
-            public Task InvokeAsync(TEvent e)
+            protected override Task InvokeCoreAsync(TEvent e)
             {
                 if (this.callback.TryGetTarget(out var target))
                 {
@@ -231,12 +254,21 @@ namespace Google.Solutions.IapDesktop.Core.ObjectModel
                 }
                 else
                 {
+                    //
+                    // The subscriber is gone, remove this subscription
+                    // so that the list of subscriber doesn't grow unbounded.
+                    //
+                    Dispose();
                     return Task.CompletedTask;
                 }
             }
 
-            public void Dispose()
+            /// <summary>
+            /// For testing only: Simulate that the subscriber was GC'ed.
+            /// </summary>
+            internal void SimulateSubscriberWasGarbageCollected()
             {
+                this.callback.SetTarget(null!);
             }
         }
     }

--- a/sources/Google.Solutions.IapDesktop.Core/ObjectModel/IEventQueue.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ObjectModel/IEventQueue.cs
@@ -1,0 +1,66 @@
+﻿//
+// Copyright 2020 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.IapDesktop.Core.ObjectModel
+{
+    /// <summary>
+    /// Publishes events to subscribers.
+    /// 
+    /// There are multiple differences to regular C#/CLR events:
+    /// 
+    /// * Events can be emitted from any thread, but subscribers
+    ///   are guaranteed to be invoked on a specific thread, 
+    ///   effectively resulting in queueing semantics.
+    /// * Event handlers can be asynchronous.
+    /// * Subscribing to an event doesn't keep the source alive.
+    /// 
+    /// </summary>
+    public interface IEventQueue
+    {
+        /// <summary>
+        /// Subscribe to an event using an asynchronous handler
+        /// until the subscription is disposed.
+        /// </summary>
+        ISubscription Subscribe<TEvent>(Func<TEvent, Task> handler);
+
+        /// <summary>
+        /// Subscribe to an event using an synchronous handler
+        /// until the subscription is disposed.
+        /// </summary>
+        ISubscription Subscribe<TEvent>(Action<TEvent> handler);
+
+        /// <summary>
+        /// Publish an event and wait for all subscribers to handle the event.
+        /// </summary>
+        Task PublishAsync<TEvent>(TEvent eventObject);
+
+        /// <summary>
+        /// Publish an event without awaiting subcribers.
+        /// </summary>
+        void Publish<TEvent>(TEvent eventObject);
+    }
+
+    public interface ISubscription : IDisposable
+    { }
+}

--- a/sources/Google.Solutions.IapDesktop.Core/ObjectModel/IEventQueue.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ObjectModel/IEventQueue.cs
@@ -39,16 +39,18 @@ namespace Google.Solutions.IapDesktop.Core.ObjectModel
     public interface IEventQueue
     {
         /// <summary>
-        /// Subscribe to an event using an asynchronous handler
-        /// until the subscription is disposed.
+        /// Subscribe to an event using an asynchronous handler.
         /// </summary>
-        ISubscription Subscribe<TEvent>(Func<TEvent, Task> handler);
+        ISubscription Subscribe<TEvent>(
+            Func<TEvent, Task> handler,
+            SubscriptionOptions subscriberReference = SubscriptionOptions.None);
 
         /// <summary>
-        /// Subscribe to an event using an synchronous handler
-        /// until the subscription is disposed.
+        /// Subscribe to an event using an synchronous handler.
         /// </summary>
-        ISubscription Subscribe<TEvent>(Action<TEvent> handler);
+        ISubscription Subscribe<TEvent>(
+            Action<TEvent> handler,
+            SubscriptionOptions subscriberReference = SubscriptionOptions.None);
 
         /// <summary>
         /// Publish an event and wait for all subscribers to handle the event.
@@ -59,6 +61,20 @@ namespace Google.Solutions.IapDesktop.Core.ObjectModel
         /// Publish an event without awaiting subcribers.
         /// </summary>
         void Publish<TEvent>(TEvent eventObject);
+    }
+
+    public enum SubscriptionOptions
+    {
+        /// <summary>
+        /// Use default behavior and keep the subscriber alive until 
+        /// the subscription is disposed.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Use a weak reference for the subscriber.
+        /// </summary>
+        WeakSubscriberReference
     }
 
     public interface ISubscription : IDisposable

--- a/sources/Google.Solutions.IapDesktop.Core/ObjectModel/IEventQueue.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ObjectModel/IEventQueue.cs
@@ -77,6 +77,9 @@ namespace Google.Solutions.IapDesktop.Core.ObjectModel
         WeakSubscriberReference
     }
 
+    /// <summary>
+    /// Event subscription. Disposing the object removes the subscription.
+    /// </summary>
     public interface ISubscription : IDisposable
     { }
 }


### PR DESCRIPTION
Extend `EventQueue` to support weak subscriptions that avoid keeping the subsribing object alive.