### PR TITLE
b/335313274 Convert ConnectCore to async method

### DIFF
--- a/sources/Google.Solutions.Terminal.Test/Controls/TestPseudoTerminalClientBase.cs
+++ b/sources/Google.Solutions.Terminal.Test/Controls/TestPseudoTerminalClientBase.cs
@@ -25,6 +25,7 @@ using Google.Solutions.Testing.Apis;
 using Moq;
 using NUnit.Framework;
 using System;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace Google.Solutions.Terminal.Test.Controls
@@ -43,9 +44,10 @@ namespace Google.Solutions.Terminal.Test.Controls
                 this.connectCore = connectCore;
             }
 
-            protected override IPseudoTerminal ConnectCore(PseudoTerminalSize initialSize)
+            protected override Task<IPseudoTerminal> ConnectCoreAsync(
+                PseudoTerminalSize initialSize)
             {
-                return this.connectCore(initialSize);
+                return Task.FromResult(this.connectCore(initialSize));
             }
 
             protected override bool IsCausedByConnectionTimeout(Exception e)

--- a/sources/Google.Solutions.Terminal/Controls/LocalShellClient.cs
+++ b/sources/Google.Solutions.Terminal/Controls/LocalShellClient.cs
@@ -23,6 +23,7 @@ using Google.Solutions.Platform.Dispatch;
 using Google.Solutions.Platform.IO;
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 
 namespace Google.Solutions.Terminal.Controls
 {
@@ -39,7 +40,7 @@ namespace Google.Solutions.Terminal.Controls
             this.shellProgram = shellProgram;
         }
 
-        protected override IPseudoTerminal ConnectCore(
+        protected override Task<IPseudoTerminal> ConnectCoreAsync(
             PseudoTerminalSize initialSize)
         {
             Debug.Assert(this.process == null);
@@ -56,7 +57,7 @@ namespace Google.Solutions.Terminal.Controls
             //
 
             Debug.Assert(this.process.PseudoTerminal != null);
-            return this.process.PseudoTerminal!;
+            return Task.FromResult(this.process.PseudoTerminal!);
         }
 
         private void CloseProcess()


### PR DESCRIPTION
Allow async implementations because some connections (such as slow) are slow to establish.