### PR TITLE
b/372783332 Restore conection setting for controlling remote desktop size

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestConnectionSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Settings/TestConnectionSettingsRepository.cs
@@ -196,6 +196,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsTrue(settings.RdpRedirectWebAuthn.IsDefault);
             Assert.IsTrue(settings.RdpRestrictedAdminMode.IsDefault);
             Assert.IsTrue(settings.RdpSessionType.IsDefault);
+            Assert.IsTrue(settings.RdpDesktopSize.IsDefault);
         }
 
         [Test]
@@ -286,6 +287,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.IsTrue(settings.RdpRestrictedAdminMode.IsDefault);
             Assert.IsTrue(settings.RdpSessionType.IsDefault);
             Assert.IsTrue(settings.RdpDpiScaling.IsDefault);
+            Assert.IsTrue(settings.RdpDesktopSize.IsDefault);
         }
 
         [Test]
@@ -312,6 +314,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             originalSettings.RdpPort.Value = 13389;
             originalSettings.RdpTransport.Value = SessionTransportType.Vpc;
             originalSettings.RdpDpiScaling.Value = RdpDpiScaling.Disabled;
+            originalSettings.RdpDesktopSize.Value = RdpDesktopSize.ScreenSize;
 
             repository.SetInstanceSettings(originalSettings);
 
@@ -332,6 +335,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Settings
             Assert.AreEqual(13389, settings.RdpPort.Value);
             Assert.AreEqual(SessionTransportType.Vpc, settings.RdpTransport.Value);
             Assert.AreEqual(RdpDpiScaling.Disabled, settings.RdpDpiScaling.Value);
+            Assert.AreEqual(RdpDesktopSize.ScreenSize, settings.RdpDesktopSize.Value);
         }
 
         [Test]

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpParameters.cs
@@ -48,6 +48,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
         public RdpRestrictedAdminMode RestrictedAdminMode { get; set; } = RdpRestrictedAdminMode._Default;
         public RdpSessionType SessionType { get; set; } = RdpSessionType._Default;
         public RdpDpiScaling DpiScaling { get; set; } = RdpDpiScaling._Default;
+        public RdpDisplayResolution DisplayResolution { get; set; } = RdpDisplayResolution._Default;
+
 
         /// <summary>
         /// Sources where these parameters were obtained from.
@@ -94,6 +96,22 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
 
         [Browsable(false)]
         _Default = AutoHide
+    }
+
+
+    public enum RdpDisplayResolution
+    {
+        [Description("Same as this computer")]
+        FullScreen = 1,
+
+        [Description("Adjust automatically")]
+        AutoAdjust = 2,
+
+        [Browsable(false)]
+        LegacyClientSize = 0,
+
+        [Browsable(false)]
+        _Default = AutoAdjust
     }
 
     public enum RdpAuthenticationLevel

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpParameters.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Rdp/RdpParameters.cs
@@ -48,7 +48,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
         public RdpRestrictedAdminMode RestrictedAdminMode { get; set; } = RdpRestrictedAdminMode._Default;
         public RdpSessionType SessionType { get; set; } = RdpSessionType._Default;
         public RdpDpiScaling DpiScaling { get; set; } = RdpDpiScaling._Default;
-        public RdpDisplayResolution DisplayResolution { get; set; } = RdpDisplayResolution._Default;
+        public RdpDesktopSize DesktopSize { get; set; } = RdpDesktopSize._Default;
 
 
         /// <summary>
@@ -99,10 +99,10 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp
     }
 
 
-    public enum RdpDisplayResolution
+    public enum RdpDesktopSize
     {
         [Description("Same as this computer")]
-        FullScreen = 1,
+        ScreenSize = 1,
 
         [Description("Adjust automatically")]
         AutoAdjust = 2,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextFactory.cs
@@ -168,6 +168,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol
             context.Parameters.RestrictedAdminMode = settings.RdpRestrictedAdminMode.Value;
             context.Parameters.SessionType = settings.RdpSessionType.Value;
             context.Parameters.DpiScaling = settings.RdpDpiScaling.Value;
+            context.Parameters.DisplayResolution = settings.RdpDisplayResolution.Value;
 
             return context;
         }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextFactory.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/SessionContextFactory.cs
@@ -168,7 +168,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol
             context.Parameters.RestrictedAdminMode = settings.RdpRestrictedAdminMode.Value;
             context.Parameters.SessionType = settings.RdpSessionType.Value;
             context.Parameters.DpiScaling = settings.RdpDpiScaling.Value;
-            context.Parameters.DisplayResolution = settings.RdpDisplayResolution.Value;
+            context.Parameters.DesktopSize = settings.RdpDesktopSize.Value;
 
             return context;
         }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
@@ -214,6 +214,12 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                 "Scale remote display to match local scaling settings.",
                 Categories.RdpDisplay,
                 Protocol.Rdp.RdpDpiScaling._Default);
+            this.RdpDisplayResolution = store.Read<RdpDisplayResolution>(
+                "DesktopSize",
+                "Display resolution",
+                "Display resolution of remote desktop.",
+                Categories.RdpDisplay,
+                Protocol.Rdp.RdpDisplayResolution._Default);
 
             //
             // SSH Settings.
@@ -309,6 +315,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
         public ISetting<RdpRestrictedAdminMode> RdpRestrictedAdminMode { get; }
         public ISetting<RdpSessionType> RdpSessionType { get; }
         public ISetting<RdpDpiScaling> RdpDpiScaling { get; }
+        public ISetting<RdpDisplayResolution> RdpDisplayResolution { get; private set; }
 
         internal IEnumerable<ISetting> RdpSettings => new ISetting[]
         {
@@ -326,6 +333,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
 
             this.RdpColorDepth,
             this.RdpConnectionBar,
+            this.RdpDisplayResolution,
             this.RdpDpiScaling,
 
             this.RdpAudioMode,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
@@ -214,12 +214,12 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                 "Scale remote display to match local scaling settings.",
                 Categories.RdpDisplay,
                 Protocol.Rdp.RdpDpiScaling._Default);
-            this.RdpDisplayResolution = store.Read<RdpDisplayResolution>(
+            this.RdpDesktopSize = store.Read<RdpDesktopSize>(
                 "DesktopSize",
                 "Display resolution",
                 "Display resolution of remote desktop.",
                 Categories.RdpDisplay,
-                Protocol.Rdp.RdpDisplayResolution._Default);
+                Protocol.Rdp.RdpDesktopSize._Default);
 
             //
             // SSH Settings.
@@ -315,7 +315,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
         public ISetting<RdpRestrictedAdminMode> RdpRestrictedAdminMode { get; }
         public ISetting<RdpSessionType> RdpSessionType { get; }
         public ISetting<RdpDpiScaling> RdpDpiScaling { get; }
-        public ISetting<RdpDisplayResolution> RdpDisplayResolution { get; private set; }
+        public ISetting<RdpDesktopSize> RdpDesktopSize { get; private set; }
 
         internal IEnumerable<ISetting> RdpSettings => new ISetting[]
         {
@@ -333,7 +333,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
 
             this.RdpColorDepth,
             this.RdpConnectionBar,
-            this.RdpDisplayResolution,
+            this.RdpDesktopSize,
             this.RdpDpiScaling,
 
             this.RdpAudioMode,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/RdpView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Rdp/RdpView.cs
@@ -295,6 +295,8 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Rdp
                 //
                 this.rdpClient.EnableDpiScaling =
                     viewModel.Parameters.DpiScaling == RdpDpiScaling.Enabled;
+                this.rdpClient.EnableAutoResize =
+                    viewModel.Parameters.DesktopSize == RdpDesktopSize.AutoAdjust;
 
                 switch (viewModel.Parameters.ColorDepth)
                 {

--- a/sources/Google.Solutions.Terminal.Test/Controls/TestRdpClient.cs
+++ b/sources/Google.Solutions.Terminal.Test/Controls/TestRdpClient.cs
@@ -54,10 +54,12 @@ namespace Google.Solutions.Terminal.Test.Controls
         }
 
         [WindowsFormsTest]
-        public async Task ResizeWindow()
+        public async Task ResizeWindow(
+            [Values(true, false)] bool enableAutoResize)
         {
             using (var window = CreateWindow())
             {
+                window.Client.EnableAutoResize = enableAutoResize;
                 window.Show();
 
                 //
@@ -96,10 +98,12 @@ namespace Google.Solutions.Terminal.Test.Controls
         }
 
         [WindowsFormsTest]
-        public async Task MinimizeAndRestoreFullScreenWindow()
+        public async Task MinimizeAndRestoreFullScreenWindow(
+            [Values(true, false)] bool enableAutoResize)
         {
             using (var window = CreateWindow())
             {
+                window.Client.EnableAutoResize = enableAutoResize;
                 window.Show();
 
                 //
@@ -151,10 +155,12 @@ namespace Google.Solutions.Terminal.Test.Controls
         }
 
         [WindowsFormsTest]
-        public async Task EnterAndLeaveFullscreen()
+        public async Task EnterAndLeaveFullscreen(
+            [Values(true, false)] bool enableAutoResize)
         {
             using (var window = CreateWindow())
             {
+                window.Client.EnableAutoResize = enableAutoResize;
                 window.Show();
 
                 //
@@ -171,6 +177,9 @@ namespace Google.Solutions.Terminal.Test.Controls
                 Assert.IsFalse(window.Client.IsFullScreen);
                 Assert.IsTrue(window.Client.CanEnterFullScreen);
                 Assert.IsTrue(window.Client.TryEnterFullScreen(null));
+
+                await Task.Delay(TimeSpan.FromSeconds(1));
+
                 Assert.IsTrue(window.Client.IsFullScreen);
                 Assert.IsFalse(window.Client.CanEnterFullScreen);
 

--- a/sources/Google.Solutions.Terminal/Controls/RdpClient.ConnectionProperties.cs
+++ b/sources/Google.Solutions.Terminal/Controls/RdpClient.ConnectionProperties.cs
@@ -567,5 +567,13 @@ namespace Google.Solutions.Terminal.Controls
         [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
         [Category(RdpCategory)]
         public bool EnableDpiScaling { get; set; }
+
+        /// <summary>
+        /// Auto-resize remote desktop to fit client size.
+        /// </summary>
+        [Browsable(true)]
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        [Category(RdpCategory)]
+        public bool EnableAutoResize { get; set; } = true;
     }
 }

--- a/sources/Google.Solutions.Terminal/Controls/RdpClient.cs
+++ b/sources/Google.Solutions.Terminal/Controls/RdpClient.cs
@@ -400,6 +400,14 @@ namespace Google.Solutions.Terminal.Controls
             //
             this.client.Size = newSize;
 
+            if (!this.EnableAutoResize)
+            {
+                //
+                // Leave remote desktop size as-is.
+                //
+                return;
+            }
+
             //
             // Resize the session.
             //
@@ -822,8 +830,26 @@ namespace Google.Solutions.Terminal.Controls
             base.OnBeforeConnect();
             this.client.FullScreen = false;
             this.client.Size = this.Size;
-            this.client.DesktopHeight = this.Size.Height;
-            this.client.DesktopWidth = this.Size.Width;
+
+            if (this.EnableAutoResize)
+            {
+                //
+                // Size to fit.
+                //
+                this.client.DesktopHeight = this.Size.Height;
+                this.client.DesktopWidth = this.Size.Width;
+            }
+            else
+            {
+                //
+                // Set to current screen's resolution, which means
+                // the desktop size is the same in full-screen and
+                // regular mode.
+                //
+                var screenSize = Screen.GetBounds(this);
+                this.client.DesktopHeight = screenSize.Height;
+                this.client.DesktopWidth = screenSize.Width;
+            }
 
             try
             {


### PR DESCRIPTION
- Restore `ScreenSize` connection setting.
- Extend `RdpClient` to adjust remote desktop size and disable automatic resizing based on connection setting.

Ref #1461