### PR TITLE
b/372352359 Add command to sign out of RDP session

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Session/TestSessionCommands.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Session/TestSessionCommands.cs
@@ -296,6 +296,44 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Sessio
         }
 
         //---------------------------------------------------------------------
+        // Logoff.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void Logoff_WhenApplicable_ThenLogoffIsEnabled()
+        {
+            var sessionCommands = new SessionCommands(
+                new Mock<ISessionBroker>().Object);
+
+            var connectedSession = new Mock<IRdpSession>();
+            connectedSession.SetupGet(s => s.IsConnected).Returns(true);
+
+            Assert.AreEqual(
+                CommandState.Enabled,
+                sessionCommands.Logoff.QueryState(connectedSession.Object));
+        }
+
+        [Test]
+        public void Logoff_WhenNotApplicable_ThenLogoffIsDisabled()
+        {
+            var sessionCommands = new SessionCommands(
+                new Mock<ISessionBroker>().Object);
+
+            var closedSession = new Mock<IRdpSession>();
+            closedSession.SetupGet(s => s.IsConnected).Returns(false);
+
+            var sshSession = new Mock<ISshTerminalSession>();
+            sshSession.SetupGet(s => s.IsConnected).Returns(true);
+
+            Assert.AreEqual(
+                CommandState.Disabled,
+                sessionCommands.Logoff.QueryState(closedSession.Object));
+            Assert.AreEqual(
+                CommandState.Disabled,
+                sessionCommands.Logoff.QueryState(sshSession.Object));
+        }
+
+        //---------------------------------------------------------------------
         // TypeClipboardText.
         //---------------------------------------------------------------------
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/InitializeSessionExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/InitializeSessionExtension.cs
@@ -301,6 +301,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session
             menu.AddCommand(sessionCommands.TypeClipboardText);
             menu.AddCommand(sessionCommands.ShowSecurityScreen);
             menu.AddCommand(sessionCommands.ShowTaskManager);
+            menu.AddCommand(sessionCommands.Logoff);
             menu.AddSeparator();
             menu.AddCommand(sessionCommands.Close);
             menu.AddCommand(sessionCommands.CloseAll);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/IRdpSession.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/IRdpSession.cs
@@ -34,6 +34,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Rdp
 
         void ShowTaskManager();
 
+        void Logoff();
+
         void SendText(string text);
 
         bool CanEnterFullScreen { get; }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/RdpView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/RdpView.cs
@@ -547,6 +547,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Rdp
             this.rdpClient.ShowTaskManager();
         }
 
+        public void Logoff()
+        {
+            this.rdpClient.Logoff();
+        }
+
         public void SendText(string text)
         {
             this.rdpClient.SendText(text);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/SessionCommands.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/SessionCommands.cs
@@ -45,6 +45,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
             this.Close = new CloseCommand();
             this.ShowSecurityScreen = new ShowSecurityScreenCommand();
             this.ShowTaskManager = new ShowTaskManagerCommand();
+            this.Logoff = new LogoffCommand();
             this.TypeClipboardText = new TypeClipboardTextCommand();
             this.DownloadFiles = new DownloadFilesCommand();
             this.UploadFiles = new UploadFilesCommand();
@@ -61,6 +62,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
         public IContextCommand<ISession> Close { get; }
         public IContextCommand<ISession> ShowSecurityScreen { get; }
         public IContextCommand<ISession> ShowTaskManager { get; }
+        public IContextCommand<ISession> Logoff { get; }
         public IContextCommand<ISession> TypeClipboardText { get; }
         public IContextCommand<ISession> DownloadFiles { get; }
         public IContextCommand<ISession> UploadFiles { get; }
@@ -275,6 +277,27 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
             {
                 var rdpSession = (IRdpSession)session;
                 rdpSession.ShowTaskManager();
+            }
+        }
+
+        private class LogoffCommand : SessionCommandBase
+        {
+            public LogoffCommand()
+                : base("Sign o&ut")
+            {
+            }
+
+            protected override bool IsEnabled(ISession session)
+            {
+                return session != null &&
+                    session is IRdpSession rdpSession &&
+                    rdpSession.IsConnected;
+            }
+
+            public override void Execute(ISession session)
+            {
+                var rdpSession = (IRdpSession)session;
+                rdpSession.Logoff();
             }
         }
 

--- a/sources/Google.Solutions.Terminal.Test/Controls/TestRdpClient.cs
+++ b/sources/Google.Solutions.Terminal.Test/Controls/TestRdpClient.cs
@@ -19,7 +19,6 @@
 // under the License.
 //
 
-using Google.Solutions.Common.Util;
 using Google.Solutions.Mvvm.Controls;
 using Google.Solutions.Terminal.Controls;
 using Google.Solutions.Testing.Apis;
@@ -272,6 +271,31 @@ namespace Google.Solutions.Terminal.Test.Controls
 
                 Assert.NotNull(eventArgs);
                 Assert.IsInstanceOf<RdpDisconnectedException>(eventArgs!.Exception);
+
+                window.Close();
+            }
+        }
+
+        [WindowsFormsTest]
+        public async Task Logoff()
+        {
+            using (var window = CreateWindow())
+            {
+                window.Show();
+
+                //
+                // Connect.
+                //
+                window.Client.Connect();
+                await window.Client
+                    .AwaitStateAsync(RdpClient.ConnectionState.LoggedOn)
+                    .ConfigureAwait(true);
+
+                window.Client.Logoff();
+
+                await window.Client
+                    .AwaitStateAsync(RdpClient.ConnectionState.NotConnected)
+                    .ConfigureAwait(true);
 
                 window.Close();
             }


### PR DESCRIPTION
Add 'Sign out' command to Session menu. There's no API to log off a user programatically, so the command makes a "best effort" to initiate a logoff by using the security screen. This works reliably on Windows client and Windows Server with Desktop experience, but not on Server Core.

ref #1463.