### PR TITLE
b/372783667 Control automatic logons

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Rdp/TestRdpParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Rdp/TestRdpParameters.cs
@@ -42,7 +42,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
             Assert.AreEqual(RdpColorDepth._Default, parameters.ColorDepth);
             Assert.AreEqual(RdpAudioMode._Default, parameters.AudioMode);
             Assert.AreEqual(RdpNetworkLevelAuthentication._Default, parameters.NetworkLevelAuthentication);
-            Assert.AreEqual(RdpUserAuthenticationBehavior._Default, parameters.UserAuthenticationBehavior);
+            Assert.AreEqual(RdpAutomaticLogin._Default, parameters.UserAuthenticationBehavior);
             Assert.AreEqual(RdpRedirectClipboard._Default, parameters.RedirectClipboard);
             Assert.AreEqual(RdpRedirectPrinter._Default, parameters.RedirectPrinter);
             Assert.AreEqual(RdpRedirectSmartCard._Default, parameters.RedirectSmartCard);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Rdp/TestRdpParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Rdp/TestRdpParameters.cs
@@ -42,7 +42,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Rdp
             Assert.AreEqual(RdpColorDepth._Default, parameters.ColorDepth);
             Assert.AreEqual(RdpAudioMode._Default, parameters.AudioMode);
             Assert.AreEqual(RdpNetworkLevelAuthentication._Default, parameters.NetworkLevelAuthentication);
-            Assert.AreEqual(RdpAutomaticLogin._Default, parameters.UserAuthenticationBehavior);
+            Assert.AreEqual(RdpAutomaticLogon._Default, parameters.UserAuthenticationBehavior);
             Assert.AreEqual(RdpRedirectClipboard._Default, parameters.RedirectClipboard);
             Assert.AreEqual(RdpRedirectPrinter._Default, parameters.RedirectPrinter);
             Assert.AreEqual(RdpRedirectSmartCard._Default, parameters.RedirectSmartCard);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestConnectionSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestConnectionSettingsRepository.cs
@@ -80,7 +80,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsTrue(settings.RdpColorDepth.IsDefault);
             Assert.IsTrue(settings.RdpAudioMode.IsDefault);
             Assert.IsTrue(settings.RdpRedirectClipboard.IsDefault);
-            Assert.IsTrue(settings.RdpAutomaticLogin.IsDefault);
+            Assert.IsTrue(settings.RdpAutomaticLogon.IsDefault);
             Assert.IsTrue(settings.RdpConnectionTimeout.IsDefault);
             Assert.IsTrue(settings.RdpPort.IsDefault);
             Assert.IsTrue(settings.RdpTransport.IsDefault);
@@ -189,7 +189,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsTrue(settings.RdpColorDepth.IsDefault);
             Assert.IsTrue(settings.RdpAudioMode.IsDefault);
             Assert.IsTrue(settings.RdpRedirectClipboard.IsDefault);
-            Assert.IsTrue(settings.RdpAutomaticLogin.IsDefault);
+            Assert.IsTrue(settings.RdpAutomaticLogon.IsDefault);
             Assert.IsTrue(settings.RdpConnectionTimeout.IsDefault);
             Assert.IsTrue(settings.RdpPort.IsDefault);
             Assert.IsTrue(settings.RdpTransport.IsDefault);
@@ -272,7 +272,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsTrue(settings.RdpAuthenticationLevel.IsDefault);
             Assert.IsTrue(settings.RdpColorDepth.IsDefault);
             Assert.IsTrue(settings.RdpAudioMode.IsDefault);
-            Assert.IsTrue(settings.RdpAutomaticLogin.IsDefault);
+            Assert.IsTrue(settings.RdpAutomaticLogon.IsDefault);
             Assert.IsTrue(settings.RdpConnectionTimeout.IsDefault);
             Assert.IsTrue(settings.RdpRedirectClipboard.IsDefault);
             Assert.IsTrue(settings.RdpRedirectPrinter.IsDefault);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestConnectionSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestConnectionSettingsRepository.cs
@@ -80,7 +80,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsTrue(settings.RdpColorDepth.IsDefault);
             Assert.IsTrue(settings.RdpAudioMode.IsDefault);
             Assert.IsTrue(settings.RdpRedirectClipboard.IsDefault);
-            Assert.IsTrue(settings.RdpUserAuthenticationBehavior.IsDefault);
+            Assert.IsTrue(settings.RdpAutomaticLogin.IsDefault);
             Assert.IsTrue(settings.RdpConnectionTimeout.IsDefault);
             Assert.IsTrue(settings.RdpPort.IsDefault);
             Assert.IsTrue(settings.RdpTransport.IsDefault);
@@ -189,7 +189,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsTrue(settings.RdpColorDepth.IsDefault);
             Assert.IsTrue(settings.RdpAudioMode.IsDefault);
             Assert.IsTrue(settings.RdpRedirectClipboard.IsDefault);
-            Assert.IsTrue(settings.RdpUserAuthenticationBehavior.IsDefault);
+            Assert.IsTrue(settings.RdpAutomaticLogin.IsDefault);
             Assert.IsTrue(settings.RdpConnectionTimeout.IsDefault);
             Assert.IsTrue(settings.RdpPort.IsDefault);
             Assert.IsTrue(settings.RdpTransport.IsDefault);
@@ -272,7 +272,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsTrue(settings.RdpAuthenticationLevel.IsDefault);
             Assert.IsTrue(settings.RdpColorDepth.IsDefault);
             Assert.IsTrue(settings.RdpAudioMode.IsDefault);
-            Assert.IsTrue(settings.RdpUserAuthenticationBehavior.IsDefault);
+            Assert.IsTrue(settings.RdpAutomaticLogin.IsDefault);
             Assert.IsTrue(settings.RdpConnectionTimeout.IsDefault);
             Assert.IsTrue(settings.RdpRedirectClipboard.IsDefault);
             Assert.IsTrue(settings.RdpRedirectPrinter.IsDefault);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Rdp/TestRdpView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Rdp/TestRdpView.cs
@@ -159,7 +159,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Rdp
                 var rdpParameters = new RdpParameters()
                 {
                     AuthenticationLevel = RdpAuthenticationLevel.NoServerAuthentication,
-                    UserAuthenticationBehavior = RdpAutomaticLogin.LegacyAbortOnFailure
+                    UserAuthenticationBehavior = RdpAutomaticLogon.LegacyAbortOnFailure
                 };
 
                 var broker = new SessionFactory(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Rdp/TestRdpView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Rdp/TestRdpView.cs
@@ -159,7 +159,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Rdp
                 var rdpParameters = new RdpParameters()
                 {
                     AuthenticationLevel = RdpAuthenticationLevel.NoServerAuthentication,
-                    UserAuthenticationBehavior = RdpUserAuthenticationBehavior.AbortOnFailure
+                    UserAuthenticationBehavior = RdpAutomaticLogin.LegacyAbortOnFailure
                 };
 
                 var broker = new SessionFactory(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Session/TestRdpCredentialEditor.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Session/TestRdpCredentialEditor.cs
@@ -441,6 +441,30 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Sessio
                 .ConfigureAwait(false);
         }
 
+        [Test]
+        public async Task AmendCredentials_WhenAutomaticLoginDisabled_ThenAmendCredentialsReturns()
+        {
+            var settings = new ConnectionSettings(SampleInstance);
+            settings.RdpAutomaticLogin.Value = RdpAutomaticLogin.Disabled;
+
+            var editor = new RdpCredentialEditor(
+                null,
+                settings,
+                new Mock<IAuthorization>().Object,
+                new Mock<IJobService>().Object,
+                new Mock<IWindowsCredentialGenerator>().Object,
+                new Mock<ITaskDialog>().Object,
+                new Mock<ICredentialDialog>().Object,
+                new MockWindowActivator<NewCredentialsView, NewCredentialsViewModel, IDialogTheme>(),
+                new MockWindowActivator<ShowCredentialsView, ShowCredentialsViewModel, IDialogTheme>());
+
+            Assert.IsNull(editor.Settings.RdpUsername.Value);
+
+            await editor
+                .AmendCredentialsAsync(RdpCredentialGenerationBehavior._Default)
+                .ConfigureAwait(false);
+        }
+
         //---------------------------------------------------------------------
         // AmendCredentials - Force.
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Session/TestRdpCredentialEditor.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Session/TestRdpCredentialEditor.cs
@@ -442,10 +442,10 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Sessio
         }
 
         [Test]
-        public async Task AmendCredentials_WhenAutomaticLoginDisabled_ThenAmendCredentialsReturns()
+        public async Task AmendCredentials_WhenAutomaticLogonDisabled_ThenAmendCredentialsReturns()
         {
             var settings = new ConnectionSettings(SampleInstance);
-            settings.RdpAutomaticLogin.Value = RdpAutomaticLogin.Disabled;
+            settings.RdpAutomaticLogon.Value = RdpAutomaticLogon.Disabled;
 
             var editor = new RdpCredentialEditor(
                 null,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpParameters.cs
@@ -36,7 +36,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
         public RdpColorDepth ColorDepth { get; set; } = RdpColorDepth._Default;
         public RdpAudioMode AudioMode { get; set; } = RdpAudioMode._Default;
         public RdpNetworkLevelAuthentication NetworkLevelAuthentication { get; set; } = RdpNetworkLevelAuthentication._Default;
-        public RdpAutomaticLogin UserAuthenticationBehavior { get; set; } = RdpAutomaticLogin._Default;
+        public RdpAutomaticLogon UserAuthenticationBehavior { get; set; } = RdpAutomaticLogon._Default;
         public RdpRedirectClipboard RedirectClipboard { get; set; } = RdpRedirectClipboard._Default;
         public RdpRedirectPrinter RedirectPrinter { get; set; } = RdpRedirectPrinter._Default;
         public RdpRedirectSmartCard RedirectSmartCard { get; set; } = RdpRedirectSmartCard._Default;
@@ -141,7 +141,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
     /// automatically log on the user, or whether to hand off
     /// authentication to the RDP control entirely.
     /// </summary>
-    public enum RdpAutomaticLogin
+    public enum RdpAutomaticLogon
     {
         /// <summary>
         /// Allow users to enter new credentials when saved

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpParameters.cs
@@ -36,7 +36,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
         public RdpColorDepth ColorDepth { get; set; } = RdpColorDepth._Default;
         public RdpAudioMode AudioMode { get; set; } = RdpAudioMode._Default;
         public RdpNetworkLevelAuthentication NetworkLevelAuthentication { get; set; } = RdpNetworkLevelAuthentication._Default;
-        public RdpUserAuthenticationBehavior UserAuthenticationBehavior { get; set; } = RdpUserAuthenticationBehavior._Default;
+        public RdpAutomaticLogin UserAuthenticationBehavior { get; set; } = RdpAutomaticLogin._Default;
         public RdpRedirectClipboard RedirectClipboard { get; set; } = RdpRedirectClipboard._Default;
         public RdpRedirectPrinter RedirectPrinter { get; set; } = RdpRedirectPrinter._Default;
         public RdpRedirectSmartCard RedirectSmartCard { get; set; } = RdpRedirectSmartCard._Default;
@@ -136,13 +136,37 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
         _Default = Enabled
     }
 
-    public enum RdpUserAuthenticationBehavior
+    /// <summary>
+    /// Controls whether IAP Desktop engages in trying to
+    /// automatically log on the user, or whether to hand off
+    /// authentication to the RDP control entirely.
+    /// </summary>
+    public enum RdpAutomaticLogin
     {
-        PromptOnFailure = 0,
-        AbortOnFailure = 1,
+        /// <summary>
+        /// Allow users to enter new credentials when saved
+        /// credentials are missing or invalid.
+        /// </summary>
+        Enabled = 0,
+
+        /// <summary>
+        /// Abort when saved credentials are missing or invalid.
+        /// </summary>
+        /// <remarks>
+        /// This is a legacy setting that shouldn't be used anymore.
+        /// </remarks>
+        [Browsable(false)]
+        LegacyAbortOnFailure = 1,
+
+        /// <summary>
+        /// Ignore saved credentials and always prompt, matches the
+        /// "Always prompt for password upon connection" server-side
+        /// group policy.
+        /// </summary>
+        Disabled = 2,
 
         [Browsable(false)]
-        _Default = PromptOnFailure
+        _Default = Enabled
     }
 
     public enum RdpCredentialGenerationBehavior

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextFactory.cs
@@ -156,7 +156,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol
             context.Parameters.ColorDepth = settings.RdpColorDepth.Value;
             context.Parameters.AudioMode = settings.RdpAudioMode.Value;
             context.Parameters.NetworkLevelAuthentication = settings.RdpNetworkLevelAuthentication.Value;
-            context.Parameters.UserAuthenticationBehavior = settings.RdpAutomaticLogin.Value;
+            context.Parameters.UserAuthenticationBehavior = settings.RdpAutomaticLogon.Value;
             context.Parameters.RedirectClipboard = settings.RdpRedirectClipboard.Value;
             context.Parameters.RedirectPrinter = settings.RdpRedirectPrinter.Value;
             context.Parameters.RedirectSmartCard = settings.RdpRedirectSmartCard.Value;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextFactory.cs
@@ -156,7 +156,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol
             context.Parameters.ColorDepth = settings.RdpColorDepth.Value;
             context.Parameters.AudioMode = settings.RdpAudioMode.Value;
             context.Parameters.NetworkLevelAuthentication = settings.RdpNetworkLevelAuthentication.Value;
-            context.Parameters.UserAuthenticationBehavior = settings.RdpUserAuthenticationBehavior.Value;
+            context.Parameters.UserAuthenticationBehavior = settings.RdpAutomaticLogin.Value;
             context.Parameters.RedirectClipboard = settings.RdpRedirectClipboard.Value;
             context.Parameters.RedirectPrinter = settings.RdpRedirectPrinter.Value;
             context.Parameters.RedirectSmartCard = settings.RdpRedirectSmartCard.Value;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
@@ -106,12 +106,14 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                 "Redirect audio when playing on server.",
                 Categories.RdpResources,
                 Protocol.Rdp.RdpAudioMode._Default);
-            this.RdpUserAuthenticationBehavior = store.Read<RdpUserAuthenticationBehavior>(
+            this.RdpAutomaticLogin = store.Read<RdpAutomaticLogin>(
                 "RdpUserAuthenticationBehavior",
-                null, // Hidden.
-                null, // Hidden.
-                null, // Hidden.
-                Protocol.Rdp.RdpUserAuthenticationBehavior._Default);
+                "Automatic logon",
+                "Log on automatically using saved credentials if possible. Disable if the VM " +
+                    "is configured to always prompt for passwords upon connection (a server-side " +
+                    "group policy)",
+                Categories.RdpSecurity,
+                Protocol.Rdp.RdpAutomaticLogin._Default);
             this.RdpNetworkLevelAuthentication = store.Read<RdpNetworkLevelAuthentication>(
                 "NetworkLevelAuthentication",
                 "Network level authentication",
@@ -291,7 +293,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
         public ISetting<RdpAuthenticationLevel> RdpAuthenticationLevel { get; }
         public ISetting<RdpColorDepth> RdpColorDepth { get; }
         public ISetting<RdpAudioMode> RdpAudioMode { get; }
-        public ISetting<RdpUserAuthenticationBehavior> RdpUserAuthenticationBehavior { get; }
+        public ISetting<RdpAutomaticLogin> RdpAutomaticLogin { get; }
         public ISetting<RdpNetworkLevelAuthentication> RdpNetworkLevelAuthentication { get; }
         public ISetting<int> RdpConnectionTimeout { get; }
         public ISetting<int> RdpPort { get; }
@@ -336,7 +338,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
             this.RdpRedirectDevice,
             this.RdpRedirectWebAuthn,
 
-            this.RdpUserAuthenticationBehavior,
+            this.RdpAutomaticLogin,
             this.RdpNetworkLevelAuthentication,
             this.RdpAuthenticationLevel,
             this.RdpRestrictedAdminMode,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
@@ -106,14 +106,14 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                 "Redirect audio when playing on server.",
                 Categories.RdpResources,
                 Protocol.Rdp.RdpAudioMode._Default);
-            this.RdpAutomaticLogin = store.Read<RdpAutomaticLogin>(
+            this.RdpAutomaticLogon = store.Read<RdpAutomaticLogon>(
                 "RdpUserAuthenticationBehavior",
                 "Automatic logon",
                 "Log on automatically using saved credentials if possible. Disable if the VM " +
                     "is configured to always prompt for passwords upon connection (a server-side " +
                     "group policy)",
                 Categories.RdpSecurity,
-                Protocol.Rdp.RdpAutomaticLogin._Default);
+                Protocol.Rdp.RdpAutomaticLogon._Default);
             this.RdpNetworkLevelAuthentication = store.Read<RdpNetworkLevelAuthentication>(
                 "NetworkLevelAuthentication",
                 "Network level authentication",
@@ -293,7 +293,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
         public ISetting<RdpAuthenticationLevel> RdpAuthenticationLevel { get; }
         public ISetting<RdpColorDepth> RdpColorDepth { get; }
         public ISetting<RdpAudioMode> RdpAudioMode { get; }
-        public ISetting<RdpAutomaticLogin> RdpAutomaticLogin { get; }
+        public ISetting<RdpAutomaticLogon> RdpAutomaticLogon { get; }
         public ISetting<RdpNetworkLevelAuthentication> RdpNetworkLevelAuthentication { get; }
         public ISetting<int> RdpConnectionTimeout { get; }
         public ISetting<int> RdpPort { get; }
@@ -338,7 +338,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
             this.RdpRedirectDevice,
             this.RdpRedirectWebAuthn,
 
-            this.RdpAutomaticLogin,
+            this.RdpAutomaticLogon,
             this.RdpNetworkLevelAuthentication,
             this.RdpAuthenticationLevel,
             this.RdpRestrictedAdminMode,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/RdpView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/RdpView.cs
@@ -239,7 +239,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Rdp
                 this.rdpClient.Domain = viewModel.Credential!.Domain;
                 this.rdpClient.Username = viewModel.Credential.User;
                 this.rdpClient.ServerPort = viewModel.Port!.Value;
-                this.rdpClient.Password = viewModel.Credential.Password?.AsClearText() ?? string.Empty;
                 this.rdpClient.ConnectionTimeout = viewModel.Parameters.ConnectionTimeout;
                 this.rdpClient.EnableAdminMode = viewModel.Parameters.SessionType == RdpSessionType.Admin;
 
@@ -261,8 +260,24 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Rdp
                         break;
                 }
 
-                this.rdpClient.EnableCredentialPrompt =
-                    (viewModel.Parameters.UserAuthenticationBehavior == RdpUserAuthenticationBehavior.PromptOnFailure);
+                switch (viewModel.Parameters.UserAuthenticationBehavior) // TODO: test
+                {
+                    case RdpAutomaticLogin.Enabled:
+                        this.rdpClient.EnableCredentialPrompt = true;
+                        this.rdpClient.Password = viewModel.Credential.Password?.AsClearText() ?? string.Empty;
+                        break;
+
+                    case RdpAutomaticLogin.Disabled:
+                        this.rdpClient.EnableCredentialPrompt = true;
+                        // Leave password blank.
+                        break;
+
+                    case RdpAutomaticLogin.LegacyAbortOnFailure:
+                        this.rdpClient.EnableCredentialPrompt = false;
+                        this.rdpClient.Password = viewModel.Credential.Password?.AsClearText() ?? string.Empty;
+                        break;
+                }
+
                 this.rdpClient.EnableNetworkLevelAuthentication =
                     (viewModel.Parameters.NetworkLevelAuthentication != RdpNetworkLevelAuthentication.Disabled);
                 this.rdpClient.EnableRestrictedAdminMode =

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/RdpView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/RdpView.cs
@@ -262,17 +262,17 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Rdp
 
                 switch (viewModel.Parameters.UserAuthenticationBehavior)
                 {
-                    case RdpAutomaticLogin.Enabled:
+                    case RdpAutomaticLogon.Enabled:
                         this.rdpClient.EnableCredentialPrompt = true;
                         this.rdpClient.Password = viewModel.Credential.Password?.AsClearText() ?? string.Empty;
                         break;
 
-                    case RdpAutomaticLogin.Disabled:
+                    case RdpAutomaticLogon.Disabled:
                         this.rdpClient.EnableCredentialPrompt = true;
                         // Leave password blank.
                         break;
 
-                    case RdpAutomaticLogin.LegacyAbortOnFailure:
+                    case RdpAutomaticLogon.LegacyAbortOnFailure:
                         this.rdpClient.EnableCredentialPrompt = false;
                         this.rdpClient.Password = viewModel.Credential.Password?.AsClearText() ?? string.Empty;
                         break;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/RdpView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/RdpView.cs
@@ -260,7 +260,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Rdp
                         break;
                 }
 
-                switch (viewModel.Parameters.UserAuthenticationBehavior) // TODO: test
+                switch (viewModel.Parameters.UserAuthenticationBehavior)
                 {
                     case RdpAutomaticLogin.Enabled:
                         this.rdpClient.EnableCredentialPrompt = true;

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/RdpCredentialEditor.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/RdpCredentialEditor.cs
@@ -272,6 +272,15 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
                 //
                 return;
             }
+            else if (this.Settings.RdpAutomaticLogin.Value
+                == RdpAutomaticLogin.Disabled)
+            {
+                //
+                // Don't even try to collect credentials, because the
+                // RDP control needs to prompt again anyway.
+                //
+                return;
+            }
             else if (allowedBehavior == RdpCredentialGenerationBehavior.Force &&
                 await IsGrantedPermissionToCreateWindowsCredentialsAsync()
                     .ConfigureAwait(true))

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/RdpCredentialEditor.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/RdpCredentialEditor.cs
@@ -272,8 +272,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
                 //
                 return;
             }
-            else if (this.Settings.RdpAutomaticLogin.Value
-                == RdpAutomaticLogin.Disabled)
+            else if (this.Settings.RdpAutomaticLogon.Value
+                == RdpAutomaticLogon.Disabled)
             {
                 //
                 // Don't even try to collect credentials, because the


### PR DESCRIPTION
Extend the existing `RdpUserAuthenticationBehavior` setting so that it can be used to control automatic logons.

If automatic logons are enabled (the default), IAP Desktop attempts to use save credentials, or will prompt the user to enter or generate new credentials if necessary.

If automatic logons are disabled, IAP Desktop ignores saved credentials and defers all prompting to the RDP control. This behavior ensures compliance with the _Always prompt for password upon connection_ server-side group policy.

ref #1501