### PR TITLE
b/345335944 Rename interface to IPseudoTerminal

### DIFF
--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ProcessFactory.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ProcessFactory.cs
@@ -66,7 +66,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
                 Assert.IsNotNull(process.Handle);
                 Assert.IsFalse(process.Handle.IsInvalid);
                 Assert.IsNull(process.Job);
-                Assert.IsNull(process.PseudoConsole);
+                Assert.IsNull(process.PseudoTerminal);
 
                 process.Terminate(1);
             }
@@ -103,7 +103,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
             Assert.Throws<DispatchException>(() => factory.CreateProcessWithPseudoConsole(
                 "doesnotexist.exe",
                 null,
-                PseudoConsoleSize.Default));
+                PseudoTerminalSize.Default));
         }
 
         [Test]
@@ -114,14 +114,14 @@ namespace Google.Solutions.Platform.Test.Dispatch
             using (var process = factory.CreateProcessWithPseudoConsole(
                 CmdExe,
                 null,
-                PseudoConsoleSize.Default))
+                PseudoTerminalSize.Default))
             {
                 Assert.IsNotNull(process.Handle);
                 Assert.IsFalse(process.Handle.IsInvalid);
                 Assert.IsNull(process.Job);
 
-                Assert.IsNotNull(process.PseudoConsole);
-                Assert.IsFalse(process.PseudoConsole!.IsClosed);
+                Assert.IsNotNull(process.PseudoTerminal);
+                Assert.IsFalse(process.PseudoTerminal!.IsClosed);
 
                 process.Terminate(1);
             }
@@ -142,7 +142,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
                 () => factory.CreateProcessWithPseudoConsole(
                     CmdExe,
                     null,
-                    PseudoConsoleSize.Default));
+                    PseudoTerminalSize.Default));
 
             Assert.IsNotNull(createdProcess);
             Assert.IsTrue(((Win32Process)createdProcess!).IsDisposed);

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32PseudoConsole.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32PseudoConsole.cs
@@ -42,10 +42,10 @@ namespace Google.Solutions.Platform.Test.Dispatch
             using (var process = factory.CreateProcessWithPseudoConsole(
                 "powershell.exe",
                 null,
-                PseudoConsoleSize.Default))
+                PseudoTerminalSize.Default))
             {
-                Assert.IsNotNull(process.PseudoConsole);
-                var pty = process.PseudoConsole!;
+                Assert.IsNotNull(process.PseudoTerminal);
+                var pty = process.PseudoTerminal!;
 
                 var output = new StringBuilder();
                 pty.OutputAvailable += (_, args) =>
@@ -82,10 +82,10 @@ namespace Google.Solutions.Platform.Test.Dispatch
             using (var process = factory.CreateProcessWithPseudoConsole(
                 "powershell.exe",
                 null,
-                PseudoConsoleSize.Default))
+                PseudoTerminalSize.Default))
             {
-                Assert.IsNotNull(process.PseudoConsole);
-                var pty = process.PseudoConsole!;
+                Assert.IsNotNull(process.PseudoTerminal);
+                var pty = process.PseudoTerminal!;
 
                 var eventRaised = false;
                 pty.Disconnected += (_, __) => eventRaised = true;
@@ -105,7 +105,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         [Test]
         public async Task Close_KeepsStreamOpen()
         {
-            using (var pty = new Win32PseudoConsole(new PseudoConsoleSize(80, 24)))
+            using (var pty = new Win32PseudoConsole(new PseudoTerminalSize(80, 24)))
             {
                 Assert.IsFalse(pty.IsClosed);
 
@@ -132,10 +132,10 @@ namespace Google.Solutions.Platform.Test.Dispatch
             using (var process = factory.CreateProcessWithPseudoConsole(
                 "powershell.exe",
                 null,
-                PseudoConsoleSize.Default))
+                PseudoTerminalSize.Default))
             {
-                Assert.IsNotNull(process.PseudoConsole);
-                using (var pty = process.PseudoConsole!)
+                Assert.IsNotNull(process.PseudoTerminal);
+                using (var pty = process.PseudoTerminal!)
                 {
                 }
             }
@@ -144,7 +144,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         [Test]
         public void Dispose_ClosesStreams()
         {
-            var pty = new Win32PseudoConsole(new PseudoConsoleSize(80, 24));
+            var pty = new Win32PseudoConsole(new PseudoTerminalSize(80, 24));
             pty.Dispose();
 
             Assert.IsTrue(pty.IsClosed);

--- a/sources/Google.Solutions.Platform.Test/IO/TestPseudoTerminaSize.cs
+++ b/sources/Google.Solutions.Platform.Test/IO/TestPseudoTerminaSize.cs
@@ -25,12 +25,12 @@ using NUnit.Framework;
 namespace Google.Solutions.Platform.Test.IO
 {
     [TestFixture]
-    public class TestPseudoConsoleSize
+    public class TestPseudoTerminaSize
     {
         [Test]
         public void ToString_ReturnsSize()
         {
-            Assert.AreEqual("80x24", new PseudoConsoleSize(80, 24).ToString());
+            Assert.AreEqual("80x24", new PseudoTerminalSize(80, 24).ToString());
         }
     }
 }

--- a/sources/Google.Solutions.Platform.Test/IO/TestPseudoTerminalException.cs
+++ b/sources/Google.Solutions.Platform.Test/IO/TestPseudoTerminalException.cs
@@ -20,30 +20,20 @@
 //
 
 using Google.Solutions.Platform.Interop;
-using System;
-using System.IO;
-using System.Runtime.InteropServices;
+using Google.Solutions.Platform.IO;
+using NUnit.Framework;
 
-namespace Google.Solutions.Platform.IO
+namespace Google.Solutions.Platform.Test.IO
 {
-    public class PseudoConsoleException : IOException
+    [TestFixture]
+    public class TestPseudoTerminalException
     {
-        public PseudoConsoleException(string message) : base(message)
+        [Test]
+        public void FromHresult()
         {
-        }
-
-        public PseudoConsoleException(string message, Exception innerException)
-            : base(message, innerException)
-        {
-        }
-
-        internal static PseudoConsoleException FromHresult(
-            HRESULT hresult,
-            string message)
-        {
-            return new PseudoConsoleException(
-                $"{message} (HRESULT 0x{hresult:X})",
-                new ExternalException(message, (int)hresult));
+            var e = PseudoTerminalException.FromHresult(HRESULT.E_UNEXPECTED, "message");
+            StringAssert.Contains("message", e.Message);
+            StringAssert.Contains("0x8000FFFF", e.Message);
         }
     }
 }

--- a/sources/Google.Solutions.Platform/Dispatch/IWin32Process.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/IWin32Process.cs
@@ -101,8 +101,8 @@ namespace Google.Solutions.Platform.Dispatch
         IWtsSession Session { get; }
 
         /// <summary>
-        /// Pseudo-console for this process, if any.
+        /// Pseudo-terminal for this process, if any.
         /// </summary>
-        IPseudoConsole? PseudoConsole { get; }
+        IPseudoTerminal? PseudoTerminal { get; }
     }
 }

--- a/sources/Google.Solutions.Platform/Dispatch/Win32Process.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32Process.cs
@@ -140,7 +140,7 @@ namespace Google.Solutions.Platform.Dispatch
 
         public IWin32Job? Job { get; internal set; }
 
-        public IPseudoConsole? PseudoConsole { get; internal set; }
+        public IPseudoTerminal? PseudoTerminal { get; internal set; }
 
         public bool IsRunning
         {
@@ -291,7 +291,7 @@ namespace Google.Solutions.Platform.Dispatch
             this.process.Close();
 
             this.processExitedWaitHandle.Unregister(this.WaitHandle);
-            this.PseudoConsole?.Dispose();
+            this.PseudoTerminal?.Dispose();
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.Platform/Dispatch/Win32ProcessFactory.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32ProcessFactory.cs
@@ -53,7 +53,7 @@ namespace Google.Solutions.Platform.Dispatch
         IWin32Process CreateProcessWithPseudoConsole(
             string executable,
             string? arguments,
-            PseudoConsoleSize pseudoConsoleSize);
+            PseudoTerminalSize pseudoConsoleSize);
 
         /// <summary>
         /// Start a new process as a different user.
@@ -151,7 +151,7 @@ namespace Google.Solutions.Platform.Dispatch
         public IWin32Process CreateProcessWithPseudoConsole(
             string executable,
             string? arguments,
-            PseudoConsoleSize pseudoConsoleSize)
+            PseudoTerminalSize pseudoConsoleSize)
         {
             using (PlatformTraceSource.Log.TraceMethod()
                 .WithParameters(executable, arguments))
@@ -244,7 +244,7 @@ namespace Google.Solutions.Platform.Dispatch
                             new SafeProcessHandle(processInfo.hProcess, true),
                             new SafeThreadHandle(processInfo.hThread, true))
                         {
-                            PseudoConsole = pseudoConsole
+                            PseudoTerminal = pseudoConsole
                         };
 
                         process.Exited += (_, __) =>

--- a/sources/Google.Solutions.Platform/Dispatch/Win32PseudoConsole.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32PseudoConsole.cs
@@ -39,7 +39,7 @@ namespace Google.Solutions.Platform.Dispatch
     /// 
     /// Note: Pseudo consoles don't work properly in NUnit tests!
     /// </summary>
-    public class Win32PseudoConsole : DisposableBase, IPseudoConsole
+    public class Win32PseudoConsole : DisposableBase, IPseudoTerminal
     {
         /// <summary>
         /// Encoding used by terminal, which is always UTF-8 (not UCS-2!) 
@@ -55,7 +55,7 @@ namespace Google.Solutions.Platform.Dispatch
         internal AnonymousPipe OutputPipe { get; }
         internal PseudoConsoleHandle Handle { get; }
 
-        public Win32PseudoConsole(PseudoConsoleSize size)
+        public Win32PseudoConsole(PseudoTerminalSize size)
         {
             var stdin = new AnonymousPipe();
             var stdout = new AnonymousPipe();
@@ -76,7 +76,7 @@ namespace Google.Solutions.Platform.Dispatch
                         out var handle);
                     if (hresult.Failed())
                     {
-                        throw PseudoConsoleException.FromHresult(
+                        throw PseudoTerminalException.FromHresult(
                             hresult,
                             "Failed to create pseudo console");
                     }
@@ -97,7 +97,7 @@ namespace Google.Solutions.Platform.Dispatch
                 }
                 catch (EntryPointNotFoundException)
                 {
-                    throw new PseudoConsoleException(
+                    throw new PseudoTerminalException(
                         "This feature requires Windows 10 version 1809 or newer");
                 }
             }
@@ -132,7 +132,7 @@ namespace Google.Solutions.Platform.Dispatch
                     {
                         this.OutputAvailable?.Invoke(
                             this,
-                            new PseudoConsoleDataEventArgs(new string(buffer, 0, charsRead)));
+                            new PseudoTerminalDataEventArgs(new string(buffer, 0, charsRead)));
                     }
                 }
                 catch (Exception) when (this.IsDisposed)
@@ -141,7 +141,7 @@ namespace Google.Solutions.Platform.Dispatch
                 {
                     this.FatalError?.Invoke(
                         this,
-                        new PseudoConsoleErrorEventArgs(e));
+                        new PseudoTerminalErrorEventArgs(e));
                 }
             }
         }
@@ -158,16 +158,16 @@ namespace Google.Solutions.Platform.Dispatch
         // IPseudoTerminal.
         //---------------------------------------------------------------------
 
-        public event EventHandler<PseudoConsoleDataEventArgs>? OutputAvailable;
+        public event EventHandler<PseudoTerminalDataEventArgs>? OutputAvailable;
 
-        public event EventHandler<PseudoConsoleErrorEventArgs>? FatalError;
+        public event EventHandler<PseudoTerminalErrorEventArgs>? FatalError;
 
         public event EventHandler<EventArgs>? Disconnected;
 
         public bool IsClosed { get; private set; }
 
         public Task ResizeAsync(
-            PseudoConsoleSize size,
+            PseudoTerminalSize size,
             CancellationToken cancellationToken)
         {
             ExpectNotClosed();
@@ -183,7 +183,7 @@ namespace Google.Solutions.Platform.Dispatch
                     });
                 if (hresult.Failed())
                 {
-                    throw PseudoConsoleException.FromHresult(
+                    throw PseudoTerminalException.FromHresult(
                         hresult,
                         "Failed to resize pseudo console");
                 }

--- a/sources/Google.Solutions.Platform/IO/IPseudoTerminal.cs
+++ b/sources/Google.Solutions.Platform/IO/IPseudoTerminal.cs
@@ -27,17 +27,17 @@ using System.Threading.Tasks;
 namespace Google.Solutions.Platform.IO
 {
     /// <summary>
-    /// A pseudo-console that accepts and produces VT/xterm-formatted
+    /// A pseudo-terminal or pty that accepts and produces VT/xterm-formatted
     /// input and output.
     /// </summary>
-    public interface IPseudoConsole : IDisposable
+    public interface IPseudoTerminal : IDisposable
     {
         /// <summary>
         /// Raised when output is available.
         /// 
         /// The event can be delivered on any thread.
         /// </summary>
-        event EventHandler<PseudoConsoleDataEventArgs>? OutputAvailable;
+        event EventHandler<PseudoTerminalDataEventArgs>? OutputAvailable;
 
         /// <summary>
         /// Raised when a fatal error occured. After a fatal error,
@@ -45,7 +45,7 @@ namespace Google.Solutions.Platform.IO
         /// 
         /// The event can be delivered on any thread
         /// </summary>
-        event EventHandler<PseudoConsoleErrorEventArgs>? FatalError;
+        event EventHandler<PseudoTerminalErrorEventArgs>? FatalError;
 
         /// <summary>
         /// Raised when the console was disconnected.
@@ -64,7 +64,7 @@ namespace Google.Solutions.Platform.IO
         /// Adjust the size of the current session.
         /// </summary>
         Task ResizeAsync(
-            PseudoConsoleSize dimensions,
+            PseudoTerminalSize dimensions,
             CancellationToken cancellationToken);
 
         /// <summary>
@@ -89,11 +89,11 @@ namespace Google.Solutions.Platform.IO
     /// <summary>
     /// Size of a console, in characters.
     /// </summary>
-    public readonly struct PseudoConsoleSize
+    public readonly struct PseudoTerminalSize
     {
-        public static readonly PseudoConsoleSize Default = new PseudoConsoleSize(80, 24);
+        public static readonly PseudoTerminalSize Default = new PseudoTerminalSize(80, 24);
 
-        public PseudoConsoleSize(ushort width, ushort height)
+        public PseudoTerminalSize(ushort width, ushort height)
         {
             Debug.Assert(width > 0 && height > 0);
 
@@ -115,7 +115,7 @@ namespace Google.Solutions.Platform.IO
     /// <summary>
     /// Event data for console data.
     /// </summary>
-    public class PseudoConsoleDataEventArgs : EventArgs
+    public class PseudoTerminalDataEventArgs : EventArgs
     {
         /// <summary>
         /// Xterm-encoded data.
@@ -124,12 +124,12 @@ namespace Google.Solutions.Platform.IO
 
         public bool IsEof { get; private set; }
 
-        public static PseudoConsoleDataEventArgs Eof = new PseudoConsoleDataEventArgs(string.Empty)
+        public static PseudoTerminalDataEventArgs Eof = new PseudoTerminalDataEventArgs(string.Empty)
         {
             IsEof = true
         };
 
-        public PseudoConsoleDataEventArgs(string data)
+        public PseudoTerminalDataEventArgs(string data)
         {
             this.Data = data;
         }
@@ -138,11 +138,11 @@ namespace Google.Solutions.Platform.IO
     /// <summary>
     /// Event data for a console error.
     /// </summary>
-    public class PseudoConsoleErrorEventArgs : EventArgs
+    public class PseudoTerminalErrorEventArgs : EventArgs
     {
         public Exception Exception { get; }
 
-        public PseudoConsoleErrorEventArgs(Exception exception)
+        public PseudoTerminalErrorEventArgs(Exception exception)
         {
             this.Exception = exception;
         }

--- a/sources/Google.Solutions.Platform/IO/PseudoTerminalException.cs
+++ b/sources/Google.Solutions.Platform/IO/PseudoTerminalException.cs
@@ -20,20 +20,30 @@
 //
 
 using Google.Solutions.Platform.Interop;
-using Google.Solutions.Platform.IO;
-using NUnit.Framework;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
 
-namespace Google.Solutions.Platform.Test.IO
+namespace Google.Solutions.Platform.IO
 {
-    [TestFixture]
-    public class TestPseudoConsoleException
+    public class PseudoTerminalException : IOException
     {
-        [Test]
-        public void FromHresult()
+        public PseudoTerminalException(string message) : base(message)
         {
-            var e = PseudoConsoleException.FromHresult(HRESULT.E_UNEXPECTED, "message");
-            StringAssert.Contains("message", e.Message);
-            StringAssert.Contains("0x8000FFFF", e.Message);
+        }
+
+        public PseudoTerminalException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        internal static PseudoTerminalException FromHresult(
+            HRESULT hresult,
+            string message)
+        {
+            return new PseudoTerminalException(
+                $"{message} (HRESULT 0x{hresult:X})",
+                new ExternalException(message, (int)hresult));
         }
     }
 }

--- a/sources/Google.Solutions.Terminal.Test/Controls/TestTerminalDeviceBinding.cs
+++ b/sources/Google.Solutions.Terminal.Test/Controls/TestTerminalDeviceBinding.cs
@@ -38,7 +38,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [Test]
         public void OnTerminalDisposed_WhenTerminalDisposed_DisposesDevice()
         {
-            var device = new Mock<IPseudoConsole>();
+            var device = new Mock<IPseudoTerminal>();
             var virtualTerminal = new VirtualTerminal()
             {
                 Device = device.Object,
@@ -56,7 +56,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [Test]
         public void OnTerminalUserInput_WritesToDevice()
         {
-            var device = new Mock<IPseudoConsole>();
+            var device = new Mock<IPseudoTerminal>();
             using (var virtualTerminal = new VirtualTerminal()
             {
                 Device = device.Object,
@@ -74,7 +74,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [Test]
         public void OnTerminalUserInput_WhenDeviceIsClosed_ThenDoesNotWriteToDevice()
         {
-            var device = new Mock<IPseudoConsole>();
+            var device = new Mock<IPseudoTerminal>();
             device.SetupGet(d => d.IsClosed).Returns(true);
 
             using (var virtualTerminal = new VirtualTerminal()
@@ -94,7 +94,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [Test]
         public void OnTerminalUserInput_WhenDeviceFails_ThenRaisesEvent()
         {
-            var device = new Mock<IPseudoConsole>();
+            var device = new Mock<IPseudoTerminal>();
             device
                 .Setup(d => d.WriteAsync(
                     It.IsAny<string>(),
@@ -123,17 +123,17 @@ namespace Google.Solutions.Terminal.Test.Controls
         [Test]
         public void OnTerminalDimensionsChanged_ResizesDevice()
         {
-            var device = new Mock<IPseudoConsole>();
+            var device = new Mock<IPseudoTerminal>();
             using (var virtualTerminal = new VirtualTerminal()
             {
                 Device = device.Object,
             })
             {
-                virtualTerminal.Dimensions = new PseudoConsoleSize(81, 25);
+                virtualTerminal.Dimensions = new PseudoTerminalSize(81, 25);
             }
 
             device.Verify(d => d.ResizeAsync(
-                    It.Is<PseudoConsoleSize>(s => s.Width == 81),
+                    It.Is<PseudoTerminalSize>(s => s.Width == 81),
                     It.IsAny<CancellationToken>()),
                 Times.Once);
         }
@@ -141,7 +141,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [Test]
         public void OnTerminalDimensionsChanged_WhenDeviceIsClosed_ThenDoesNotResizeDevice()
         {
-            var device = new Mock<IPseudoConsole>();
+            var device = new Mock<IPseudoTerminal>();
             device.SetupGet(d => d.IsClosed).Returns(true);
 
             using (var virtualTerminal = new VirtualTerminal()
@@ -149,11 +149,11 @@ namespace Google.Solutions.Terminal.Test.Controls
                 Device = device.Object,
             })
             {
-                virtualTerminal.Dimensions = new PseudoConsoleSize(81, 25);
+                virtualTerminal.Dimensions = new PseudoTerminalSize(81, 25);
             }
 
             device.Verify(d => d.ResizeAsync(
-                    It.IsAny<PseudoConsoleSize>(),
+                    It.IsAny<PseudoTerminalSize>(),
                     It.IsAny<CancellationToken>()),
                 Times.Never);
         }
@@ -161,10 +161,10 @@ namespace Google.Solutions.Terminal.Test.Controls
         [Test]
         public void OnTerminalDimensionsChanged_WhenDeviceResizeFails_ThenRaisesEvent()
         {
-            var device = new Mock<IPseudoConsole>();
+            var device = new Mock<IPseudoTerminal>();
             device
                 .Setup(d => d.ResizeAsync(
-                    It.IsAny<PseudoConsoleSize>(),
+                    It.IsAny<PseudoTerminalSize>(),
                     It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new ArgumentException("mock"));
 
@@ -176,7 +176,7 @@ namespace Google.Solutions.Terminal.Test.Controls
                 Exception exception = null;
                 virtualTerminal.DeviceError += (_, args) => exception = args.Exception;
 
-                virtualTerminal.Dimensions = new PseudoConsoleSize(81, 25);
+                virtualTerminal.Dimensions = new PseudoTerminalSize(81, 25);
 
                 Assert.IsNotNull(exception);
                 Assert.IsInstanceOf<ArgumentException>(exception);
@@ -190,7 +190,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [Test]
         public void OnDeviceError_RaisesEvent()
         {
-            var device = new Mock<IPseudoConsole>();
+            var device = new Mock<IPseudoTerminal>();
             using (var virtualTerminal = new VirtualTerminal()
             {
                 Device = device.Object,
@@ -201,7 +201,7 @@ namespace Google.Solutions.Terminal.Test.Controls
 
                 device.Raise(
                     d => d.FatalError += null, 
-                    new PseudoConsoleErrorEventArgs(new ArgumentException()));
+                    new PseudoTerminalErrorEventArgs(new ArgumentException()));
 
                 Assert.IsNotNull(exception);
                 Assert.IsInstanceOf<ArgumentException>(exception);
@@ -215,7 +215,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [Test]
         public void OnDeviceDisconnected_ClosesDevice()
         {
-            var device = new Mock<IPseudoConsole>();
+            var device = new Mock<IPseudoTerminal>();
             using (var virtualTerminal = new VirtualTerminal()
             {
                 Device = device.Object,
@@ -237,7 +237,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [Test]
         public void OnDeviceOutput_RaisesEvent()
         {
-            var device = new Mock<IPseudoConsole>();
+            var device = new Mock<IPseudoTerminal>();
             using (var virtualTerminal = new VirtualTerminal()
             {
                 Device = device.Object,
@@ -246,7 +246,7 @@ namespace Google.Solutions.Terminal.Test.Controls
                 string data = string.Empty;
                 virtualTerminal.Output += (_, args) => data += args.Data;
 
-                device.Raise(d => d.OutputAvailable += null, new PseudoConsoleDataEventArgs("data"));
+                device.Raise(d => d.OutputAvailable += null, new PseudoTerminalDataEventArgs("data"));
 
                 Assert.AreEqual("data", data);
             }
@@ -255,7 +255,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [Test]
         public void OnDeviceOutput_WhenDeviceReportsEof_ThenRaisesEvent()
         {
-            var device = new Mock<IPseudoConsole>();
+            var device = new Mock<IPseudoTerminal>();
             using (var virtualTerminal = new VirtualTerminal()
             {
                 Device = device.Object,
@@ -264,7 +264,7 @@ namespace Google.Solutions.Terminal.Test.Controls
                 var deviceClosed = false;
                 virtualTerminal.DeviceClosed += (_, args) => deviceClosed = true;
 
-                device.Raise(d => d.OutputAvailable += null, PseudoConsoleDataEventArgs.Eof);
+                device.Raise(d => d.OutputAvailable += null, PseudoTerminalDataEventArgs.Eof);
 
                 Assert.IsTrue(deviceClosed);
             }

--- a/sources/Google.Solutions.Terminal.Test/Controls/TestVirtualTerminal.cs
+++ b/sources/Google.Solutions.Terminal.Test/Controls/TestVirtualTerminal.cs
@@ -175,14 +175,14 @@ namespace Google.Solutions.Terminal.Test.Controls
         {
             using (var form = TerminalForm.Create())
             {
-                form.VirtualTerminal.Device = new Mock<IPseudoConsole>().Object;
+                form.VirtualTerminal.Device = new Mock<IPseudoTerminal>().Object;
                 form.Show();
 
                 string receivedData = string.Empty;
                 form.VirtualTerminal.Output += (_, args) => receivedData += args.Data;
 
                 // Change device.
-                form.VirtualTerminal.Device = new Mock<IPseudoConsole>().Object;
+                form.VirtualTerminal.Device = new Mock<IPseudoTerminal>().Object;
 
                 form.Close();
 
@@ -195,13 +195,13 @@ namespace Google.Solutions.Terminal.Test.Controls
         {
             using (var form = TerminalForm.Create())
             {
-                var device = new Mock<IPseudoConsole>();
+                var device = new Mock<IPseudoTerminal>();
 
                 form.VirtualTerminal.Device = device.Object;
                 form.Show();
 
                 // Change device.
-                form.VirtualTerminal.Device = new Mock<IPseudoConsole>().Object;
+                form.VirtualTerminal.Device = new Mock<IPseudoTerminal>().Object;
 
                 form.Close();
 
@@ -212,7 +212,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [Test]
         public void Device_WhenDisposed_ThenDisposesDevice()
         {
-            var device = new Mock<IPseudoConsole>();
+            var device = new Mock<IPseudoTerminal>();
 
             using (var form = TerminalForm.Create())
             {

--- a/sources/Google.Solutions.Terminal.TestApp/Program.cs
+++ b/sources/Google.Solutions.Terminal.TestApp/Program.cs
@@ -71,12 +71,12 @@ namespace Google.Solutions.Terminal.TestApp
                         null,
                         control.Dimensions);
 
-                    process.PseudoConsole!.OutputAvailable += (_, args) =>
+                    process.PseudoTerminal!.OutputAvailable += (_, args) =>
                     {
                         Debug.WriteLine($"PTY: {args.Data}");
                     };
 
-                    control.Device = process.PseudoConsole;
+                    control.Device = process.PseudoTerminal;
 
                     process.Resume();
                 };

--- a/sources/Google.Solutions.Terminal/Controls/TerminalBinding.cs
+++ b/sources/Google.Solutions.Terminal/Controls/TerminalBinding.cs
@@ -28,15 +28,15 @@ using System.Threading;
 namespace Google.Solutions.Terminal.Controls
 {
     /// <summary>
-    /// Connection between a Terminal and a Pty device.
+    /// Connection between a Terminal and a Pty.
     /// </summary>
-    internal class TerminalDeviceBinding : IDisposable
+    internal class TerminalBinding : IDisposable
     {
         private readonly VirtualTerminal terminal;
 
-        internal IPseudoConsole Device { get; }
+        internal IPseudoTerminal Device { get; }
 
-        public TerminalDeviceBinding(VirtualTerminal terminal, IPseudoConsole device)
+        public TerminalBinding(VirtualTerminal terminal, IPseudoTerminal device)
         {
             this.terminal = terminal.ExpectNotNull(nameof(terminal));
             this.Device = device.ExpectNotNull(nameof(device));
@@ -108,7 +108,7 @@ namespace Google.Solutions.Terminal.Controls
             }
         }
 
-        private void OnDeviceError(object sender, PseudoConsoleErrorEventArgs args)
+        private void OnDeviceError(object sender, PseudoTerminalErrorEventArgs args)
         {
             //
             // The device encountered an error.
@@ -116,7 +116,7 @@ namespace Google.Solutions.Terminal.Controls
             this.terminal.ReceiveError(args.Exception);
         }
 
-        private void OnDeviceOutput(object sender, PseudoConsoleDataEventArgs args)
+        private void OnDeviceOutput(object sender, PseudoTerminalDataEventArgs args)
         {
             //
             // The device produced some output. Forward to the terminal

--- a/sources/Google.Solutions.Terminal/Controls/VirtualTerminal.cs
+++ b/sources/Google.Solutions.Terminal/Controls/VirtualTerminal.cs
@@ -48,8 +48,8 @@ namespace Google.Solutions.Terminal.Controls
         private IntPtr terminalHwnd;
         private SubclassCallback? terminalSubclass;
 
-        private PseudoConsoleSize dimensions;
-        private TerminalDeviceBinding? deviceBinding;
+        private PseudoTerminalSize dimensions;
+        private TerminalBinding? deviceBinding;
 
         private readonly NativeMethods.WriteCallback writeCallback;
         private readonly NativeMethods.ScrollCallback scrollCallback;
@@ -180,7 +180,7 @@ namespace Google.Solutions.Terminal.Controls
         /// <summary>
         /// Get or set dimensions of terminal (in characters).
         /// </summary>
-        public PseudoConsoleSize Dimensions
+        public PseudoTerminalSize Dimensions
         {
             get => this.dimensions;
             internal set
@@ -195,7 +195,7 @@ namespace Google.Solutions.Terminal.Controls
         /// <summary>
         /// Get or set the device to interact with.
         /// </summary>
-        public IPseudoConsole? Device
+        public IPseudoTerminal? Device
         {
             get => this.deviceBinding?.Device;
             set
@@ -211,7 +211,7 @@ namespace Google.Solutions.Terminal.Controls
 
                 if (value != null)
                 {
-                    this.deviceBinding = new TerminalDeviceBinding(
+                    this.deviceBinding = new TerminalBinding(
                         this, 
                         value);
                 }
@@ -508,7 +508,7 @@ namespace Google.Solutions.Terminal.Controls
                 Debug.Assert(dimensions.X <= ushort.MaxValue);
                 Debug.Assert(dimensions.Y <= ushort.MaxValue);
 
-                this.Dimensions = new PseudoConsoleSize(
+                this.Dimensions = new PseudoTerminalSize(
                     (ushort)dimensions.X, 
                     (ushort)dimensions.Y);
 


### PR DESCRIPTION
Use term 'pseudo-terminal' instead of 'pseudo-console' as the latter is Windows-specific