### PR TITLE
Relax parsing rules for metadata keys

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestMetadataAuthorizedPublicKey.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestMetadataAuthorizedPublicKey.cs
@@ -36,13 +36,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
         public void Parse_WhenMalformed(
             [Values(
                 "xxx",
-                "login:ssh-rsa key",
                 "login: key username",
                 "login:ssh-rsa key username morejunk",
                 "login:ssh-rsa key username google-ssh {",
                 "login:ssh-rsa key username google-ssh {}",
                 "login:ssh-rsa key username google-ssh {\"userName\": \"user\", \"expireOn\": null}",
-                "login:ssh-rsa key username google-ssh {\"userName\": \"user\", \"expireOn\": \"x\"}"
+                "login:ssh-rsa key username google-ssh {\"userName\": \"user\", \"expireOn\": \"x\"}",
+                "login:ssh-rsa key username google-ssh {\"notjson}"
             )]
             string line)
         {
@@ -67,6 +67,28 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
             Assert.AreEqual("user", ((UnmanagedMetadataAuthorizedPublicKey)key).Email);
 
             Assert.AreEqual("login:ssh-rsa key user", key.ToString());
+        }
+
+        [Test]
+        public void Parse_UnmanagedRsaKey_WhenUsernameMissing(
+            [Values(
+                "login:ssh-rsa key",
+                "login:ssh-rsa  key    ",
+                " login:ssh-rsa \tkey\t         "
+            )]
+            string line)
+        {
+            var key = MetadataAuthorizedPublicKey.Parse(line);
+            Assert.IsInstanceOf<UnmanagedMetadataAuthorizedPublicKey>(key);
+
+            Assert.AreEqual("login", key.PosixUsername);
+            Assert.AreEqual("ssh-rsa", key.KeyType);
+            Assert.AreEqual("key", key.PublicKey);
+            Assert.IsNull(((UnmanagedMetadataAuthorizedPublicKey)key).Email);
+
+            Assert.AreEqual(
+                "login:ssh-rsa key",
+                key.ToString());
         }
 
         [Test]

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Ssh/IAuthorizedPublicKey.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Protocol/Ssh/IAuthorizedPublicKey.cs
@@ -31,7 +31,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Protocol.Ssh
         /// <summary>
         /// Email address of user.
         /// </summary>
-        string Email { get; }
+        string? Email { get; }
 
         /// <summary>
         /// Type of key (rsa-rsa, ...).

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/SshKeys/AuthorizedPublicKeysList.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/SshKeys/AuthorizedPublicKeysList.cs
@@ -42,7 +42,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.SshKeys
             this.List.GridLines = true;
 
             this.List.BindImageIndex(m => 0);
-            this.List.BindColumn(0, m => m.Key.Email);
+            this.List.BindColumn(0, m => m.Key.Email ?? string.Empty);
             this.List.BindColumn(1, m => m.Key.KeyType);
             this.List.BindColumn(2, m => m.AuthorizationMethod.ToString());
             this.List.BindColumn(3, m =>

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/SshKeys/AuthorizedPublicKeysViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/SshKeys/AuthorizedPublicKeysViewModel.cs
@@ -129,7 +129,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.SshKeys
 
                 var matches = this.AllKeys
                     .Where(k => string.IsNullOrEmpty(this.filter) ||
-                                k.Key.Email.Contains(this.filter) ||
+                                (k.Key.Email != null && k.Key.Email.Contains(this.filter)) ||
                                 k.Key.KeyType.Contains(this.filter));
 
                 this.FilteredKeys.Clear();


### PR DESCRIPTION
- Relax parsing rules to allow excess whitespace
- Refactor tests