### PR TITLE
b/374823115 Use IsContainerFullScreen for state tracking

### DIFF
--- a/sources/Google.Solutions.Terminal/Controls/ClientBase.cs
+++ b/sources/Google.Solutions.Terminal/Controls/ClientBase.cs
@@ -99,7 +99,19 @@ namespace Google.Solutions.Terminal.Controls
             this.StateChanged += (_, args) =>
             {
                 this.statePanel.State = this.State;
-                this.statePanel.Visible = !this.IsFullScreen && (
+
+                //
+                // NB. We check IsContainerFullScreen as opposed to
+                //     IsFullScreen here because IsFullScreen (at least
+                //     in the case of the RdpClient) is only updated
+                //     asynchronously after leaving full-screen. 
+                //
+                //     One particular example where this difference shows
+                //     is when the RDP session is disconnected because of
+                //     a session timeout while in full-screen mode.
+                //     
+
+                this.statePanel.Visible = !this.IsContainerFullScreen && (
                     this.State == ConnectionState.NotConnected ||
                     this.State == ConnectionState.Disconnecting ||
                     this.State == ConnectionState.Connecting);
@@ -108,10 +120,10 @@ namespace Google.Solutions.Terminal.Controls
         }
 
         /// <summary>
-        /// Check if the client is currently in full-screen mode.
+        /// Check if the client is currently hosted in a full-screen container.
         /// </summary>
         [Browsable(false)]
-        public virtual bool IsFullScreen
+        public virtual bool IsContainerFullScreen
         {
             get => false;
         }

--- a/sources/Google.Solutions.Terminal/Controls/ClientDiagnosticsWindow.cs
+++ b/sources/Google.Solutions.Terminal/Controls/ClientDiagnosticsWindow.cs
@@ -53,6 +53,11 @@ namespace Google.Solutions.Terminal.Controls
         {
             this.Client = client;
 
+            if (client is RdpClient rdpClient)
+            {
+                rdpClient.MainWindow = this;
+            }
+
             SuspendLayout();
             this.AutoScaleDimensions = new System.Drawing.SizeF(96, 96);
             this.AutoScaleMode = AutoScaleMode.Dpi;

--- a/sources/Google.Solutions.Terminal/Controls/RdpClient.cs
+++ b/sources/Google.Solutions.Terminal/Controls/RdpClient.cs
@@ -197,7 +197,7 @@ namespace Google.Solutions.Terminal.Controls
                 args.Cancel = true;
                 return;
             }
-            else if (this.IsFullScreen)
+            else if (this.IsContainerFullScreen)
             {
                 //
                 // Veto this event as it would leave an orphaned full-screen
@@ -1168,13 +1168,18 @@ namespace Google.Solutions.Terminal.Controls
             Debug.Assert(source.Controls.Count == 0);
         }
 
+        public override bool IsContainerFullScreen
+        {
+            get => this.ContainerFullScreen;
+        }
+
         /// <summary>
         /// Gets or sets full-scren mode for the containing window.
         /// 
         /// This property should only be changed from within RDP
         /// callbacks.
         /// </summary>
-        internal bool ContainerFullScreen
+        protected bool ContainerFullScreen
         {
             get => fullScreenForm != null && fullScreenForm.Visible;
             private set
@@ -1279,7 +1284,7 @@ namespace Google.Solutions.Terminal.Controls
         /// Check if the client is currently in full-screen mode.
         /// </summary>
         [Browsable(false)]
-        public override bool IsFullScreen
+        public bool IsFullScreen
         {
             get
             {
@@ -1325,6 +1330,14 @@ namespace Google.Solutions.Terminal.Controls
             this.client.FullScreen = true;
 
             return true;
+        }
+
+        /// <summary>
+        /// Enter full screen mode.
+        /// </summary>
+        public bool TryEnterFullScreen()
+        {
+            return TryEnterFullScreen(null);
         }
 
         /// <summary>


### PR DESCRIPTION
- Use IsContainerFullScreen instead of IsFullScreen to determine the connection state because IsFullScreen doesn't immediately reflect the correct value after leaving full-screen mode.
- This fixes an issue where an RDP client was left in a defunct state after the session timed out in full-screen mode.