### PR TITLE
b/354037219 Show masked value for inherited SecureString settings

### DIFF
--- a/sources/Google.Solutions.Settings.Test/ComponentModel/TestMaskedSettingDescriptor.cs
+++ b/sources/Google.Solutions.Settings.Test/ComponentModel/TestMaskedSettingDescriptor.cs
@@ -33,7 +33,7 @@ namespace Google.Solutions.Settings.Test.ComponentModel
         //----------------------------------------------------------------------
 
         [Test]
-        public void GetValue_ReturnsMaskedString()
+        public void GetValue_WhenNotEmpty()
         {
             var setting = DictionarySettingsStore
                 .Empty()
@@ -42,7 +42,32 @@ namespace Google.Solutions.Settings.Test.ComponentModel
 
             var descriptor = new MaskedSettingDescriptor(setting);
 
-            Assert.AreEqual("********", descriptor.GetValue(setting));
+            Assert.AreEqual("******", descriptor.GetValue(setting));
+        }
+
+        [Test]
+        public void GetValue_WhenEmpty()
+        {
+            var setting = DictionarySettingsStore
+                .Empty()
+                .Read<SecureString>("key", "display name", "description", "category", null);
+            setting.SetClearTextValue(string.Empty);
+
+            var descriptor = new MaskedSettingDescriptor(setting);
+
+            Assert.AreEqual(string.Empty, descriptor.GetValue(setting));
+        }
+
+        [Test]
+        public void GetValue_WhenNull()
+        {
+            var setting = DictionarySettingsStore
+                .Empty()
+                .Read<SecureString>("key", "display name", "description", "category", null);
+
+            var descriptor = new MaskedSettingDescriptor(setting);
+
+            Assert.IsNull(descriptor.GetValue(setting));
         }
 
         //----------------------------------------------------------------------

--- a/sources/Google.Solutions.Settings/ComponentModel/MaskedSettingDescriptor.cs
+++ b/sources/Google.Solutions.Settings/ComponentModel/MaskedSettingDescriptor.cs
@@ -56,9 +56,18 @@ namespace Google.Solutions.Settings.ComponentModel
 
         public override object GetValue(object component)
         {
-            return this.setting.IsDefault
-                ? null
-                : "********";
+            var value = base.GetValue(component);
+            if (value is SecureString secureString) 
+            {
+                //
+                // Return masked value, retaining the original length.
+                //
+                return new string('*', secureString.Length);
+            }
+            else
+            {
+                return value;
+            }
         }
 
         public override void SetValue(object component, object value)


### PR DESCRIPTION
- Show masked value instead of an empty value if the setting is inherited
- Reflect original length