### PR TITLE
b/376134352 Add SFTP file browser

### DIFF
--- a/sources/Google.Solutions.Common/IO/StreamExtensions.cs
+++ b/sources/Google.Solutions.Common/IO/StreamExtensions.cs
@@ -28,7 +28,10 @@ namespace Google.Solutions.Common.IO
 {
     public static class StreamExtensions
     {
-        internal const int DefaultBufferSize = 64 * 1024;
+        /// <summary>
+        /// Default size for stream copy operations.
+        /// </summary>
+        public const int DefaultBufferSize = 64 * 1024;
 
         private static void ExpectReadable(Stream s)
         {

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Windows/TestSessionBroker.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Windows/TestSessionBroker.cs
@@ -55,12 +55,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows
             {
             }
 
-            public Task DownloadFilesAsync()
-            {
-                throw new System.NotImplementedException();
-            }
-
-            public Task UploadFilesAsync()
+            public Task TransferFilesAsync()
             {
                 throw new System.NotImplementedException();
             }

--- a/sources/Google.Solutions.IapDesktop.Application/Client/ExternalRestClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Client/ExternalRestClient.cs
@@ -43,14 +43,13 @@ namespace Google.Solutions.IapDesktop.Application.Client
             where TModel : class;
     }
 
-    public class ExternalRestClient : IExternalRestClient
+    public sealed class ExternalRestClient : IExternalRestClient
     {
         //
         // Use the same client for all connections to benefit
         // from connection pooling.
         //
         private readonly RestClient client = new RestClient(Install.UserAgent);
-
 
         public async Task<TModel?> GetAsync<TModel>(Uri url, CancellationToken cancellationToken)
             where TModel : class

--- a/sources/Google.Solutions.IapDesktop.Application/Windows/SessionBroker.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Windows/SessionBroker.cs
@@ -52,14 +52,9 @@ namespace Google.Solutions.IapDesktop.Application.Windows
         bool CanTransferFiles { get; }
 
         /// <summary>
-        /// Download a file from the remote VM.
+        /// Transfer files from or to the remote VM.
         /// </summary>
-        Task DownloadFilesAsync();
-
-        /// <summary>
-        /// Upload a file to the remote VM.
-        /// </summary>
-        Task UploadFilesAsync();
+        Task TransferFilesAsync();
 
         /// <summary>
         /// Instance this session is connected to.

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Session/TestSessionCommands.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/ToolWindows/Session/TestSessionCommands.cs
@@ -370,11 +370,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Sessio
         }
 
         //---------------------------------------------------------------------
-        // DownloadFiles.
+        // TransferFiles.
         //---------------------------------------------------------------------
 
         [Test]
-        public void DownloadFiles_WhenApplicable_ThenDownloadFilesIsEnabled()
+        public void TransferFiles_WhenApplicable_ThenTransferFilesIsEnabled()
         {
             var sessionCommands = new SessionCommands(
                 new Mock<ISessionBroker>().Object);
@@ -385,11 +385,11 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Sessio
 
             Assert.AreEqual(
                 CommandState.Enabled,
-                sessionCommands.DownloadFiles.QueryState(connectedSession.Object));
+                sessionCommands.TransferFiles.QueryState(connectedSession.Object));
         }
 
         [Test]
-        public void DownloadFiles_WhenNotConnected_ThenDownloadFilesIsDisabled()
+        public void TransferFiles_WhenNotConnected_ThenTransferFilesIsDisabled()
         {
             var sessionCommands = new SessionCommands(
                 new Mock<ISessionBroker>().Object);
@@ -402,14 +402,14 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Sessio
 
             Assert.AreEqual(
                 CommandState.Disabled,
-                sessionCommands.DownloadFiles.QueryState(closedSession.Object));
+                sessionCommands.TransferFiles.QueryState(closedSession.Object));
             Assert.AreEqual(
                 CommandState.Disabled,
-                sessionCommands.DownloadFiles.QueryState(rdpSession.Object));
+                sessionCommands.TransferFiles.QueryState(rdpSession.Object));
         }
 
         [Test]
-        public void DownloadFiles_WhenFileTransferNotSupported_ThenDownloadFilesIsDisabled()
+        public void TransferFiles_WhenFileTransferNotSupported_ThenTransferFilesIsDisabled()
         {
             var sessionCommands = new SessionCommands(
                 new Mock<ISessionBroker>().Object);
@@ -423,70 +423,10 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Sessio
 
             Assert.AreEqual(
                 CommandState.Disabled,
-                sessionCommands.DownloadFiles.QueryState(connectedSession.Object));
+                sessionCommands.TransferFiles.QueryState(connectedSession.Object));
             Assert.AreEqual(
                 CommandState.Disabled,
-                sessionCommands.DownloadFiles.QueryState(rdpSession.Object));
-        }
-
-        //---------------------------------------------------------------------
-        // UploadFiles.
-        //---------------------------------------------------------------------
-
-        [Test]
-        public void UploadFiles_WhenApplicable_ThenUploadFilesIsEnabled()
-        {
-            var sessionCommands = new SessionCommands(
-                new Mock<ISessionBroker>().Object);
-
-            var connectedSession = new Mock<ISession>();
-            connectedSession.SetupGet(s => s.IsConnected).Returns(true);
-            connectedSession.SetupGet(s => s.CanTransferFiles).Returns(true);
-
-            Assert.AreEqual(
-                CommandState.Enabled,
-                sessionCommands.UploadFiles.QueryState(connectedSession.Object));
-        }
-
-        [Test]
-        public void UploadFiles_WhenNotConnected_ThenUploadFilesIsDisabled()
-        {
-            var sessionCommands = new SessionCommands(
-                new Mock<ISessionBroker>().Object);
-
-            var closedSession = new Mock<ISession>();
-            closedSession.SetupGet(s => s.IsConnected).Returns(false);
-
-            var rdpSession = new Mock<IRdpSession>();
-            rdpSession.SetupGet(s => s.IsConnected).Returns(true);
-
-            Assert.AreEqual(
-                CommandState.Disabled,
-                sessionCommands.UploadFiles.QueryState(closedSession.Object));
-            Assert.AreEqual(
-                CommandState.Disabled,
-                sessionCommands.UploadFiles.QueryState(rdpSession.Object));
-        }
-
-        [Test]
-        public void UploadFiles_WhenFileTransferNotSupported_ThenUploadFilesIsDisabled()
-        {
-            var sessionCommands = new SessionCommands(
-                new Mock<ISessionBroker>().Object);
-
-            var connectedSession = new Mock<ISession>();
-            connectedSession.SetupGet(s => s.IsConnected).Returns(true);
-            connectedSession.SetupGet(s => s.CanTransferFiles).Returns(false);
-
-            var rdpSession = new Mock<IRdpSession>();
-            rdpSession.SetupGet(s => s.IsConnected).Returns(true);
-
-            Assert.AreEqual(
-                CommandState.Disabled,
-                sessionCommands.UploadFiles.QueryState(connectedSession.Object));
-            Assert.AreEqual(
-                CommandState.Disabled,
-                sessionCommands.UploadFiles.QueryState(rdpSession.Object));
+                sessionCommands.TransferFiles.QueryState(rdpSession.Object));
         }
     }
 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/InitializeSessionExtension.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/InitializeSessionExtension.cs
@@ -296,8 +296,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session
             menu.AddCommand(sessionCommands.EnterFullScreenOnAllScreens);
             menu.AddCommand(connectCommands.DuplicateSession);
             menu.AddSeparator();
-            menu.AddCommand(sessionCommands.DownloadFiles);
-            menu.AddCommand(sessionCommands.UploadFiles);
+            menu.AddCommand(sessionCommands.TransferFiles);
             menu.AddCommand(sessionCommands.TypeClipboardText);
             menu.AddCommand(sessionCommands.ShowSecurityScreen);
             menu.AddCommand(sessionCommands.ShowTaskManager);

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/ClientViewBase.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/ClientViewBase.cs
@@ -230,6 +230,22 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
         public abstract InstanceLocator Instance { get; }
 
         /// <summary>
+        /// Display a non-fatal error.
+        /// </summary>
+        protected virtual void OnError(string caption, Exception e)
+        {
+            if (e.IsCancellation())
+            {
+                //
+                // The user cancelled, nervemind.
+                //
+                return;
+            }
+
+            this.exceptionDialog.Show(this, caption, e);
+        }
+
+        /// <summary>
         /// Display a fatal error.
         /// </summary>
         protected virtual void OnFatalError(Exception e)

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/RdpView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/RdpView.cs
@@ -406,20 +406,10 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
                 .RedirectClipboard == RdpRedirectClipboard.Enabled;
         }
 
-        public Task DownloadFilesAsync()
+        public Task TransferFilesAsync()
         {
             ShowTooltip(
                 "Copy and paste files here",
-                "Use copy and paste to transfer files between " +
-                "your local computer and the VM.");
-
-            return Task.CompletedTask;
-        }
-
-        public Task UploadFilesAsync()
-        {
-            ShowTooltip(
-                "Paste files to upload",
                 "Use copy and paste to transfer files between " +
                 "your local computer and the VM.");
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/SessionCommands.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/SessionCommands.cs
@@ -47,8 +47,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
             this.Logoff = new LogoffCommand();
             this.Reconnect = new ReconnectCommand();
             this.TypeClipboardText = new TypeClipboardTextCommand();
-            this.DownloadFiles = new DownloadFilesCommand();
-            this.UploadFiles = new UploadFilesCommand();
+            this.TransferFiles = new TransferFilesCommand();
             this.CloseAll = new CloseAllCommand(sessionBroker);
             this.CloseAllButThis = new CloseAllButThisCommand(sessionBroker);
         }
@@ -65,8 +64,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
         public IContextCommand<ISession> Logoff { get; }
         public IContextCommand<ISession> Reconnect { get; }
         public IContextCommand<ISession> TypeClipboardText { get; }
-        public IContextCommand<ISession> DownloadFiles { get; }
-        public IContextCommand<ISession> UploadFiles { get; }
+        public IContextCommand<ISession> TransferFiles { get; }
         public IContextCommand<ISession> CloseAll { get; }
         public IContextCommand<ISession> CloseAllButThis { get; }
 
@@ -86,13 +84,13 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
             }
         }
 
-        private class DownloadFilesCommand : SessionCommandBase
+        private class TransferFilesCommand : SessionCommandBase
         {
-            public DownloadFilesCommand()
-                : base("Do&wnload files...")
+            public TransferFilesCommand()
+                : base("&Transfer files...")
             {
                 this.Image = Resources.DownloadFile_16;
-                this.ActivityText = "Downloading files";
+                this.ActivityText = "Transferring files";
             }
 
             protected override bool IsEnabled(ISession session)
@@ -104,29 +102,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
 
             public override Task ExecuteAsync(ISession session)
             {
-                return session.DownloadFilesAsync();
-            }
-        }
-
-        private class UploadFilesCommand : SessionCommandBase
-        {
-            public UploadFilesCommand()
-                : base("U&pload files...")
-            {
-                this.Image = Resources.UploadFile_16;
-                this.ActivityText = "Uploading files";
-            }
-
-            protected override bool IsEnabled(ISession session)
-            {
-                return session != null &&
-                    session.IsConnected &&
-                    session.CanTransferFiles;
-            }
-
-            public override Task ExecuteAsync(ISession session)
-            {
-                return session.UploadFilesAsync();
+                return session.TransferFilesAsync();
             }
         }
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/SshKeyboardInteractiveHandler.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/SshKeyboardInteractiveHandler.cs
@@ -103,7 +103,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
             }
             else
             {
-                throw new OperationCanceledException(); // TODO: Verify that OperationCanceledException is handled correctly.
+                throw new OperationCanceledException();
             }
         }
 

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/SshView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/SshView.cs
@@ -165,6 +165,9 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
                 //
                 ApplyTerminalSettings(this.settingsRepository.GetSettings());
 
+                client.FileBrowsingFailed += (_, args)
+                    => OnError("The file operation failed", args.Exception);
+
                 //
                 // Start establishing a connection and react to events.
                 //

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/SshView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/SshView.cs
@@ -166,7 +166,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
                 ApplyTerminalSettings(this.settingsRepository.GetSettings());
 
                 client.FileBrowsingFailed += (_, args)
-                    => OnError("The file operation failed", args.Exception);
+                    => OnError("Unable to complete file operation", args.Exception);
 
                 //
                 // Start establishing a connection and react to events.

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/SshView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/SshView.cs
@@ -46,7 +46,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
 {
     [Service]
     public class SshView
-        : ClientViewBase<SshShellClient>, ISshSession, IView<SshViewModel>
+        : ClientViewBase<SshHybridClient>, ISshSession, IView<SshViewModel>
     {
         private Bound<SshViewModel> viewModel;
         private readonly ITerminalSettingsRepository settingsRepository;
@@ -245,7 +245,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
             }
         }
 
-        protected override void OnKeyDown(KeyEventArgs e) // TODO: verify this works
+        protected override void OnKeyDown(KeyEventArgs e)
         {
             if (e.KeyData == ToggleFocusHotKey)
             {
@@ -260,24 +260,20 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
 
         public bool CanTransferFiles
         {
-            //TODO: SFTP - Implement dnd
-            get => false;
+            get => 
+                this.Client != null &&
+                this.Client.CanShowFileBrowser;
         }
 
         //---------------------------------------------------------------------
         // ISshSession.
         //---------------------------------------------------------------------
 
-        public Task DownloadFilesAsync()
+        public Task TransferFilesAsync()
         {
-            //TODO: SFTP - Show pane.
-            throw new NotImplementedException();
-        }
-
-        public Task UploadFilesAsync()
-        {
-            //TODO: SFTP - Show pane.
-            throw new NotImplementedException();
+            Debug.Assert(this.CanTransferFiles);
+            this.Client?.BrowseFiles();
+            return Task.CompletedTask;
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowser.cs
@@ -31,6 +31,7 @@ using System.Collections.ObjectModel;
 using System.Drawing;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices.ComTypes;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -668,8 +669,16 @@ namespace Google.Solutions.Mvvm.Test.Controls
                     Exception? fileCopyException = null;
                     browser.FileCopyFailed += (_, args) => fileCopyException = args.Exception;
 
+                    var ucomDataObject = (System.Runtime.InteropServices.ComTypes.IDataObject)dataObject;
+                    var formatetc = new FORMATETC()
+                    {
+                        tymed = TYMED.TYMED_HGLOBAL,
+                        cfFormat = (short)DataFormats.GetFormat(VirtualFileDataObject.CFSTR_FILECONTENTS).Id,
+                        dwAspect = DVASPECT.DVASPECT_CONTENT,
+                        lindex = 0
+                    };
                     Assert.Throws<UnauthorizedAccessException>(
-                        () => dataObject.GetData(VirtualFileDataObject.CFSTR_FILECONTENTS));
+                        () => ucomDataObject.GetData(ref formatetc, out var medium));
 
                     Assert.IsInstanceOf<UnauthorizedAccessException>(fileCopyException);
                 }

--- a/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowser.cs
@@ -984,5 +984,43 @@ namespace Google.Solutions.Mvvm.Test.Controls
                     Times.Exactly(2));
             }
         }
+
+        //---------------------------------------------------------------------
+        // Dispose.
+        //---------------------------------------------------------------------
+
+        [Test]
+        public void Dispose_DisposesFileSystem()
+        {
+            var fileSystem = new Mock<IFileSystem>();
+            fileSystem
+                .SetupGet(fs => fs.Root)
+                .Returns(CreateDirectory().Object);
+            fileSystem
+                .Setup(fs => fs.ListFilesAsync(It.IsAny<IFileItem>()))
+                .ReturnsAsync(new ObservableCollection<IFileItem>());
+
+            using (var form = new Form()
+            {
+                Size = new Size(800, 600)
+            })
+            {
+                var browser = new FileBrowser()
+                {
+                    Dock = DockStyle.Fill
+                };
+                form.Controls.Add(browser);
+
+
+                browser.Bind(
+                    fileSystem.Object,
+                    new Mock<IBindingContext>().Object);
+                Application.DoEvents();
+
+                form.Show();
+            }
+
+            fileSystem.Verify(f => f.Dispose(), Times.Once);
+        }
     }
 }

--- a/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowser.cs
@@ -673,7 +673,7 @@ namespace Google.Solutions.Mvvm.Test.Controls
                     var formatetc = new FORMATETC()
                     {
                         tymed = TYMED.TYMED_HGLOBAL,
-                        cfFormat = (short)DataFormats.GetFormat(VirtualFileDataObject.CFSTR_FILECONTENTS).Id,
+                        cfFormat = (short)DataFormats.GetFormat(ShellDataFormats.CFSTR_FILECONTENTS).Id,
                         dwAspect = DVASPECT.DVASPECT_CONTENT,
                         lindex = 0
                     };

--- a/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowserUi.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowserUi.cs
@@ -104,6 +104,10 @@ namespace Google.Solutions.Mvvm.Test.Controls
                 await Task.Delay(750);
                 return (new ObservableCollection<IFileItem>(directories.Concat(files)));
             }
+
+            public void Dispose()
+            {
+            }
         }
 
         private class LocalFileItem : ViewModelBase, IFileItem

--- a/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowserUi.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowserUi.cs
@@ -105,6 +105,34 @@ namespace Google.Solutions.Mvvm.Test.Controls
                 return (new ObservableCollection<IFileItem>(directories.Concat(files)));
             }
 
+            public Task<Stream> OpenFileAsync(
+                IFileItem file,
+                FileAccess access)
+            {
+                var localFile = (LocalFileItem)file;
+                Precondition.Expect(localFile.IsFile, "Not a file");
+
+                return Task.FromResult<Stream>(File.Open(
+                    localFile.FileInfo.FullName,
+                    FileMode.Open,
+                    access));
+            }
+
+            public Task<Stream> OpenFileAsync(
+                IFileItem directory,
+                string name,
+                FileMode mode,
+                FileAccess access)
+            {
+                var localDirectory = (LocalFileItem)directory;
+                Precondition.Expect(!localDirectory.IsFile, "Not a directory");
+
+                return Task.FromResult<Stream>(File.Open(
+                    System.IO.Path.Combine(localDirectory.FileInfo.FullName, name),
+                    FileMode.OpenOrCreate,
+                    access));
+            }
+
             public void Dispose()
             {
             }
@@ -171,25 +199,6 @@ namespace Google.Solutions.Mvvm.Test.Controls
                     this.expanded = value;
                     RaisePropertyChange();
                 }
-            }
-
-            public Stream Open(FileAccess access)
-            {
-                Precondition.Expect(this.IsFile, "Not a file");
-                return File.Open(this.FileInfo.FullName, FileMode.Open, access);
-            }
-
-            public Stream Create(
-                string name,
-                FileMode mode,
-                FileAccess access)
-            {
-                Precondition.Expect(!this.IsFile, "Not a directory");
-
-                return File.Open(
-                    System.IO.Path.Combine(this.FileInfo.FullName, name), 
-                    FileMode.OpenOrCreate,
-                    access);
             }
         }
     }

--- a/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowserUi.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowserUi.cs
@@ -180,7 +180,8 @@ namespace Google.Solutions.Mvvm.Test.Controls
             }
 
             public Stream Create(
-                string name, 
+                string name,
+                FileMode mode,
                 FileAccess access)
             {
                 Precondition.Expect(!this.IsFile, "Not a directory");

--- a/sources/Google.Solutions.Mvvm.Test/Shell/TestVirtualFileDataObject.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Shell/TestVirtualFileDataObject.cs
@@ -60,11 +60,11 @@ namespace Google.Solutions.Mvvm.Test.Shell
                 });
 
                 Assert.IsInstanceOf<Stream>(dataObject.GetData(
-                    VirtualFileDataObject.CFSTR_FILEDESCRIPTORW, 
+                    ShellDataFormats.CFSTR_FILEDESCRIPTORW, 
                     false));
 
                 Assert.IsInstanceOf<Stream>(dataObject.GetData(
-                    VirtualFileDataObject.CFSTR_FILECONTENTS, 
+                    ShellDataFormats.CFSTR_FILECONTENTS, 
                     false));
             }
         }
@@ -85,7 +85,7 @@ namespace Google.Solutions.Mvvm.Test.Shell
                 Array.Empty<VirtualFileDataObject.Descriptor>());
             dataObject.Dispose();
             Assert.IsNull(dataObject.GetData(
-                VirtualFileDataObject.CFSTR_FILEDESCRIPTORW, 
+                ShellDataFormats.CFSTR_FILEDESCRIPTORW, 
                 false));
         }
 
@@ -112,7 +112,7 @@ namespace Google.Solutions.Mvvm.Test.Shell
                 });
 
             var stream = (Stream)dataObject.GetData(
-                VirtualFileDataObject.CFSTR_FILECONTENTS,
+                ShellDataFormats.CFSTR_FILECONTENTS,
                 false);
             Assert.AreEqual(2, stream.Length);
             Assert.AreEqual(2, stream.Read(new byte[2], 0, 2));

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.Designer.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.Designer.cs
@@ -60,8 +60,8 @@ namespace Google.Solutions.Mvvm.Controls
             this.sizeColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.filesContextMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.refreshToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.refreshToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             nameColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             lastModifiedColumn = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer)).BeginInit();
@@ -115,7 +115,6 @@ namespace Google.Solutions.Mvvm.Controls
             this.directoryTree.SelectedImageIndex = 0;
             this.directoryTree.Size = new System.Drawing.Size(200, 256);
             this.directoryTree.TabIndex = 0;
-            this.directoryTree.HideSelection = false;
             this.directoryTree.SelectedModelNodeChanged += new System.EventHandler(this.directoryTree_SelectedModelNodeChanged);
             this.directoryTree.KeyDown += new System.Windows.Forms.KeyEventHandler(this.fileList_KeyDown);
             // 
@@ -144,14 +143,13 @@ namespace Google.Solutions.Mvvm.Controls
             this.fileList.Size = new System.Drawing.Size(390, 256);
             this.fileList.SmallImageList = this.fileIconsList;
             this.fileList.TabIndex = 1;
-            this.fileList.HideSelection = false;
             this.fileList.UseCompatibleStateImageBehavior = false;
             this.fileList.View = System.Windows.Forms.View.Details;
             this.fileList.DragDrop += new System.Windows.Forms.DragEventHandler(this.fileList_DragDrop);
             this.fileList.DragEnter += new System.Windows.Forms.DragEventHandler(this.fileList_DragEnter);
             this.fileList.DoubleClick += new System.EventHandler(this.fileList_DoubleClick);
             this.fileList.KeyDown += new System.Windows.Forms.KeyEventHandler(this.fileList_KeyDown);
-            this.fileList.MouseDown += new System.Windows.Forms.MouseEventHandler(this.fileList_MouseDown);
+            this.fileList.MouseMove += new System.Windows.Forms.MouseEventHandler(this.fileList_MouseMove);
             // 
             // typeColumn
             // 
@@ -171,29 +169,29 @@ namespace Google.Solutions.Mvvm.Controls
             this.pasteToolStripMenuItem,
             this.refreshToolStripMenuItem});
             this.filesContextMenu.Name = "contextMenu";
-            this.filesContextMenu.Size = new System.Drawing.Size(181, 92);
+            this.filesContextMenu.Size = new System.Drawing.Size(114, 70);
             // 
             // copyToolStripMenuItem
             // 
             this.copyToolStripMenuItem.Image = global::Google.Solutions.Mvvm.Properties.Resources.Copy_16x;
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
-            this.copyToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.copyToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
             this.copyToolStripMenuItem.Text = "&Copy";
             this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
-            // 
-            // refreshToolStripMenuItem
-            // 
-            this.refreshToolStripMenuItem.Name = "refreshToolStripMenuItem";
-            this.refreshToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
-            this.refreshToolStripMenuItem.Text = "&Refresh";
-            this.refreshToolStripMenuItem.Click += new System.EventHandler(this.refreshToolStripMenuItem_Click);
             // 
             // pasteToolStripMenuItem
             // 
             this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
-            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.pasteToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
             this.pasteToolStripMenuItem.Text = "&Paste";
             this.pasteToolStripMenuItem.Click += new System.EventHandler(this.pasteToolStripMenuItem_Click);
+            // 
+            // refreshToolStripMenuItem
+            // 
+            this.refreshToolStripMenuItem.Name = "refreshToolStripMenuItem";
+            this.refreshToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
+            this.refreshToolStripMenuItem.Text = "&Refresh";
+            this.refreshToolStripMenuItem.Click += new System.EventHandler(this.refreshToolStripMenuItem_Click);
             // 
             // FileBrowser
             // 

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.Designer.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.Designer.cs
@@ -115,6 +115,7 @@ namespace Google.Solutions.Mvvm.Controls
             this.directoryTree.SelectedImageIndex = 0;
             this.directoryTree.Size = new System.Drawing.Size(200, 256);
             this.directoryTree.TabIndex = 0;
+            this.directoryTree.HideSelection = false;
             this.directoryTree.SelectedModelNodeChanged += new System.EventHandler(this.directoryTree_SelectedModelNodeChanged);
             this.directoryTree.KeyDown += new System.Windows.Forms.KeyEventHandler(this.fileList_KeyDown);
             // 
@@ -143,6 +144,7 @@ namespace Google.Solutions.Mvvm.Controls
             this.fileList.Size = new System.Drawing.Size(390, 256);
             this.fileList.SmallImageList = this.fileIconsList;
             this.fileList.TabIndex = 1;
+            this.fileList.HideSelection = false;
             this.fileList.UseCompatibleStateImageBehavior = false;
             this.fileList.View = System.Windows.Forms.View.Details;
             this.fileList.DragDrop += new System.Windows.Forms.DragEventHandler(this.fileList_DragDrop);

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -426,7 +426,7 @@ namespace Google.Solutions.Mvvm.Controls
             }
         }
 
-        private void fileList_MouseDown(object sender, MouseEventArgs args)
+        private void fileList_MouseMove(object sender, MouseEventArgs args)
         {
             if (args.Button != MouseButtons.Left)
             {
@@ -451,8 +451,6 @@ namespace Google.Solutions.Mvvm.Controls
             {
                 OnFileCopyFailed(e);
             }
-
-            //TODO: Cancel selection after drag - https://stackoverflow.com/questions/8066982/disabling-drag-selection-on-listbox
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -352,20 +352,23 @@ namespace Google.Solutions.Mvvm.Controls
                     // Go down one level, same as double-click.
                     //
                     fileList_DoubleClick(sender, EventArgs.Empty);
+                    args.Handled = true;
                 }
-                if (args.KeyCode == Keys.C && args.Control)
+                else if (args.KeyCode == Keys.C && args.Control)
                 {
                     //
                     // Copy files.
                     //
                     copyToolStripMenuItem_Click(sender, EventArgs.Empty);
+                    args.Handled = true;
                 }
-                if (args.KeyCode == Keys.V && args.Control)
+                else if (args.KeyCode == Keys.V && args.Control)
                 {
                     //
                     // Paste files.
                     //
                     pasteToolStripMenuItem_Click(sender, EventArgs.Empty);
+                    args.Handled = true;
                 }
                 else if (args.KeyCode == Keys.Up && args.Alt)
                 {
@@ -373,10 +376,12 @@ namespace Google.Solutions.Mvvm.Controls
                     // Go up one level.
                     //
                     await NavigateUpAsync();
+                    args.Handled = true;
                 }
                 else if (args.KeyCode == Keys.F5)
                 {
                     await RefreshAsync();
+                    args.Handled = true;
                 }
             }
             catch (Exception e)
@@ -440,6 +445,8 @@ namespace Google.Solutions.Mvvm.Controls
             {
                 OnNavigationFailed(e);
             }
+
+            //TODO: Cancel selection after drag - https://stackoverflow.com/questions/8066982/disabling-drag-selection-on-listbox
         }
 
         //---------------------------------------------------------------------
@@ -559,6 +566,8 @@ namespace Google.Solutions.Mvvm.Controls
             {
                 var conflictingItem = this.currentDirectoryContents
                     .FirstOrDefault(f => f.Name == file.Name);
+
+                // TODO: Optimize dialog messages
 
                 var dialogResult = DialogResult.OK;
                 if (conflictingItem != null && !conflictingItem.Type.IsFile)
@@ -689,7 +698,7 @@ namespace Google.Solutions.Mvvm.Controls
                         var parameters = new TaskDialogParameters(
                             "Copy files",
                             file.Name,
-                            e.Unwrap().Message)
+                            e.Unwrap().Message) // TODO: Optimize error message
                         {
                             Icon = TaskDialogIcon.Error
                         };

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -717,7 +717,7 @@ namespace Google.Solutions.Mvvm.Controls
                     {
                         var parameters = new TaskDialogParameters(
                             "Copy files",
-                            file.Name,
+                            $"Unable to copy {file.Name}",
                             e.Unwrap().Message)
                         {
                             Icon = TaskDialogIcon.Error

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -521,6 +521,8 @@ namespace Google.Solutions.Mvvm.Controls
                         return this.fileSystem!
                             .OpenFileAsync(f, FileAccess.Read)
                             .Result;
+
+                        //TODO: catch & report exception (on UI thread)
                     }))
                 .ToList())
             {

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -103,6 +103,7 @@ namespace Google.Solutions.Mvvm.Controls
             this.Disposed += (s, e) =>
             {
                 this.fileTypeCache.Dispose();
+                this.fileSystem?.Dispose();
             };
         }
 

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -524,17 +524,9 @@ namespace Google.Solutions.Mvvm.Controls
                         //     should come from a worker thread, not the UI
                         //     thread.
                         //
-                        try
-                        {
-                            return this.fileSystem!
-                                .OpenFileAsync(f, FileAccess.Read)
-                                .Result;
-                        }
-                        catch (Exception e)
-                        {
-                            this.Invoke(new Action(() => OnFileCopyFailed(e)));
-                            throw;
-                        }
+                        return this.fileSystem!
+                            .OpenFileAsync(f, FileAccess.Read)
+                            .Result;
                     }))
                 .ToList())
             {
@@ -543,6 +535,11 @@ namespace Google.Solutions.Mvvm.Controls
                 // the data.
                 //
                 IsAsync = true
+            };
+
+            dataObject.AsyncOperationFailed += (_, args) =>
+            {
+                this.Invoke(new Action(() => OnFileCopyFailed(args.Exception)));
             };
 
             return dataObject;

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -641,8 +641,10 @@ namespace Google.Solutions.Mvvm.Controls
                                     using (var sourceStream = file.OpenRead())
                                     using (var targetStream = this.navigationState!.Directory.Create(
                                         file.Name,
+                                        FileMode.Create,
                                         FileAccess.Write))
                                     {
+                                        //TODO: Async, w/ right buffer size
                                         sourceStream.CopyTo(targetStream, copyProgress);
                                     }
                                 })

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -29,6 +29,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -483,6 +484,9 @@ namespace Google.Solutions.Mvvm.Controls
         /// <summary>
         /// Create an IDataObject with the contents of the selected files.
         /// </summary>
+        [SuppressMessage("Usage", 
+            "VSTHRD002:Avoid problematic synchronous waits", 
+            Justification = "Blocking calls made from worker thread")]
         internal VirtualFileDataObject CopySelectedFiles()
         {
             Precondition.ExpectNotNull(this.fileSystem, nameof(this.fileSystem));
@@ -501,12 +505,16 @@ namespace Google.Solutions.Mvvm.Controls
                         //
                         // NB. We're in a synchronous execution path here,
                         //     so we can't open the file asynchronously.
-                        // TODO: On background thread here?
+                        //
+                        //     However, this isn't a problem because this
+                        //     is an asynchronous data object, so the call
+                        //     should come from a worker thread, not the UI
+                        //     thread.
                         //
                         return this.fileSystem!
                             .OpenFileAsync(f, FileAccess.Read)
                             .Result;
-                        }))
+                    }))
                 .ToList())
             {
                 //

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -569,8 +569,6 @@ namespace Google.Solutions.Mvvm.Controls
                 var conflictingItem = this.currentDirectoryContents
                     .FirstOrDefault(f => f.Name == file.Name);
 
-                // TODO: Optimize dialog messages
-
                 var dialogResult = DialogResult.OK;
                 if (conflictingItem != null && !conflictingItem.Type.IsFile)
                 {
@@ -582,7 +580,11 @@ namespace Google.Solutions.Mvvm.Controls
                     var parameters = new TaskDialogParameters(
                         "Copy files",
                         $"The destination already has a directory named '{conflictingItem.Name}'",
-                        string.Empty);
+                        string.Empty)
+                    {
+                        Icon = TaskDialogIcon.Error
+                    };
+
                     parameters.Buttons.Add(new TaskDialogCommandLinkButton(
                         "Skip this file",
                         DialogResult.Ignore));
@@ -600,7 +602,11 @@ namespace Google.Solutions.Mvvm.Controls
                     var parameters = new TaskDialogParameters(
                         "Copy files",
                         $"The destination already has a file named '{conflictingItem.Name}'",
-                        string.Empty);
+                        string.Empty)
+                    {
+                        Icon = TaskDialogIcon.Warning
+                    };
+
                     parameters.Buttons.Add(new TaskDialogCommandLinkButton(
                         "Replace the file in the destination",
                         DialogResult.OK));
@@ -695,12 +701,12 @@ namespace Google.Solutions.Mvvm.Controls
                                 })
                             .ConfigureAwait(true);
                     }
-                    catch (Exception e)
+                    catch (Exception e) when (!e.IsCancellation())
                     {
                         var parameters = new TaskDialogParameters(
                             "Copy files",
                             file.Name,
-                            e.Unwrap().Message) // TODO: Optimize error message
+                            e.Unwrap().Message)
                         {
                             Icon = TaskDialogIcon.Error
                         };

--- a/sources/Google.Solutions.Mvvm/Controls/IFileSystem.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/IFileSystem.cs
@@ -40,6 +40,28 @@ namespace Google.Solutions.Mvvm.Controls
         /// Returns an empty collection if the directory is empty.
         /// </summary>
         Task<ObservableCollection<IFileItem>> ListFilesAsync(IFileItem directory);
+
+        /// <summary>
+        /// Open a file for reading or writing.
+        /// </summary>
+        /// <param name="directory">Parent directory</param>
+        /// <param name="name">Name of the file</param>
+        /// <param name="mode">Defines whether to create or open a file</param>
+        /// <param name="access">Type of access</param>
+        Task<Stream> OpenFileAsync(
+            IFileItem directory,
+            string name,
+            FileMode mode,
+            FileAccess access);
+
+        /// <summary>
+        /// Open a file for reading or writing.
+        /// </summary>
+        /// <param name="file">File to open</param>
+        /// <param name="access">Type of access</param>
+        Task<Stream> OpenFileAsync(
+            IFileItem file,
+            FileAccess access);
     }
 
     /// <summary>
@@ -81,24 +103,5 @@ namespace Google.Solutions.Mvvm.Controls
         /// Gets or sets the expansion state.
         /// </summary>
         bool IsExpanded { get; set; }
-
-        /// <summary>
-        /// Open the file.
-        /// </summary>
-        /// <param name="access">Type of access</param>
-        /// <remarks>Only applicable if the item is a file</remarks>
-        Stream Open(FileAccess access);
-
-        /// <summary>
-        /// Create or open a file.
-        /// </summary>
-        /// <param name="name">Name of the file</param>
-        /// <param name="mode">Defines whether to create or open a file</param>
-        /// <param name="access">Type of access</param>
-        /// <remarks>Only applicable if the item is a directory</remarks>
-        Stream Create(
-            string name,
-            FileMode mode,
-            FileAccess access);
     }
 }

--- a/sources/Google.Solutions.Mvvm/Controls/IFileSystem.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/IFileSystem.cs
@@ -85,7 +85,7 @@ namespace Google.Solutions.Mvvm.Controls
         /// <summary>
         /// Open the file.
         /// </summary>
-        /// <param name="access">type of access</param>
+        /// <param name="access">Type of access</param>
         /// <remarks>Only applicable if the item is a file</remarks>
         Stream Open(FileAccess access);
 
@@ -93,10 +93,12 @@ namespace Google.Solutions.Mvvm.Controls
         /// Create or open a file.
         /// </summary>
         /// <param name="name">Name of the file</param>
-        /// <param name="access">type of access</param>
+        /// <param name="mode">Defines whether to create or open a file</param>
+        /// <param name="access">Type of access</param>
         /// <remarks>Only applicable if the item is a directory</remarks>
         Stream Create(
             string name,
+            FileMode mode,
             FileAccess access);
     }
 }

--- a/sources/Google.Solutions.Mvvm/Controls/IFileSystem.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/IFileSystem.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 
 namespace Google.Solutions.Mvvm.Controls
 {
-    public interface IFileSystem
+    public interface IFileSystem : IDisposable
     {
         /// <summary>
         /// Root of the file system.

--- a/sources/Google.Solutions.Mvvm/Shell/FileType.cs
+++ b/sources/Google.Solutions.Mvvm/Shell/FileType.cs
@@ -129,21 +129,42 @@ namespace Google.Solutions.Mvvm.Shell
             private const int MAX_PATH = 260;
             private const int NAMESIZE = 80;
 
-            [StructLayout(LayoutKind.Sequential)]
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
             public struct SHFILEINFOA
             {
+                /// <summary>
+                /// A handle to the icon that represents the file. 
+                /// </summary>
                 public IntPtr hIcon;
+
+                /// <summary>
+                /// The index of the icon image within the system image list.
+                /// </summary>
                 public int iIcon;
+
+                /// <summary>
+                /// An array of values that indicates the attributes of the
+                /// file object. 
+                /// </summary>
                 public uint dwAttributes;
+
+                /// <summary>
+                /// A string that contains the name of the file as it appears
+                /// in the Windows Shell
+                /// </summary>
                 [MarshalAs(UnmanagedType.ByValTStr, SizeConst = MAX_PATH)]
                 public string szDisplayName;
+
+                /// <summary>
+                /// A string that describes the type of file.
+                /// </summary>
                 [MarshalAs(UnmanagedType.ByValTStr, SizeConst = NAMESIZE)]
                 public string szTypeName;
             };
 
-            [DllImport("Shell32.dll", CharSet = CharSet.Ansi)]
+            [DllImport("Shell32.dll", CharSet = CharSet.Unicode)]
             public static extern IntPtr SHGetFileInfo(
-                [In] string pszPath,
+                [In][MarshalAs(UnmanagedType.LPWStr)] string pszPath,
                 [In] FileAttributes dwFileAttributes,
                 [In][Out] ref SHFILEINFOA psfi,
                 [In] uint cbFileInfo,

--- a/sources/Google.Solutions.Mvvm/Shell/ShellDataFormats.cs
+++ b/sources/Google.Solutions.Mvvm/Shell/ShellDataFormats.cs
@@ -1,0 +1,54 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+namespace Google.Solutions.Mvvm.Shell
+{
+    /// <summary>
+    /// Shell Clipboard Formats.
+    /// </summary>
+    internal static class ShellDataFormats
+    {
+        /// <summary>
+        /// This format identifier is used with the CFSTR_FILECONTENTS 
+        /// format to transfer data as a group of files. 
+        /// </summary>
+        internal const string CFSTR_FILEDESCRIPTORW = "FileGroupDescriptorW";
+
+        /// <summary>
+        /// This format identifier is used with the CFSTR_FILEDESCRIPTOR 
+        /// format to transfer data as if it were a file, regardless of how it 
+        /// is actually stored.
+        /// </summary>
+        internal const string CFSTR_FILECONTENTS = "FileContents";
+
+        /// <summary>
+        /// This format identifier is used by the source to specify whether its 
+        /// preferred method of data transfer is move or copy.
+        /// </summary>
+        internal const string CFSTR_PREFERREDDROPEFFECT = "Preferred DropEffect";
+
+        /// <summary>
+        /// This format identifier is used by the target to inform the data object
+        /// through its IDataObject::SetData method of the outcome of a data transfer.
+        /// </summary>
+        internal const string CFSTR_PERFORMEDDROPEFFECT = "Performed DropEffect";
+    }
+}

--- a/sources/Google.Solutions.Mvvm/Shell/VirtualFileDataObject.cs
+++ b/sources/Google.Solutions.Mvvm/Shell/VirtualFileDataObject.cs
@@ -26,7 +26,6 @@ using Google.Solutions.Platform.Interop;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection.Emit;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Windows.Forms;
@@ -68,9 +67,9 @@ namespace Google.Solutions.Mvvm.Shell
             //
             // Enable delayed rendering
             //
-            SetData(CFSTR_FILEDESCRIPTORW, null);
-            SetData(CFSTR_FILECONTENTS, null);
-            SetData(CFSTR_PERFORMEDDROPEFFECT, null);
+            SetData(ShellDataFormats.CFSTR_FILEDESCRIPTORW, null);
+            SetData(ShellDataFormats.CFSTR_FILECONTENTS, null);
+            SetData(ShellDataFormats.CFSTR_PERFORMEDDROPEFFECT, null);
         }
 
         /// <summary>
@@ -118,16 +117,16 @@ namespace Google.Solutions.Mvvm.Shell
                 return null;
             }
 
-            if (CFSTR_FILEDESCRIPTORW.Equals(format, StringComparison.OrdinalIgnoreCase))
+            if (ShellDataFormats.CFSTR_FILEDESCRIPTORW.Equals(format, StringComparison.OrdinalIgnoreCase))
             {
                 //
                 // Supply group descriptor for all files.
                 //
                 base.SetData(
-                    CFSTR_FILEDESCRIPTORW,
+                    ShellDataFormats.CFSTR_FILEDESCRIPTORW,
                     Descriptor.ToNativeGroupDescriptorStream(this.Files));
             }
-            else if (CFSTR_FILECONTENTS.Equals(format, StringComparison.OrdinalIgnoreCase))
+            else if (ShellDataFormats.CFSTR_FILECONTENTS.Equals(format, StringComparison.OrdinalIgnoreCase))
             {
                 //
                 // Open the stream. We do that lazily in case the client
@@ -154,7 +153,7 @@ namespace Google.Solutions.Mvvm.Shell
                 //
                 //
                 base.SetData(
-                    CFSTR_FILECONTENTS,
+                    ShellDataFormats.CFSTR_FILECONTENTS,
                     this.currentFile < this.Files.Count
                         ? contentStream
                         : null);
@@ -178,7 +177,8 @@ namespace Google.Solutions.Mvvm.Shell
             //     information is encoded in the FORMATETC parameter.
             //
 
-            if (formatetc.cfFormat == (short)DataFormats.GetFormat(CFSTR_FILECONTENTS).Id)
+            if (formatetc.cfFormat == 
+                (short)DataFormats.GetFormat(ShellDataFormats.CFSTR_FILECONTENTS).Id)
             {
                 //
                 // Cache the index so that we can use it in GetData(format, autoConvert).
@@ -221,7 +221,7 @@ namespace Google.Solutions.Mvvm.Shell
 
                         if (e is COMException comEx && (
                             comEx.HResult == DV_E_FORMATETC ||
-                            comEx.HResult == E_FAIL))
+                            comEx.HResult == (int)HRESULT.E_FAIL))
                         {
                             //
                             // These can happen during format negotiation and 
@@ -276,14 +276,14 @@ namespace Google.Solutions.Mvvm.Shell
         {
             ExpectNotDisposed();
 
-            this.IsAsync = fDoOpAsync != VARIANT_FALSE;
+            this.IsAsync = fDoOpAsync != VariantBool.False;
         }
 
         public void GetAsyncMode([Out] out int pfIsOpAsync)
         {
             ExpectNotDisposed();
 
-            pfIsOpAsync = this.IsAsync ? VARIANT_TRUE : VARIANT_FALSE;
+            pfIsOpAsync = this.IsAsync ? VariantBool.True : VariantBool.False;
         }
 
         public void StartOperation([In] IBindCtx pbcReserved)
@@ -319,7 +319,7 @@ namespace Google.Solutions.Mvvm.Shell
         {
             ExpectNotDisposed();
 
-            pfInAsyncOp = this.IsOperationInProgress ? VARIANT_TRUE : VARIANT_FALSE;
+            pfInAsyncOp = this.IsOperationInProgress ? VariantBool.True : VariantBool.False;
         }
 
         //----------------------------------------------------------------------
@@ -616,22 +616,13 @@ namespace Google.Solutions.Mvvm.Shell
         private const uint FD_PROGRESSUI = 0x00004000;
         private const uint FD_UNICODE = 0x80000000;
 
-        internal const string CFSTR_FILEDESCRIPTORW = "FileGroupDescriptorW"; // TODO: Extract to class
-        internal const string CFSTR_FILECONTENTS = "FileContents";
-        internal const string CFSTR_PREFERREDDROPEFFECT = "Preferred DropEffect";
-        internal const string CFSTR_PERFORMEDDROPEFFECT = "Performed DropEffect";
-
         private const uint GMEM_MOVEABLE = 0x0002;
         private const uint GMEM_ZEROINIT = 0x0040;
         private const uint GHND = (GMEM_MOVEABLE | GMEM_ZEROINIT);
         private const uint GMEM_DDESHARE = 0x2000;
 
-        private const int VARIANT_FALSE = 0;
-        private const int VARIANT_TRUE = -1;
-
-        private const int DV_E_TYMED = unchecked((int)0x80040069); // TODO: Move to HRESULT
+        private const int DV_E_TYMED = unchecked((int)0x80040069);
         private const int DV_E_FORMATETC = unchecked((int)0x80040064);
-        private const int E_FAIL = unchecked((int)0x80004005);
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         internal struct FILEDESCRIPTORW

--- a/sources/Google.Solutions.Mvvm/Shell/VirtualFileDataObject.cs
+++ b/sources/Google.Solutions.Mvvm/Shell/VirtualFileDataObject.cs
@@ -629,7 +629,7 @@ namespace Google.Solutions.Mvvm.Shell
         private const int VARIANT_FALSE = 0;
         private const int VARIANT_TRUE = -1;
 
-        private const int DV_E_TYMED = unchecked((int)0x80040069);
+        private const int DV_E_TYMED = unchecked((int)0x80040069); // TODO: Move to HRESULT
         private const int DV_E_FORMATETC = unchecked((int)0x80040064);
         private const int E_FAIL = unchecked((int)0x80004005);
 

--- a/sources/Google.Solutions.Mvvm/Shell/VirtualFileDataObject.cs
+++ b/sources/Google.Solutions.Mvvm/Shell/VirtualFileDataObject.cs
@@ -587,18 +587,14 @@ namespace Google.Solutions.Mvvm.Shell
         // Interop declarations.
         //----------------------------------------------------------------------
 
-        private const uint FD_CLSID = 0x00000001;
-        private const uint FD_SIZEPOINT = 0x00000002;
-        private const uint FD_ATTRIBUTES = 0x00000004;
         private const uint FD_CREATETIME = 0x00000008;
         private const uint FD_ACCESSTIME = 0x00000010;
         private const uint FD_WRITESTIME = 0x00000020;
         private const uint FD_FILESIZE = 0x00000040;
         private const uint FD_PROGRESSUI = 0x00004000;
-        private const uint FD_LINKUI = 0x00008000;
         private const uint FD_UNICODE = 0x80000000;
 
-        internal const string CFSTR_FILEDESCRIPTORW = "FileGroupDescriptorW";
+        internal const string CFSTR_FILEDESCRIPTORW = "FileGroupDescriptorW"; // TODO: Extract to class
         internal const string CFSTR_FILECONTENTS = "FileContents";
         internal const string CFSTR_PREFERREDDROPEFFECT = "Preferred DropEffect";
         internal const string CFSTR_PERFORMEDDROPEFFECT = "Performed DropEffect";

--- a/sources/Google.Solutions.Platform/Interop/Hresult.cs
+++ b/sources/Google.Solutions.Platform/Interop/Hresult.cs
@@ -26,6 +26,7 @@ namespace Google.Solutions.Platform.Interop
         S_OK = 0,
         S_FALSE = 1,
         E_UNEXPECTED = unchecked((int)0x8000ffff),
+        E_FAIL = unchecked((int)0x80004005),
     }
 
     public static class HresultExtensions

--- a/sources/Google.Solutions.Platform/Security/Quarantine.cs
+++ b/sources/Google.Solutions.Platform/Security/Quarantine.cs
@@ -99,7 +99,7 @@ namespace Google.Solutions.Platform.Security
                 {
                     //
                     // Set a client GUID that identifies the current application. Might
-                    // be used to persistently suppress promotes.
+                    // be used to persistently suppress prompts.
                     //
                     attachment.SetClientGuid(clientGuid);
                     attachment.SetLocalPath(filePath.FullName);

--- a/sources/Google.Solutions.Ssh.Test/TestSftpChannel.cs
+++ b/sources/Google.Solutions.Ssh.Test/TestSftpChannel.cs
@@ -36,7 +36,7 @@ namespace Google.Solutions.Ssh.Test
 {
     [TestFixture]
     [UsesCloudResources]
-    public class TestSshFileSystemChannel : SshFixtureBase
+    public class TestSftpChannel : SshFixtureBase
     {
         public static Stream CreateStream(string content)
         {

--- a/sources/Google.Solutions.Ssh.Test/TestSftpChannel.cs
+++ b/sources/Google.Solutions.Ssh.Test/TestSftpChannel.cs
@@ -27,9 +27,7 @@ using Google.Solutions.Testing.Apis.Integration;
 using NUnit.Framework;
 using System;
 using System.IO;
-using System.Runtime.Remoting.Channels;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Google.Solutions.Ssh.Test
@@ -189,7 +187,7 @@ namespace Google.Solutions.Ssh.Test
         }
 
         [Test]
-        public async Task CreateFile_CreateNew(
+        public async Task CreateFile_WriteReadAsynchronously(
             [LinuxInstance] ResourceTask<InstanceLocator> instanceLocatorTask)
         {
             var instance = await instanceLocatorTask;
@@ -230,10 +228,8 @@ namespace Google.Solutions.Ssh.Test
                         Assert.IsFalse(outputStream.CanRead);
                         Assert.IsFalse(outputStream.CanSeek);
 
-                        Assert.Throws<NotSupportedException>(
-                            () => outputStream.Read(new byte[1], 0, 1));
-                        Assert.Throws<NotSupportedException>(
-                            () => outputStream.Write(new byte[1], 0, 1));
+                        Assert.AreEqual(0, outputStream.Length);
+
                         ExceptionAssert.ThrowsAggregateException<NotSupportedException>(
                             () => outputStream.ReadAsync(new byte[1], 0, 1).Wait());
 
@@ -241,6 +237,8 @@ namespace Google.Solutions.Ssh.Test
                         await outputStream
                             .WriteAsync(data, 1, data.Length - 2)
                             .ConfigureAwait(false);
+
+                        Assert.AreEqual(data.Length - 2, outputStream.Position);
                     }
 
                     //
@@ -258,10 +256,8 @@ namespace Google.Solutions.Ssh.Test
                         Assert.IsFalse(inputStream.CanWrite);
                         Assert.IsFalse(inputStream.CanSeek);
 
-                        Assert.Throws<NotSupportedException>(
-                            () => inputStream.Read(new byte[1], 0, 1));
-                        Assert.Throws<NotSupportedException>(
-                            () => inputStream.Write(new byte[1], 0, 1));
+                        Assert.AreNotEqual(0, inputStream.Length);
+
                         ExceptionAssert.ThrowsAggregateException<NotSupportedException>(
                             () => inputStream.WriteAsync(new byte[1], 0, 1).Wait());
 
@@ -273,10 +269,99 @@ namespace Google.Solutions.Ssh.Test
                         Assert.AreEqual(
                             "Some data",
                             Encoding.ASCII.GetString(buffer, 1, bytesRead));
+                        Assert.AreEqual(bytesRead, inputStream.Position);
 
                         bytesRead = await inputStream
                             .ReadAsync(buffer, 0, buffer.Length)
                             .ConfigureAwait(false);
+                        Assert.AreEqual(0, bytesRead);
+                    }
+                }
+            }
+        }
+
+        [Test]
+        public async Task CreateFile_WriteReadSynchronously(
+            [LinuxInstance] ResourceTask<InstanceLocator> instanceLocatorTask)
+        {
+            var instance = await instanceLocatorTask;
+            var endpoint = await GetPublicSshEndpointAsync(instance)
+                .ConfigureAwait(false);
+            var credential = await CreateAsymmetricKeyCredentialAsync(
+                    instance,
+                    SshKeyType.Rsa3072)
+                .ConfigureAwait(false);
+
+            using (var connection = new SshConnection(
+                endpoint,
+                credential,
+                new KeyboardInteractiveHandler()))
+            {
+                await connection
+                    .ConnectAsync()
+                    .ConfigureAwait(false);
+
+                using (var channel = await connection
+                    .OpenFileSystemAsync()
+                    .ConfigureAwait(false))
+                {
+                    var tempFile = $"{Guid.NewGuid()}.txt";
+
+                    //
+                    // Write to temp file.
+                    //
+                    using (var outputStream = await channel
+                        .CreateFileAsync(
+                            tempFile,
+                            FileMode.Create,
+                            FileAccess.Write,
+                            FilePermissions.OwnerWrite | FilePermissions.OwnerRead)
+                        .ConfigureAwait(false))
+                    {
+                        Assert.IsTrue(outputStream.CanWrite);
+                        Assert.IsFalse(outputStream.CanRead);
+                        Assert.IsFalse(outputStream.CanSeek);
+
+                        Assert.AreEqual(0, outputStream.Length);
+
+                        Assert.Throws<NotSupportedException>(
+                            () => outputStream.Read(new byte[1], 0, 1));
+
+                        var data = Encoding.ASCII.GetBytes("'Some data'");
+                        outputStream.Write(data, 1, data.Length - 2);
+
+                        Assert.AreEqual(data.Length - 2, outputStream.Position);
+                    }
+
+                    //
+                    // Read back.
+                    //
+                    using (var inputStream = await channel
+                        .CreateFileAsync(
+                            tempFile,
+                            FileMode.Open,
+                            FileAccess.Read,
+                            FilePermissions.None)
+                        .ConfigureAwait(false))
+                    {
+                        Assert.IsTrue(inputStream.CanRead);
+                        Assert.IsFalse(inputStream.CanWrite);
+                        Assert.IsFalse(inputStream.CanSeek);
+
+                        Assert.AreNotEqual(0, inputStream.Length);
+
+                        Assert.Throws<NotSupportedException>(
+                            () => inputStream.Write(new byte[1], 0, 1));
+
+                        var buffer = new byte[1024];
+                        var bytesRead = inputStream.Read(buffer, 1, buffer.Length - 1);
+
+                        Assert.AreEqual(
+                            "Some data",
+                            Encoding.ASCII.GetString(buffer, 1, bytesRead));
+                        Assert.AreEqual(bytesRead, inputStream.Position);
+
+                        bytesRead = inputStream.Read(buffer, 0, buffer.Length);
                         Assert.AreEqual(0, bytesRead);
                     }
                 }

--- a/sources/Google.Solutions.Ssh/ISftpChannel.cs
+++ b/sources/Google.Solutions.Ssh/ISftpChannel.cs
@@ -1,0 +1,47 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Ssh.Native;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.Ssh
+{
+    public interface ISftpChannel : IDisposable
+    {
+        /// <summary>
+        /// List contents of a directory.
+        /// </summary>
+        Task<IReadOnlyCollection<Libssh2SftpFileInfo>> ListFilesAsync(
+            string remotePath);
+
+        /// <summary>
+        /// Create or open a file.
+        /// </summary>
+        Task<Stream> CreateFileAsync(
+            string remotePath,
+            FileMode mode,
+            FileAccess access,
+            FilePermissions permissions);
+    }
+}

--- a/sources/Google.Solutions.Ssh/Native/Libssh2Session.cs
+++ b/sources/Google.Solutions.Ssh/Native/Libssh2Session.cs
@@ -229,22 +229,6 @@ namespace Google.Solutions.Ssh.Native
         }
 
         /// <summary>
-        /// Enable blocking I/O for a using block.
-        /// </summary>
-        public IDisposable AsBlocking(TimeSpan timeout) // TODO: remove
-        {
-            this.IsBlocking = true;
-            var previousTimeout = this.Timeout;
-
-            this.Timeout = timeout;
-            return Disposable.For(() =>
-            {
-                this.IsBlocking = false;
-                this.Timeout = previousTimeout;
-            });
-        }
-
-        /// <summary>
         /// Enable non-blocking I/O for a using block.
         /// </summary>
         public IDisposable AsNonBlocking()

--- a/sources/Google.Solutions.Ssh/Native/Libssh2Session.cs
+++ b/sources/Google.Solutions.Ssh/Native/Libssh2Session.cs
@@ -231,7 +231,7 @@ namespace Google.Solutions.Ssh.Native
         /// <summary>
         /// Enable blocking I/O for a using block.
         /// </summary>
-        public IDisposable AsBlocking(TimeSpan timeout)
+        public IDisposable AsBlocking(TimeSpan timeout) // TODO: remove
         {
             this.IsBlocking = true;
             var previousTimeout = this.Timeout;

--- a/sources/Google.Solutions.Ssh/Native/Libssh2SftpChannel.cs
+++ b/sources/Google.Solutions.Ssh/Native/Libssh2SftpChannel.cs
@@ -194,7 +194,6 @@ namespace Google.Solutions.Ssh.Native
                         flags,
                         mode,
                         LIBSSH2_OPENTYPE.OPENFILE);
-
                     fileHandle.ValidateAndAttachToSession(this.session);
 
                     return new Libssh2SftpFileChannel(
@@ -328,7 +327,7 @@ namespace Google.Solutions.Ssh.Native
                 name,
                 new LIBSSH2_SFTP_ATTRIBUTES()
                 {
-                    permissions = (uint)permissions
+                    permissions = permissions
                 })
         {
         }

--- a/sources/Google.Solutions.Ssh/Native/Libssh2SftpChannel.cs
+++ b/sources/Google.Solutions.Ssh/Native/Libssh2SftpChannel.cs
@@ -320,5 +320,17 @@ namespace Google.Solutions.Ssh.Native
             this.Name = name;
             this.attributes = attributes;
         }
+
+        public Libssh2SftpFileInfo(
+            string name,
+            FilePermissions permissions)
+            : this(
+                name,
+                new LIBSSH2_SFTP_ATTRIBUTES()
+                {
+                    permissions = (uint)permissions
+                })
+        {
+        }
     }
 }

--- a/sources/Google.Solutions.Ssh/Native/Libssh2SftpChannel.cs
+++ b/sources/Google.Solutions.Ssh/Native/Libssh2SftpChannel.cs
@@ -264,7 +264,7 @@ namespace Google.Solutions.Ssh.Native
         }
     }
 
-    public readonly struct Libssh2SftpFileInfo // TODO: rename
+    public readonly struct Libssh2SftpFileInfo
     {
         private readonly LIBSSH2_SFTP_ATTRIBUTES attributes;
 
@@ -279,7 +279,7 @@ namespace Google.Solutions.Ssh.Native
 
         public FilePermissions Permissions
         {
-            get => (FilePermissions)this.attributes.permissions;
+            get => this.attributes.permissions;
         }
 
         public bool IsDirectory

--- a/sources/Google.Solutions.Ssh/Native/Libssh2SftpChannel.cs
+++ b/sources/Google.Solutions.Ssh/Native/Libssh2SftpChannel.cs
@@ -264,7 +264,7 @@ namespace Google.Solutions.Ssh.Native
         }
     }
 
-    public readonly struct Libssh2SftpFileInfo
+    public readonly struct Libssh2SftpFileInfo // TODO: rename
     {
         private readonly LIBSSH2_SFTP_ATTRIBUTES attributes;
 

--- a/sources/Google.Solutions.Ssh/Native/Libssh2SftpFileChannel.cs
+++ b/sources/Google.Solutions.Ssh/Native/Libssh2SftpFileChannel.cs
@@ -65,6 +65,23 @@ namespace Google.Solutions.Ssh.Native
             this.filePath = filePath;
         }
 
+        public LIBSSH2_SFTP_ATTRIBUTES Attributes
+        {
+            get
+            {
+                var result = (LIBSSH2_ERROR)NativeMethods.libssh2_sftp_fstat_ex(
+                    this.fileHandle,
+                    out var attributes,
+                    0);
+                if (result != LIBSSH2_ERROR.NONE)
+                {
+                    throw this.session.CreateException(result);
+                }
+
+                return attributes;
+            }
+        }
+
         public uint Read(byte[] buffer)
         {
             this.fileHandle.CheckCurrentThreadOwnsHandle();

--- a/sources/Google.Solutions.Ssh/Native/Libssh2SftpFileChannel.cs
+++ b/sources/Google.Solutions.Ssh/Native/Libssh2SftpFileChannel.cs
@@ -108,8 +108,6 @@ namespace Google.Solutions.Ssh.Native
                         // before the blocking timeout has elapsed.
                         //
 
-                        // TODO: Prevent ~5sec timeout?
-
                         continue;
                     }
                     else

--- a/sources/Google.Solutions.Ssh/Native/NativeMethods.cs
+++ b/sources/Google.Solutions.Ssh/Native/NativeMethods.cs
@@ -137,6 +137,18 @@ namespace Google.Solutions.Ssh.Native
         OPENDIR = 1
     }
 
+    /// <summary>
+    /// SFTP attribute flag bits
+    /// </summary>
+    internal enum LIBSSH2_SFTP_ATTR : uint
+    {
+        SIZE = 0x00000001,
+        UIDGID = 0x00000002,
+        PERMISSIONS = 0x00000004,
+        ACMODTIME = 0x00000008,
+        EXTENDED = 0x80000000,
+    }
+
     [StructLayout(LayoutKind.Sequential)]
     internal struct LIBSSH2_SFTP_ATTRIBUTES
     {
@@ -144,11 +156,11 @@ namespace Google.Solutions.Ssh.Native
         /// If flags & ATTR_* bit is set, then the value in this struct is
         /// meaningful. Otherwise it should be ignored.
         /// </summary>
-        internal uint flags;
+        internal LIBSSH2_SFTP_ATTR flags;
         internal ulong filesize;
         internal uint uid;
         internal uint gid;
-        internal uint permissions;
+        internal FilePermissions permissions;
         internal uint atime;
         internal uint mtime;
     };
@@ -548,6 +560,12 @@ namespace Google.Solutions.Ssh.Native
             Libssh2SftpFileHandle channel,
             IntPtr buffer,
             IntPtr bufferSize);
+
+        [DllImport(Libssh2, CallingConvention = CallingConvention.Cdecl)]
+        internal static extern int libssh2_sftp_fstat_ex(
+            Libssh2SftpFileHandle channel,
+            out LIBSSH2_SFTP_ATTRIBUTES attrs,
+            int setstat);
 
         //---------------------------------------------------------------------
         // Keepalive.

--- a/sources/Google.Solutions.Ssh/Native/NativeMethods.cs
+++ b/sources/Google.Solutions.Ssh/Native/NativeMethods.cs
@@ -815,6 +815,8 @@ namespace Google.Solutions.Ssh.Native
             Invariant.ExpectNotNull(this.SessionHandle, nameof(this.SessionHandle));
             Debug.Assert(!this.SessionHandle!.IsClosed);
 
+            CheckCurrentThreadOwnsHandle();
+
             if (this.SessionHandle.IsClosed)
             {
                 // Do not free the channel.

--- a/sources/Google.Solutions.Ssh/Properties/AssemblyInfo.cs
+++ b/sources/Google.Solutions.Ssh/Properties/AssemblyInfo.cs
@@ -25,4 +25,3 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("Google LLC")]
 
 [assembly: InternalsVisibleTo("Google.Solutions.Ssh.Test")]
-[assembly: InternalsVisibleTo("Google.Solutions.IapDesktop.Extensions.Session.Test")]

--- a/sources/Google.Solutions.Ssh/SftpChannel.cs
+++ b/sources/Google.Solutions.Ssh/SftpChannel.cs
@@ -32,7 +32,7 @@ namespace Google.Solutions.Ssh
     /// <summary>
     /// Channel for interacting with remote file.
     /// </summary>
-    public class SshFileSystemChannel : SshChannelBase
+    public class SftpChannel : SshChannelBase, ISftpChannel
     {
         /// <summary>
         /// Recommended buffer size to use for reading from, or
@@ -65,7 +65,7 @@ namespace Google.Solutions.Ssh
         /// </summary>
         public override SshConnection Connection { get; }
 
-        internal SshFileSystemChannel(
+        internal SftpChannel(
             SshConnection connection,
             Libssh2SftpChannel nativeChannel)
         {
@@ -159,7 +159,7 @@ namespace Google.Solutions.Ssh
 
                 using (c.Session.AsBlocking())
                 {
-                    return new SshFileStream(
+                    return new SftpFileStream(
                         this.Connection,
                         this.nativeChannel.CreateFile(
                             remotePath,

--- a/sources/Google.Solutions.Ssh/SftpChannel.cs
+++ b/sources/Google.Solutions.Ssh/SftpChannel.cs
@@ -94,7 +94,6 @@ namespace Google.Solutions.Ssh
 
         internal override void OnReceiveError(Exception exception)
         {
-            Debug.Assert(false, "OnReceiveError should never be called");
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.Ssh/SftpFileStream.cs
+++ b/sources/Google.Solutions.Ssh/SftpFileStream.cs
@@ -19,9 +19,11 @@
 // under the License.
 //
 
+using Google.Solutions.Common.Util;
 using Google.Solutions.Ssh.Native;
 using System;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -45,20 +47,53 @@ namespace Google.Solutions.Ssh
         /// </summary>
         private readonly LIBSSH2_FXF_FLAGS flags;
 
+        private readonly LIBSSH2_SFTP_ATTRIBUTES attributes;
+
+        private long position;
+
         internal SftpFileStream(
             SshConnection connection,
             Libssh2SftpFileChannel nativeChannel,
             LIBSSH2_FXF_FLAGS flags)
         {
+            Debug.Assert(connection.IsRunningOnWorkerThread);
+
             this.Connection = connection;
             this.nativeChannel = nativeChannel;
             this.flags = flags;
+            this.attributes = nativeChannel.Attributes;
         }
 
         protected override void Dispose(bool disposing)
         {
             this.nativeChannel.Dispose();
             base.Dispose(disposing);
+        }
+
+        //----------------------------------------------------------------------
+        // Attributes.
+        //----------------------------------------------------------------------
+
+        /// <summary>
+        /// Length of file at the time it was opened.
+        /// </summary>
+        public override long Length
+        {
+            get
+            {
+                //
+                // Return size at the time of open so that we don't need
+                // to block.
+                //
+                if (this.attributes.flags.HasFlag(LIBSSH2_SFTP_ATTR.SIZE))
+                {
+                    return (long)this.attributes.filesize;
+                }
+                else
+                {
+                    return 0;
+                }
+            }
         }
 
         //----------------------------------------------------------------------
@@ -70,10 +105,19 @@ namespace Google.Solutions.Ssh
             get => this.flags.HasFlag(LIBSSH2_FXF_FLAGS.READ);
         }
 
+        [SuppressMessage("Usage",
+            "VSTHRD002:Avoid problematic synchronous waits",
+            Justification = "")]
         public override int Read(byte[] buffer, int offset, int count)
         {
-            throw new NotSupportedException(
-                "The stream can only be accessed asynchonously");
+            try
+            {
+                return ReadAsync(buffer, offset, count).Result;
+            }
+            catch (AggregateException e)
+            {
+                throw e.Unwrap();
+            }
         }
 
         public override async Task<int> ReadAsync(
@@ -92,7 +136,7 @@ namespace Google.Solutions.Ssh
             //
             // Perform a synchronous read on the worker thread.
             //
-            return await this.Connection
+            var bytesRead = await this.Connection
                 .RunThrowingOperationAsync(session =>
                 {
                     Debug.Assert(this.Connection.IsRunningOnWorkerThread);
@@ -116,6 +160,9 @@ namespace Google.Solutions.Ssh
                     }
                 })
                 .ConfigureAwait(false);
+
+            this.position += bytesRead;
+            return bytesRead;
         }
 
         //----------------------------------------------------------------------
@@ -127,10 +174,19 @@ namespace Google.Solutions.Ssh
             get => this.flags.HasFlag(LIBSSH2_FXF_FLAGS.WRITE);
         }
 
+        [SuppressMessage("Usage",
+            "VSTHRD002:Avoid problematic synchronous waits",
+            Justification = "")]
         public override void Write(byte[] buffer, int offset, int count)
         {
-            throw new NotSupportedException(
-                "The stream can only be accessed asynchonously");
+            try
+            {
+                WriteAsync(buffer, offset, count).Wait();
+            }
+            catch (AggregateException e)
+            {
+                throw e.Unwrap();
+            }
         }
 
         public override async Task WriteAsync(
@@ -174,6 +230,8 @@ namespace Google.Solutions.Ssh
                     return session;
                 })
                 .ConfigureAwait(false);
+
+            this.position += count;
         }
 
         public override void Flush()
@@ -199,15 +257,17 @@ namespace Google.Solutions.Ssh
             throw new NotSupportedException();
         }
 
-        public override long Length
-        {
-            get => throw new NotSupportedException();
-        }
-
         public override long Position
         {
-            get => throw new NotSupportedException();
-            set => throw new NotSupportedException();
+            get => this.position;
+            set
+            {
+                if (this.position != value)
+                {
+                    throw new NotSupportedException(
+                        "The stream does not support seeking");
+                }
+            }
         }
     }
 }

--- a/sources/Google.Solutions.Ssh/SftpFileStream.cs
+++ b/sources/Google.Solutions.Ssh/SftpFileStream.cs
@@ -66,8 +66,20 @@ namespace Google.Solutions.Ssh
 
         protected override void Dispose(bool disposing)
         {
-            this.nativeChannel.Dispose();
             base.Dispose(disposing);
+
+            if (disposing)
+            {
+                if (this.Connection.IsRunningOnWorkerThread)
+                {
+                    this.nativeChannel.Dispose();
+                }
+                else
+                {
+                    _ = this.Connection.RunThrowingOperationAsync(
+                        _ => this.nativeChannel.Dispose());
+                }
+            }
         }
 
         //----------------------------------------------------------------------

--- a/sources/Google.Solutions.Ssh/SftpFileStream.cs
+++ b/sources/Google.Solutions.Ssh/SftpFileStream.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 
 namespace Google.Solutions.Ssh
 {
-    internal class SshFileStream : Stream
+    internal class SftpFileStream : Stream
     {
         /// <summary>
         /// Native channel, can only be accessed on the worker thread.
@@ -45,7 +45,7 @@ namespace Google.Solutions.Ssh
         /// </summary>
         private readonly LIBSSH2_FXF_FLAGS flags;
 
-        internal SshFileStream(
+        internal SftpFileStream(
             SshConnection connection,
             Libssh2SftpFileChannel nativeChannel,
             LIBSSH2_FXF_FLAGS flags)

--- a/sources/Google.Solutions.Ssh/SftpFileStream.cs
+++ b/sources/Google.Solutions.Ssh/SftpFileStream.cs
@@ -153,7 +153,7 @@ namespace Google.Solutions.Ssh
                 {
                     Debug.Assert(this.Connection.IsRunningOnWorkerThread);
 
-                    using (session.Session.AsBlocking()) // TODO: handle/avoid timeout for larger files
+                    using (session.Session.AsBlocking()) 
                     {
                         if (offset == 0 && count == buffer.Length) 
                         {

--- a/sources/Google.Solutions.Ssh/SftpFileStream.cs
+++ b/sources/Google.Solutions.Ssh/SftpFileStream.cs
@@ -153,7 +153,7 @@ namespace Google.Solutions.Ssh
                 {
                     Debug.Assert(this.Connection.IsRunningOnWorkerThread);
 
-                    using (session.Session.AsBlocking())
+                    using (session.Session.AsBlocking()) // TODO: handle/avoid timeout for larger files
                     {
                         if (offset == 0 && count == buffer.Length) 
                         {

--- a/sources/Google.Solutions.Ssh/SshConnection.cs
+++ b/sources/Google.Solutions.Ssh/SshConnection.cs
@@ -320,7 +320,7 @@ namespace Google.Solutions.Ssh
                 .ConfigureAwait(false);
         }
 
-        public async Task<SshFileSystemChannel> OpenFileSystemAsync()
+        public async Task<SftpChannel> OpenFileSystemAsync()
         {
             return await RunSendOperationAsync(
                 session =>
@@ -329,7 +329,7 @@ namespace Google.Solutions.Ssh
 
                     using (session.Session.AsBlocking())
                     {
-                        var channel = new SshFileSystemChannel(
+                        var channel = new SftpChannel(
                             this,
                             session.OpenSftpChannel());
 

--- a/sources/Google.Solutions.Ssh/SshConnection.cs
+++ b/sources/Google.Solutions.Ssh/SshConnection.cs
@@ -205,7 +205,7 @@ namespace Google.Solutions.Ssh
             }
         }
 
-        internal async Task<TResult> RunSendOperationAsync<TResult>( // TODO: consolidate, rename
+        internal async Task<TResult> RunSendOperationAsync<TResult>(
             Func<Libssh2AuthenticatedSession, TResult> sendOperation)
             where TResult : class
         {

--- a/sources/Google.Solutions.Ssh/SshFileSystemChannel.cs
+++ b/sources/Google.Solutions.Ssh/SshFileSystemChannel.cs
@@ -140,7 +140,7 @@ namespace Google.Solutions.Ssh
                 FileMode.Truncate => LIBSSH2_FXF_FLAGS.TRUNC,
                 FileMode.Append => LIBSSH2_FXF_FLAGS.APPEND,
                 
-                _ => throw new ArgumentException(nameof(mode)),
+                _ => throw new ArgumentException("The file mode is invalid"),
             };
 
             if (access.HasFlag(FileAccess.Read))

--- a/sources/Google.Solutions.Ssh/SshWorkerThread.cs
+++ b/sources/Google.Solutions.Ssh/SshWorkerThread.cs
@@ -367,7 +367,9 @@ namespace Google.Solutions.Ssh
                                     }
                                     catch (Libssh2Exception e) when (e.ErrorCode == LIBSSH2_ERROR.EAGAIN)
                                     {
+                                        //
                                         // Retry operation.
+                                        //
                                     }
                                     catch (Exception e)
                                     {
@@ -382,11 +384,15 @@ namespace Google.Solutions.Ssh
                                         }
                                         else
                                         {
+                                            //
                                             // Consider it a receive error.
+                                            //
                                             OnReceiveError(e);
                                         }
 
+                                        //
                                         // Bail out.
+                                        //
                                         return;
                                     }
                                 } // while

--- a/sources/Google.Solutions.Terminal.Test/Controls/SshClientFixtureBase.cs
+++ b/sources/Google.Solutions.Terminal.Test/Controls/SshClientFixtureBase.cs
@@ -1,0 +1,85 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Security;
+using Google.Solutions.Ssh;
+using Google.Solutions.Terminal.Controls;
+using Microsoft.VisualBasic;
+using NUnit.Framework;
+using System.Net;
+
+namespace Google.Solutions.Terminal.Test.Controls
+{
+    public abstract class SshClientFixtureBase
+    {
+        private static string? serverAddress;
+        private static string? username;
+        private static string? password;
+
+        [OneTimeSetUp]
+        public static void CollectCredentials()
+        {
+            serverAddress = Interaction.InputBox("SSH server IP address");
+            username = Interaction.InputBox("SSH username");
+            password = Interaction.InputBox("SSH password");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            //
+            // Wait for worker threads to finish so that test caseses
+            // don't interfere with another.
+            //
+            SshWorkerThread.JoinAllWorkerThreadsAsync().Wait();
+        }
+
+        private class KeyboardInteractiveHandler : IKeyboardInteractiveHandler
+        {
+            public string? Prompt(string caption, string instruction, string prompt, bool echo)
+            {
+                return Interaction.InputBox(
+                    $"Caption: {caption}\nPrompt: {prompt}",
+                    caption);
+            }
+
+            public IPasswordCredential PromptForCredentials(string username)
+            {
+                var password = Interaction.InputBox($"Enter password for {username}");
+                return new StaticPasswordCredential(username, password);
+            }
+        }
+
+        protected static ClientDiagnosticsWindow<TClient> CreateWindow<TClient>()
+            where TClient : SshShellClient, new()
+        {
+            var window = new ClientDiagnosticsWindow<TClient>(new TClient());
+            window.Client.ServerEndpoint = new IPEndPoint(
+                IPAddress.Parse(serverAddress),
+                22);
+            window.Client.Credential = new StaticPasswordCredential(
+                username ?? "test",
+                SecureStringExtensions.FromClearText(password));
+            window.Client.KeyboardInteractiveHandler = new KeyboardInteractiveHandler();
+            return window;
+        }
+    }
+}

--- a/sources/Google.Solutions.Terminal.Test/Controls/TestSshHybridClient.cs
+++ b/sources/Google.Solutions.Terminal.Test/Controls/TestSshHybridClient.cs
@@ -1,0 +1,81 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Terminal.Controls;
+using Google.Solutions.Testing.Apis;
+using Google.Solutions.Testing.Apis.Integration;
+using NUnit.Framework;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.Terminal.Test.Controls
+{
+    [TestFixture]
+    [RequiresInteraction]
+    [Apartment(ApartmentState.STA)]
+    public class TestSshHybridClient : SshClientFixtureBase
+    {
+        //---------------------------------------------------------------------
+        // File browser.
+        //---------------------------------------------------------------------
+
+        [WindowsFormsTest]
+        public async Task IsFileBrowserVisible()
+        {
+            using (var window = CreateWindow<SshHybridClient>())
+            {
+                window.Show();
+
+                Assert.IsFalse(window.Client.IsFileBrowserVisible);
+                Assert.IsFalse(window.Client.CanShowFileBrowser);
+
+                //
+                // Connect.
+                //
+                window.Client.Connect();
+                await window.Client
+                    .AwaitStateAsync(ConnectionState.LoggedOn)
+                    .ConfigureAwait(true);
+
+                Assert.IsFalse(window.Client.IsFileBrowserVisible);
+                Assert.IsTrue(window.Client.CanShowFileBrowser);
+
+                window.Client.IsFileBrowserVisible = true;
+                window.Client.IsFileBrowserVisible = true;
+
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
+                window.Client.IsFileBrowserVisible = false;
+                await Task.Delay(TimeSpan.FromSeconds(2));
+
+                //
+                // Close window.
+                //
+                window.Close();
+
+                await window.Client
+                    .AwaitStateAsync(ConnectionState.NotConnected)
+                    .ConfigureAwait(true);
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.Terminal.Test/Controls/TestSshShellClient.cs
+++ b/sources/Google.Solutions.Terminal.Test/Controls/TestSshShellClient.cs
@@ -19,13 +19,10 @@
 // under the License.
 //
 
-using Google.Solutions.Common.Security;
 using Google.Solutions.Mvvm.Controls;
-using Google.Solutions.Ssh;
 using Google.Solutions.Terminal.Controls;
 using Google.Solutions.Testing.Apis;
 using Google.Solutions.Testing.Apis.Integration;
-using Microsoft.VisualBasic;
 using NUnit.Framework;
 using System;
 using System.Net;
@@ -39,65 +36,14 @@ namespace Google.Solutions.Terminal.Test.Controls
     [TestFixture]
     [RequiresInteraction]
     [Apartment(ApartmentState.STA)]
-    public class TestSshShellClient 
+    public class TestSshShellClient : SshClientFixtureBase
     {
         private const string InvalidServer = "8.8.8.8";
-
-        private static string? serverAddress;
-        private static string? username;
-        private static string? password;
-
-        [OneTimeSetUp]
-        public static void CollectCredentials()
-        {
-            serverAddress = Interaction.InputBox("SSH server IP address");
-            username = Interaction.InputBox("SSH username");
-            password = Interaction.InputBox("SSH password");
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            //
-            // Wait for worker threads to finish so that test caseses
-            // don't interfere with another.
-            //
-            SshWorkerThread.JoinAllWorkerThreadsAsync().Wait();
-        }
-
-        private class KeyboardInteractiveHandler : IKeyboardInteractiveHandler
-        {
-            public string? Prompt(string caption, string instruction, string prompt, bool echo)
-            {
-                return Interaction.InputBox(
-                    $"Caption: {caption}\nPrompt: {prompt}",
-                    caption);
-            }
-
-            public IPasswordCredential PromptForCredentials(string username)
-            {
-                var password = Interaction.InputBox($"Enter password for {username}");
-                return new StaticPasswordCredential(username, password);
-            }
-        }
-
-        private static ClientDiagnosticsWindow<SshShellClient> CreateWindow()
-        {
-            var window = new ClientDiagnosticsWindow<SshShellClient>(new SshShellClient());
-            window.Client.ServerEndpoint = new IPEndPoint(
-                IPAddress.Parse(serverAddress), 
-                22);
-            window.Client.Credential = new StaticPasswordCredential(
-                username ?? "test", 
-                SecureStringExtensions.FromClearText(password));
-            window.Client.KeyboardInteractiveHandler = new KeyboardInteractiveHandler();
-            return window;
-        }
 
         [WindowsFormsTest]
         public async Task ResizeWindow()
         {
-            using (var window = CreateWindow())
+            using (var window = CreateWindow<SshShellClient>())
             {
                 window.Show();
 
@@ -149,7 +95,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [WindowsFormsTest]
         public async Task Connect_WhenServerInvalid_ThenRaisesEvent()
         {
-            using (var window = CreateWindow())
+            using (var window = CreateWindow<SshShellClient>())
             {
                 window.Client.ServerEndpoint = new IPEndPoint(
                     IPAddress.Parse(InvalidServer), 
@@ -179,7 +125,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [WindowsFormsTest]
         public async Task Close_RaisesEvent()
         {
-            using (var window = CreateWindow())
+            using (var window = CreateWindow<SshShellClient>())
             {
                 window.Show();
 
@@ -211,7 +157,7 @@ namespace Google.Solutions.Terminal.Test.Controls
         [WindowsFormsTest]
         public async Task Logoff()
         {
-            using (var window = CreateWindow())
+            using (var window = CreateWindow<SshShellClient>())
             {
                 window.Show();
 

--- a/sources/Google.Solutions.Terminal.Test/TestSftpFileSystem.cs
+++ b/sources/Google.Solutions.Terminal.Test/TestSftpFileSystem.cs
@@ -19,7 +19,6 @@
 // under the License.
 //
 
-using Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session;
 using Google.Solutions.Ssh;
 using Google.Solutions.Ssh.Native;
 using NUnit.Framework;
@@ -29,7 +28,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Session
+namespace Google.Solutions.Terminal.Test
 {
     [TestFixture]
     public class TestSftpFileSystem
@@ -43,12 +42,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Sessio
 
         private static Libssh2SftpFileInfo CreateFile(string name, FilePermissions permissions)
         {
-            return new Libssh2SftpFileInfo(
-                name,
-                new LIBSSH2_SFTP_ATTRIBUTES()
-                {
-                    permissions = (uint)permissions
-                });
+            return new Libssh2SftpFileInfo(name, permissions);
         }
 
         //---------------------------------------------------------------------
@@ -65,7 +59,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.ToolWindows.Sessio
                 Assert.IsNotNull(root);
                 Assert.IsFalse(root.Type.IsFile);
                 Assert.IsTrue(root.IsExpanded);
-                Assert.AreEqual(string.Empty, root.Name);
+                Assert.AreEqual("/", root.Name);
             }
         }
 

--- a/sources/Google.Solutions.Terminal.TestApp/Program.cs
+++ b/sources/Google.Solutions.Terminal.TestApp/Program.cs
@@ -20,6 +20,8 @@
 //
 
 using Google.Solutions.Common.Security;
+using Google.Solutions.Mvvm.Binding;
+using Google.Solutions.Mvvm.Binding.Commands;
 using Google.Solutions.Ssh;
 using Google.Solutions.Terminal.Controls;
 using Microsoft.VisualBasic;
@@ -37,7 +39,7 @@ namespace Google.Solutions.Terminal.TestApp
         /// <summary>
         /// SSH client that uses password authentication.
         /// </summary>
-        private class SimpleSshShellClient : SshShellClient, IKeyboardInteractiveHandler
+        private class SimpleSshShellClient : SshHybridClient, IKeyboardInteractiveHandler
         {
             public SimpleSshShellClient()
             {
@@ -75,7 +77,6 @@ namespace Google.Solutions.Terminal.TestApp
                 return new StaticPasswordCredential(username, password);
             }
         }
-
         private static ClientBase CreateClient(string[] args)
         {
             if (args.FirstOrDefault() == "/rdp")

--- a/sources/Google.Solutions.Terminal/Controls/ClientDiagnosticsWindow.cs
+++ b/sources/Google.Solutions.Terminal/Controls/ClientDiagnosticsWindow.cs
@@ -20,7 +20,10 @@
 //
 
 using Google.Solutions.Common.Util;
+using Google.Solutions.Mvvm.Binding.Commands;
+using Google.Solutions.Mvvm.Binding;
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
@@ -80,6 +83,7 @@ namespace Google.Solutions.Terminal.Controls
             //
             client.Dock = DockStyle.Fill;
             splitContainer.Panel1.Controls.Add(client);
+            client.Bind(new ClientBindingContext());
 
             //
             // PropertyGrid.
@@ -129,6 +133,28 @@ namespace Google.Solutions.Terminal.Controls
 
             client.ConnectionFailed += (_, args)
                 => ShowError("Connection failed", args.Exception);
+        }
+
+
+        private class ClientBindingContext : IBindingContext
+        {
+            public void OnBindingCreated(
+                IComponent control, 
+                IDisposable binding)
+            {
+            }
+
+            public void OnCommandExecuted(
+                ICommandBase command)
+            {
+            }
+
+            public void OnCommandFailed(
+                IWin32Window? window, 
+                ICommandBase command,
+                Exception exception)
+            {
+            }
         }
     }
 }

--- a/sources/Google.Solutions.Terminal/Controls/SshHybridClient.cs
+++ b/sources/Google.Solutions.Terminal/Controls/SshHybridClient.cs
@@ -22,6 +22,7 @@
 using Google.Solutions.Common.Util;
 using Google.Solutions.Mvvm.Binding;
 using Google.Solutions.Mvvm.Controls;
+using Google.Solutions.Ssh;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -194,6 +195,7 @@ namespace Google.Solutions.Terminal.Controls
                     this.fileBrowser = new FileBrowser()
                     {
                         Dock = DockStyle.Fill,
+                        StreamCopyBufferSize = SshFileSystemChannel.BufferSize,
                     };
                     this.fileBrowserPanel.Controls.Add(this.fileBrowser);
 

--- a/sources/Google.Solutions.Terminal/Controls/SshHybridClient.cs
+++ b/sources/Google.Solutions.Terminal/Controls/SshHybridClient.cs
@@ -197,9 +197,22 @@ namespace Google.Solutions.Terminal.Controls
                     };
                     this.fileBrowserPanel.Controls.Add(this.fileBrowser);
 
+                    var fileSystem = new SftpFileSystem(fsChannel);
+                    this.fileBrowser.Disposed += (_, args) => fileSystem.Dispose();
                     this.fileBrowser.Bind(
-                        new SftpFileSystem(fsChannel), 
+                        fileSystem, 
                         this.bindingContext!);
+
+                    //
+                    // Move focus away from terminal to file browser.
+                    // This implicily causes the root directory to
+                    // be populated.
+                    //
+
+                    this.fileBrowser.Select();
+                    this.fileBrowser.Focus();
+
+
 
                     // TODO: Handle NavigationFailed
                 }
@@ -216,14 +229,6 @@ namespace Google.Solutions.Terminal.Controls
             this.IsFileBrowserVisible = true;
         }
 
-        // TODO: Ctrl+C, V
-        // TODO: Context menu copy/paste
-        // TODO: Drag + drop
-        // TODO: F5/refresh
-        // TODO: tests
-
-        // CFSTR_FILECONTENTS + IStream
-        //  - https://www.codeproject.com/Articles/23139/Transferring-Virtual-Files-to-Windows-Explorer-in
-        //  - https://referencesource.microsoft.com/#PresentationFramework/src/Framework/MS/Internal/IO/Packaging/managedIStream.cs
+        // TODO: paste icon
     }
 }

--- a/sources/Google.Solutions.Terminal/Controls/SshHybridClient.cs
+++ b/sources/Google.Solutions.Terminal/Controls/SshHybridClient.cs
@@ -195,7 +195,7 @@ namespace Google.Solutions.Terminal.Controls
                     this.fileBrowser = new FileBrowser()
                     {
                         Dock = DockStyle.Fill,
-                        StreamCopyBufferSize = SshFileSystemChannel.BufferSize,
+                        StreamCopyBufferSize = SftpChannel.BufferSize,
                     };
                     this.fileBrowserPanel.Controls.Add(this.fileBrowser);
 

--- a/sources/Google.Solutions.Terminal/Controls/SshHybridClient.cs
+++ b/sources/Google.Solutions.Terminal/Controls/SshHybridClient.cs
@@ -1,0 +1,229 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Util;
+using Google.Solutions.Mvvm.Binding;
+using Google.Solutions.Mvvm.Controls;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Google.Solutions.Terminal.Controls
+{
+    /// <summary>
+    /// Client that connects a virtual terminal to an SSH shell channel,
+    /// and optionally allow browsing the remote file system using SFTP.
+    /// </summary>
+    public class SshHybridClient : SshShellClient
+    {
+        private readonly SplitContainer container;
+        private readonly SplitterPanel terminalPanel;
+        private readonly SplitterPanel fileBrowserPanel;
+        private IBindingContext? bindingContext;
+        private FileBrowser? fileBrowser;
+
+        public SshHybridClient()
+        {
+            SuspendLayout();
+
+            this.container = new SplitContainer()
+            {
+                Dock = DockStyle.Fill,
+                Orientation = Orientation.Horizontal,
+                SplitterIncrement = 10,
+                SplitterWidth = 6,
+            };
+            this.Controls.Add(this.container);
+
+            this.terminalPanel = this.container.Panel1;
+            this.fileBrowserPanel = this.container.Panel2;
+
+            //
+            // Move terminal into panel1.
+            //
+            this.Controls.Remove(this.Terminal);
+            this.terminalPanel.Controls.Add(this.Terminal);
+
+            //
+            // Only show terminal by default.
+            //
+            this.container.Panel1Collapsed = true;
+            this.container.Panel2Collapsed = true;
+
+            this.container.Panel2MinSize = 10;
+            this.container.SplitterMoved += OnSplitterMoved;
+
+            ResumeLayout(false);
+        }
+
+        public bool CanShowFileBrowser
+        {
+            //
+            // The browser can only be shown in logged-on state.
+            //
+            get => 
+                this.State == ConnectionState.LoggedOn && 
+                this.BindingContext != null;
+        }
+
+        //---------------------------------------------------------------------
+        // Overrides.
+        //---------------------------------------------------------------------
+
+        protected override void OnStateChanged()
+        {
+            base.OnStateChanged();
+
+            if (!this.CanShowFileBrowser)
+            {
+                //
+                // Hide file browser as soon as we're not in logged-on state
+                // anymore.
+                //
+                this.IsFileBrowserVisible = false;
+            }
+        }
+
+        //---------------------------------------------------------------------
+        // Splitter events.
+        //---------------------------------------------------------------------
+
+        private void OnSplitterMoved(object sender, SplitterEventArgs e)
+        {
+            if (this.fileBrowserPanel.Height <= this.container.Panel2MinSize * 2)
+            {
+                //
+                // File browser panel resized to almost minimum size, hide entirely.
+                //
+                this.IsFileBrowserVisible = false;
+            }
+        }
+
+        //---------------------------------------------------------------------
+        // File browser.
+        //---------------------------------------------------------------------
+
+        /// <summary>
+        /// Enable binding.
+        /// </summary>
+        public override void Bind(IBindingContext bindingContext)
+        {
+            this.bindingContext = bindingContext;
+        }
+
+        /// <summary>
+        /// Toggle visibility of SFTP file browser.
+        /// </summary>
+        public bool IsFileBrowserVisible
+        {
+            get => !this.container.Panel2Collapsed;
+            set
+            {
+                if (value == this.IsFileBrowserVisible)
+                {
+                    //
+                    // No change.
+                    //
+                    return;
+                }
+                else if (value)
+                {
+                    Debug.Assert(this.fileBrowser == null);
+
+                    Precondition.Expect(
+                        this.bindingContext != null,
+                        "Control must be bound");
+
+                    //
+                    // Show in bottom third.
+                    //
+                    this.container.SplitterDistance = this.Height * 2 / 3;
+                    this.container.Panel2Collapsed = false;
+
+                    _ = OpenFileBrowserAsync();
+                }
+                else
+                {
+                    //
+                    // Hide.
+                    //
+                    this.container.Panel2Collapsed = true;
+
+                    if (this.fileBrowser != null)
+                    {
+                        //
+                        // Dispose the file browser control and its
+                        // underlying channel.
+                        //
+                        this.Controls.Remove(this.fileBrowser);
+                        this.fileBrowser.Dispose();
+                        this.fileBrowser = null;
+                    }
+                }
+
+                async Task OpenFileBrowserAsync()
+                {
+                    //
+                    // Open SFTP channel using the existing connection.
+                    //
+                    var fsChannel = await this.Connection
+                        .OpenFileSystemAsync()
+                        .ConfigureAwait(true);
+
+                    //
+                    // Bind it to a file browser control.
+                    //
+                    this.fileBrowser = new FileBrowser()
+                    {
+                        Dock = DockStyle.Fill,
+                    };
+                    this.fileBrowserPanel.Controls.Add(this.fileBrowser);
+
+                    this.fileBrowser.Bind(
+                        new SftpFileSystem(fsChannel), 
+                        this.bindingContext!);
+
+                    // TODO: Handle NavigationFailed
+                }
+            }
+        }
+
+        public void BrowseFiles()
+        {
+            if (!this.CanShowFileBrowser) 
+            { 
+                return; 
+            }
+
+            this.IsFileBrowserVisible = true;
+        }
+
+        // TODO: Ctrl+C, V
+        // TODO: Context menu copy/paste
+        // TODO: Drag + drop
+        // TODO: F5/refresh
+        // TODO: tests
+
+        // CFSTR_FILECONTENTS + IStream
+        //  - https://www.codeproject.com/Articles/23139/Transferring-Virtual-Files-to-Windows-Explorer-in
+        //  - https://referencesource.microsoft.com/#PresentationFramework/src/Framework/MS/Internal/IO/Packaging/managedIStream.cs
+    }
+}

--- a/sources/Google.Solutions.Terminal/Controls/SshShellClient.cs
+++ b/sources/Google.Solutions.Terminal/Controls/SshShellClient.cs
@@ -126,5 +126,20 @@ namespace Google.Solutions.Terminal.Controls
             return e.Unwrap() is Libssh2Exception sshEx &&
                 sshEx.ErrorCode == LIBSSH2_ERROR.SOCKET_TIMEOUT;
         }
+
+        /// <summary>
+        /// Get underlying SSH connection.
+        /// </summary>
+        /// <remarks>
+        /// The connection must be in LoggedOn state.
+        /// </remarks>
+        protected SshConnection Connection
+        {
+            get
+            {
+                ExpectState(ConnectionState.LoggedOn);
+                return this.connection!;
+            }
+        }
     }
 }

--- a/sources/Google.Solutions.Terminal/SftpFileSystem.cs
+++ b/sources/Google.Solutions.Terminal/SftpFileSystem.cs
@@ -223,7 +223,10 @@ namespace Google.Solutions.Terminal
                 throw new UnauthorizedAccessException("/ is a directory");
             }
 
-            public Stream Create(string name, FileAccess access)
+            public Stream Create(
+                string name,
+                FileMode mode, 
+                FileAccess access)
             {
                 throw new UnauthorizedAccessException(
                     "Reading or writing to the file system root is not supported");
@@ -306,13 +309,16 @@ namespace Google.Solutions.Terminal
 
             public Stream Open(FileAccess access)
             {
+                Precondition.Expect(this.Type.IsFile, $"{this.Name} is not a file");
                 throw new NotImplementedException();
             }
 
             public Stream Create(
-                string name, 
+                string name,
+                FileMode mode,
                 FileAccess access)
             {
+                Precondition.Expect(!this.Type.IsFile, $"{this.Name} is not a directory");
                 throw new NotImplementedException();
             }
         }

--- a/sources/Google.Solutions.Terminal/SftpFileSystem.cs
+++ b/sources/Google.Solutions.Terminal/SftpFileSystem.cs
@@ -155,13 +155,11 @@ namespace Google.Solutions.Terminal
             return new ObservableCollection<IFileItem>(filteredSftpFiles);
         }
 
-        public Task<Stream> OpenFileAsync( // TODO: test
+        public Task<Stream> OpenFileAsync(
             IFileItem file,
             FileAccess access)
         {
             Precondition.Expect(file.Type.IsFile, $"{file.Name} is not a file");
-
-            // TODO: translate exceptions?
 
             return this.channel.CreateFileAsync(
                 file.Path,
@@ -170,7 +168,7 @@ namespace Google.Solutions.Terminal
                 FilePermissions.None);
         }
 
-        public Task<Stream> OpenFileAsync(// TODO: test
+        public Task<Stream> OpenFileAsync(
             IFileItem directory,
             string name,
             FileMode mode,
@@ -179,13 +177,11 @@ namespace Google.Solutions.Terminal
             Precondition.Expect(!directory.Type.IsFile, $"{directory.Name} is not a directory");
             Precondition.Expect(!name.Contains("/"), "Name must not be a path");
 
-            // TODO: translate exceptions?
-
             return this.channel.CreateFileAsync(
                 $"{directory.Path}/{name}",
-                FileMode.Create,
+                mode,
                 access,
-                DefaultFilePermissions);
+                this.DefaultFilePermissions);
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.Terminal/SftpFileSystem.cs
+++ b/sources/Google.Solutions.Terminal/SftpFileSystem.cs
@@ -220,13 +220,13 @@ namespace Google.Solutions.Terminal
 
             public Stream Open(FileAccess access)
             {
-                throw new InvalidOperationException(
-                    "Reading or writing a directory is not allowed");
+                throw new UnauthorizedAccessException("/ is a directory");
             }
 
             public Stream Create(string name, FileAccess access)
             {
-                throw new NotImplementedException();
+                throw new UnauthorizedAccessException(
+                    "Reading or writing to the file system root is not supported");
             }
         }
 

--- a/sources/Google.Solutions.Terminal/SftpFileSystem.cs
+++ b/sources/Google.Solutions.Terminal/SftpFileSystem.cs
@@ -37,12 +37,16 @@ using System.Threading.Tasks;
 
 #pragma warning disable CS0067 // The event ... is never used
 
-namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
+namespace Google.Solutions.Terminal
 {
+    /// <summary>
+    /// Implements IFileSystem on a SFTP channel.
+    /// </summary>
     internal sealed class SftpFileSystem : IFileSystem, IDisposable
     {
         private readonly Func<string, Task<IReadOnlyCollection<Libssh2SftpFileInfo>>> listRemoteFilesFunc;
         private readonly FileTypeCache fileTypeCache;
+        private readonly IDisposable? channel;
 
         private static readonly Regex configFileNamePattern = new Regex("co?ni?f(ig)?$");
 
@@ -116,6 +120,12 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
             : this((path) => channel.ListFilesAsync(path))
         {
             channel.ExpectNotNull(nameof(channel));
+
+            //
+            // Keep reference to channel so that we can
+            // dispose it later.
+            //
+            this.channel = channel;
         }
 
         //---------------------------------------------------------------------
@@ -162,6 +172,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
         public void Dispose()
         {
             this.fileTypeCache.Dispose();
+            this.channel?.Dispose();
         }
 
         //---------------------------------------------------------------------
@@ -174,7 +185,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
 
             public string Name
             {
-                get => string.Empty;
+                get => "/";
             }
 
             public FileAttributes Attributes

--- a/sources/Google.Solutions.Terminal/SftpFileSystem.cs
+++ b/sources/Google.Solutions.Terminal/SftpFileSystem.cs
@@ -165,6 +165,24 @@ namespace Google.Solutions.Terminal
             return new ObservableCollection<IFileItem>(filteredSftpFiles);
         }
 
+        public Task<Stream> OpenFileAsync(
+            IFileItem file,
+            FileAccess access)
+        {
+            Precondition.Expect(file.Type.IsFile, $"{file.Name} is not a file");
+            throw new NotImplementedException();
+        }
+
+        public Task<Stream> OpenFileAsync(
+            IFileItem directory,
+            string name,
+            FileMode mode,
+            FileAccess access)
+        {
+            Precondition.Expect(!directory.Type.IsFile, $"{directory.Name} is not a directory");
+            throw new NotImplementedException();
+        }
+
         //---------------------------------------------------------------------
         // IDisposable.
         //---------------------------------------------------------------------
@@ -216,20 +234,6 @@ namespace Google.Solutions.Terminal
             public string Path
             {
                 get => string.Empty;
-            }
-
-            public Stream Open(FileAccess access)
-            {
-                throw new UnauthorizedAccessException("/ is a directory");
-            }
-
-            public Stream Create(
-                string name,
-                FileMode mode, 
-                FileAccess access)
-            {
-                throw new UnauthorizedAccessException(
-                    "Reading or writing to the file system root is not supported");
             }
         }
 
@@ -305,21 +309,6 @@ namespace Google.Solutions.Terminal
 
                     return attributes;
                 }
-            }
-
-            public Stream Open(FileAccess access)
-            {
-                Precondition.Expect(this.Type.IsFile, $"{this.Name} is not a file");
-                throw new NotImplementedException();
-            }
-
-            public Stream Create(
-                string name,
-                FileMode mode,
-                FileAccess access)
-            {
-                Precondition.Expect(!this.Type.IsFile, $"{this.Name} is not a directory");
-                throw new NotImplementedException();
             }
         }
     }

--- a/sources/Google.Solutions.Testing.Application/Views/WindowTestFixtureBase.cs
+++ b/sources/Google.Solutions.Testing.Application/Views/WindowTestFixtureBase.cs
@@ -125,7 +125,7 @@ namespace Google.Solutions.Testing.Application.Views
         protected static void PumpWindowMessages()
             => System.Windows.Forms.Application.DoEvents();
 
-        protected async Task<TEvent> AssertRaisesEventAsync<TEvent>( // TODO: Change to Await w/ CTS
+        protected async Task<TEvent> AssertRaisesEventAsync<TEvent>(
             Func<Task> action,
             TimeSpan timeout) where TEvent : class
         {


### PR DESCRIPTION
- Add `SshHybridClient` control that combines an SSH terminal and SFTP file browser
- Allow drag/drop, copy/paste using virtual file data objects
- Allow terminal interactions while performing asynchronous SFTP transfers
- Combine Upload- and Download commands