### PR TITLE
v/372787399 Expose enum descriptions in properties window

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpParameters.cs
@@ -83,8 +83,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
 
     public enum RdpConnectionBarState
     {
+        [Description("Auto hide")]
         AutoHide = 0,
+
+        [Description("Pinned")]
         Pinned = 1,
+
+        [Description("Hide")]
         Off = 2,
 
         [Browsable(false)]
@@ -109,8 +114,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
 
     public enum RdpColorDepth
     {
+        [Description("High color (16 bit)")]
         HighColor = 0,
+
+        [Description("True color (24 bit)")]
         TrueColor = 1,
+
+        [Description("Highest quality (32 bit)")]
         DeepColor = 2,
 
         [Browsable(false)]
@@ -119,8 +129,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
 
     public enum RdpAudioMode
     {
+        [Description("Play on this computer")]
         PlayLocally = 0,
+
+        [Description("Play on server")]
         PlayOnServer = 1,
+
+        [Description("Do not play")]
         DoNotPlay = 2,
 
         [Browsable(false)]
@@ -248,10 +263,14 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
         //
         // NB. Values correspond to IMsRdpClientSecuredSettings::KeyboardHookMode.
         //
+        [Description("On this computer")]
         Disabled = 0,
-        Enabled = 1,
-        FullScreenOnly = 2,
 
+        [Description("On server")]
+        Enabled = 1,
+
+        [Description("Only in full-screen mode")]
+        FullScreenOnly = 2,
 
         [Browsable(false)]
         _Default = FullScreenOnly
@@ -271,11 +290,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
         /// <summary>
         /// Normal user session, might consume a CAL.
         /// </summary>
+        [Description("Normal user-session")] 
         User = 0,
 
         /// <summary>
         /// Admin session, equivalent to "mstsc /admin".
         /// </summary>
+        [Description("RDS admin-session")]
         Admin = 1,
 
         [Browsable(false)]
@@ -284,7 +305,10 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
 
     public enum RdpDpiScaling
     {
+        [Description("Disabled (100%)")]
         Disabled = 0,
+
+        [Description("Same as this computer")]
         Enabled = 1,
 
         [Browsable(false)]

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
@@ -90,9 +90,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                 RdpConnectionBarState._Default);
             this.RdpAuthenticationLevel = store.Read<RdpAuthenticationLevel>(
                 "AuthenticationLevel",
-                "Server authentication",
-                "Require server authentication when connecting.",
-                Categories.RdpSecurity,
+                null,
+                null,
+                null,
                 Protocol.Rdp.RdpAuthenticationLevel._Default);
             this.RdpColorDepth = store.Read<RdpColorDepth>(
                 "ColorDepth",

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
@@ -189,7 +189,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                 Protocol.Rdp.RdpRedirectWebAuthn._Default);
             this.RdpHookWindowsKeys = store.Read<RdpHookWindowsKeys>(
                 "RdpHookWindowsKeys",
-                "Windows shortcuts",
+                "Apply Windows shortcuts",
                 "Enable Windows shortcuts (like Win+R)",
                 Categories.RdpResources,
                 Protocol.Rdp.RdpHookWindowsKeys._Default);

--- a/sources/Google.Solutions.Settings.Test/ComponentModel/TestEnumDisplayNameConverter.cs
+++ b/sources/Google.Solutions.Settings.Test/ComponentModel/TestEnumDisplayNameConverter.cs
@@ -107,7 +107,7 @@ namespace Google.Solutions.Settings.Test.ComponentModel
         //----------------------------------------------------------------------
 
         [Test]
-        public void ConvertTo_WhenDescriptionPresent()
+        public void ConvertTo_WhenMemberHasDescription()
         {
             var converter = new EnumDisplayNameConverter(typeof(EnumWithDescriptions));
             Assert.AreEqual(
@@ -120,7 +120,7 @@ namespace Google.Solutions.Settings.Test.ComponentModel
         }
 
         [Test]
-        public void ConvertTo_WhenDescriptionNotPresent()
+        public void ConvertTo_WhenMemberLacksDescription()
         {
             var converter = new EnumDisplayNameConverter(typeof(EnumWithDescriptions));
             Assert.AreEqual(
@@ -149,10 +149,22 @@ namespace Google.Solutions.Settings.Test.ComponentModel
         //----------------------------------------------------------------------
 
         [Test]
+        public void ConvertFrom_WhenMemberLacksDescription()
+        {
+            var converter = new EnumDisplayNameConverter(typeof(EnumWithDescriptions));
+            Assert.AreEqual(
+                EnumWithDescriptions.Many,
+                converter.ConvertFrom(
+                    new Mock<ITypeDescriptorContext>().Object,
+                    CultureInfo.InvariantCulture,
+                    "Many"));
+        }
+
+        [Test]
         public void ConvertFrom_WhenDescriptionNotFound()
         {
             var converter = new EnumDisplayNameConverter(typeof(EnumWithDescriptions));
-            Assert.Throws<ArgumentOutOfRangeException>(
+            Assert.Throws<ArgumentException>(
                 () => converter.ConvertFrom(
                     new Mock<ITypeDescriptorContext>().Object,
                     CultureInfo.InvariantCulture,

--- a/sources/Google.Solutions.Settings.Test/ComponentModel/TestEnumDisplayNameConverter.cs
+++ b/sources/Google.Solutions.Settings.Test/ComponentModel/TestEnumDisplayNameConverter.cs
@@ -1,0 +1,185 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+
+using Google.Solutions.Settings.ComponentModel;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.ComponentModel;
+using System.Globalization;
+using DescriptionAttribute = System.ComponentModel.DescriptionAttribute;
+
+namespace Google.Solutions.Settings.Test.ComponentModel
+{
+    [TestFixture]
+    public class TestEnumDisplayNameConverter
+    {
+        private enum EnumWithoutValues { }
+
+        private enum EnumWithDuplicateDescriptions
+        {
+            [Description("one")]
+            One,
+
+            [Description("one")]
+            Anotherone,
+        }
+
+        private enum EnumWithDescriptions
+        {
+            [Description("eins")]
+            One,
+
+            [Description("zwei")]
+            Two,
+
+            Many
+        }
+
+        private enum EnumWithoutDescriptions
+        {
+            Yes,
+            No
+        }
+
+        //----------------------------------------------------------------------
+        // Constructor.
+        //----------------------------------------------------------------------
+
+        [Test]
+        public void Constructor_WhenEnumIsEmpty()
+        {
+            _ = new EnumDisplayNameConverter(typeof(EnumWithoutValues));
+        }
+
+        [Test]
+        public void Constructor_WhenEnumLacksDescriptions()
+        {
+            _ = new EnumDisplayNameConverter(typeof(EnumWithoutDescriptions));
+        }
+
+        [Test]
+        public void Constructor_WhenEnumDescriptionsNotUnique()
+        {
+            Assert.Throws<ArgumentException>(
+                () => new EnumDisplayNameConverter(typeof(EnumWithDuplicateDescriptions)));
+        }
+
+        //----------------------------------------------------------------------
+        // CanConvertTo.
+        //----------------------------------------------------------------------
+
+        [Test]
+        public void CanConvertTo_WhenString()
+        {
+            var converter = new EnumDisplayNameConverter(typeof(EnumWithDescriptions));
+            Assert.IsTrue(converter.CanConvertTo(typeof(string)));
+        }
+
+        [Test]
+        public void CanConvertTo_WhenInt()
+        {
+            var converter = new EnumDisplayNameConverter(typeof(EnumWithDescriptions));
+            Assert.IsFalse(converter.CanConvertTo(typeof(int)));
+        }
+
+        //----------------------------------------------------------------------
+        // ConvertTo.
+        //----------------------------------------------------------------------
+
+        [Test]
+        public void ConvertTo_WhenDescriptionPresent()
+        {
+            var converter = new EnumDisplayNameConverter(typeof(EnumWithDescriptions));
+            Assert.AreEqual(
+                "eins",
+                converter.ConvertTo(
+                    new Mock<ITypeDescriptorContext>().Object,
+                    CultureInfo.InvariantCulture,
+                    EnumWithDescriptions.One,
+                    typeof(string)));
+        }
+
+        [Test]
+        public void ConvertTo_WhenDescriptionNotPresent()
+        {
+            var converter = new EnumDisplayNameConverter(typeof(EnumWithDescriptions));
+            Assert.AreEqual(
+                "Many",
+                converter.ConvertTo(
+                    new Mock<ITypeDescriptorContext>().Object,
+                    CultureInfo.InvariantCulture,
+                    EnumWithDescriptions.Many,
+                    typeof(string)));
+        }
+
+        [Test]
+        public void ConvertTo_WhenDestinationTypeIsInt()
+        {
+            var converter = new EnumDisplayNameConverter(typeof(EnumWithDescriptions));
+            Assert.Throws<NotSupportedException>(
+                () => converter.ConvertTo(
+                    new Mock<ITypeDescriptorContext>().Object,
+                    CultureInfo.InvariantCulture,
+                    EnumWithDescriptions.Many,
+                    typeof(int)));
+        }
+
+        //----------------------------------------------------------------------
+        // ConvertFrom.
+        //----------------------------------------------------------------------
+
+        [Test]
+        public void ConvertFrom_WhenDescriptionNotFound()
+        {
+            var converter = new EnumDisplayNameConverter(typeof(EnumWithDescriptions));
+            Assert.Throws<ArgumentOutOfRangeException>(
+                () => converter.ConvertFrom(
+                    new Mock<ITypeDescriptorContext>().Object,
+                    CultureInfo.InvariantCulture,
+                    "invalid"));
+        }
+
+        [Test]
+        public void ConvertFrom_WhenValueIsNull()
+        {
+            var converter = new EnumDisplayNameConverter(typeof(EnumWithDescriptions));
+            Assert.Throws<ArgumentNullException>(
+                () => converter.ConvertFrom(
+                    new Mock<ITypeDescriptorContext>().Object,
+                    CultureInfo.InvariantCulture,
+                    null));
+        }
+
+        [Test]
+        public void ConvertFrom()
+        {
+            var converter = new EnumDisplayNameConverter(typeof(EnumWithDescriptions));
+            Assert.AreEqual(
+                EnumWithDescriptions.Two,
+                converter.ConvertFrom(
+                    new Mock<ITypeDescriptorContext>().Object,
+                    CultureInfo.InvariantCulture,
+                    "zwei"));
+        }
+    }
+}

--- a/sources/Google.Solutions.Settings.Test/ComponentModel/TestSettingDescriptor.cs
+++ b/sources/Google.Solutions.Settings.Test/ComponentModel/TestSettingDescriptor.cs
@@ -21,6 +21,8 @@
 
 using Google.Solutions.Settings.ComponentModel;
 using NUnit.Framework;
+using System;
+using System.Drawing;
 
 namespace Google.Solutions.Settings.Test.ComponentModel
 {
@@ -94,6 +96,32 @@ namespace Google.Solutions.Settings.Test.ComponentModel
             descriptor.ResetValue(setting);
             Assert.IsTrue(setting.IsDefault);
             Assert.IsFalse(descriptor.ShouldSerializeValue(setting));
+        }
+
+        //--------------------------------------------------------------------
+        // Converter.
+        //--------------------------------------------------------------------
+
+        [Test]
+        public void Converter_WhenEnum()
+        {
+            var setting = DictionarySettingsStore
+                .Empty()
+                .Read<StringComparison>("key", null, null, null, StringComparison.Ordinal);
+
+            var descriptor = new SettingDescriptor(setting);
+            Assert.IsInstanceOf<EnumDisplayNameConverter>(descriptor.Converter);
+        }
+
+        [Test]
+        public void Converter_WhenString()
+        {
+            var setting = DictionarySettingsStore
+                .Empty()
+                .Read<string>("key", "display name", "description", "category", "default");
+
+            var descriptor = new SettingDescriptor(setting);
+            Assert.IsNotInstanceOf<EnumDisplayNameConverter>(descriptor.Converter);
         }
     }
 }

--- a/sources/Google.Solutions.Settings/ComponentModel/EnumDisplayNameConverter.cs
+++ b/sources/Google.Solutions.Settings/ComponentModel/EnumDisplayNameConverter.cs
@@ -1,0 +1,117 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Util;
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+
+namespace Google.Solutions.Settings.ComponentModel
+{
+    /// <summary>
+    /// Converts between enum member names and strings based on
+    /// DisplayName attributes.
+    /// </summary>
+    public class EnumDisplayNameConverter : EnumConverter
+    {
+        public EnumDisplayNameConverter(Type type) : base(type)
+        {
+            Precondition.Expect(type.IsEnum, "Type must be an enum");
+            Precondition.Expect(type.GetFields().Any(), "Enum must have at least one member");
+
+            Precondition.Expect(
+                !type
+                    .GetFields()
+                    .SelectMany(m => m.GetCustomAttributes<DescriptionAttribute>())
+                    .Any() ||
+                type
+                    .GetFields()
+                    .SelectMany(m => m.GetCustomAttributes<DescriptionAttribute>())
+                    .GroupBy(m => m.Description)
+                    .Max(g => g.Count()) == 1,
+                "Type contains duplicate display names");
+        }
+
+        public override bool CanConvertTo(
+            ITypeDescriptorContext context,
+            Type destinationType)
+        {
+            return destinationType == typeof(string);
+        }
+
+        public override object ConvertTo(
+            ITypeDescriptorContext context,
+            CultureInfo culture,
+            object value,
+            Type destinationType)
+        {
+            Precondition.ExpectNotNull(value, "value");
+
+            if (destinationType == typeof(string))
+            {
+                //
+                // Lookup attribute by member name.
+                //
+                var description = this.EnumType
+                    .GetField(value.ToString())
+                    .GetCustomAttribute<DescriptionAttribute>()?
+                    .Description;
+
+                return description ?? value.ToString();
+            }
+            else
+            {
+                return base.ConvertTo(context, culture, value, destinationType);
+            }
+        }
+
+        public override object ConvertFrom(
+            ITypeDescriptorContext context,
+            CultureInfo culture,
+            object value)
+        {
+            Precondition.ExpectNotNull(value, "value");
+
+            //
+            // Lookup member by attribute value.
+            //
+            var member = this.EnumType
+                .GetFields()
+                .Where(m => Equals(
+                    m.GetCustomAttribute<DescriptionAttribute>()?.Description,
+                    value))
+                .FirstOrDefault();
+
+            if (member == null)
+            {
+                throw new ArgumentOutOfRangeException(
+                    $"'{value}' is not a valid valiue");
+            }
+            else
+            {
+                return Enum.Parse(this.EnumType, member.Name);
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.Settings/ComponentModel/EnumDisplayNameConverter.cs
+++ b/sources/Google.Solutions.Settings/ComponentModel/EnumDisplayNameConverter.cs
@@ -103,14 +103,20 @@ namespace Google.Solutions.Settings.ComponentModel
                     value))
                 .FirstOrDefault();
 
-            if (member == null)
+            if (member != null)
             {
-                throw new ArgumentOutOfRangeException(
-                    $"'{value}' is not a valid valiue");
+                //
+                // We found the member that matches the description.
+                //
+                return Enum.Parse(this.EnumType, member.Name);
             }
             else
             {
-                return Enum.Parse(this.EnumType, member.Name);
+                //
+                // The member might not have a description attribute,
+                // so try to parse directly.
+                //
+                return Enum.Parse(this.EnumType, value.ToString());
             }
         }
     }

--- a/sources/Google.Solutions.Settings/ComponentModel/SettingDescriptor.cs
+++ b/sources/Google.Solutions.Settings/ComponentModel/SettingDescriptor.cs
@@ -144,71 +144,12 @@ namespace Google.Solutions.Settings.ComponentModel
             {
                 if (this.setting.ValueType.IsEnum)
                 {
-                    return new EnumSettingConverter(this.setting.ValueType);
+                    return new EnumDisplayNameConverter(this.setting.ValueType);
                 }
                 else
                 {
                     return base.Converter;
                 }
-            }
-        }
-
-        private class EnumSettingConverter : EnumConverter // TODO: test
-        {
-            public EnumSettingConverter(Type type) : base(type)
-            {
-                Debug.Assert(type
-                    .GetMembers()
-                    .SelectMany(m => m.GetCustomAttributes<DescriptionAttribute>())
-                    .GroupBy(m => m.Description)
-                    .Max(g => g.Count()) == 1,
-                    "Type contains duplicate display names");
-            }
-
-            public override bool CanConvertTo(
-                ITypeDescriptorContext context, 
-                Type destinationType)
-            {
-                return destinationType == typeof(string);
-            }
-
-            public override object ConvertTo(
-                ITypeDescriptorContext context, 
-                CultureInfo culture, 
-                object value,
-                Type destinationType)
-            {
-                if (destinationType == typeof(string))
-                {
-                    //
-                    // Lookup attribute by symbol name.
-                    //
-                    return this.EnumType
-                        .GetMember(value.ToString())
-                        .FirstOrDefault()?
-                        .GetCustomAttribute<DescriptionAttribute>()?
-                        .Description;
-                }
-                else
-                {
-                    return base.ConvertTo(context, culture, value, destinationType);
-                }
-            }
-
-            public override object ConvertFrom(
-                ITypeDescriptorContext context, 
-                CultureInfo culture, 
-                object value)
-            {
-                //
-                // Lookup symbol name by attribute value.
-                //
-                return Enum.Parse(this.EnumType,
-                    this.EnumType
-                    .GetMembers()
-                    .Where(m => Equals(m.GetCustomAttribute<DescriptionAttribute>()?.Description, value))
-                    .First()
-                    .Name);
             }
         }
     }


### PR DESCRIPTION
- Use TypeConverter to expose descriptions (instead of member names) for enum-types properties
- Annotate connection setting enums
- Hide Server authentication level setting as it's not useful in IAP scenarios