### PR TITLE
b/376134352 Access SFTP file as stream

### DIFF
--- a/sources/Google.Solutions.Ssh/FilePermissions.cs
+++ b/sources/Google.Solutions.Ssh/FilePermissions.cs
@@ -47,7 +47,9 @@ namespace Google.Solutions.Ssh
         BlockSpecial = 0x6000,
         Regular = 0x8000,
         SymbolicLink = 0xa000,
-        Socket = 0xc000
+        Socket = 0xc000,
+
+        None = 0x0,
     }
 
     public static class FilePermissionExtensions

--- a/sources/Google.Solutions.Ssh/Native/NativeMethods.cs
+++ b/sources/Google.Solutions.Ssh/Native/NativeMethods.cs
@@ -121,7 +121,7 @@ namespace Google.Solutions.Ssh.Native
     /// FTP File Transfer Flags.
     /// </summary>
     [Flags]
-    public enum LIBSSH2_FXF_FLAGS : Int32
+    internal enum LIBSSH2_FXF_FLAGS : Int32
     {
         READ = 0x00000001,
         WRITE = 0x00000002,
@@ -837,8 +837,13 @@ namespace Google.Solutions.Ssh.Native
     {
         protected override void ProtectedReleaseHandle()
         {
-            var result = (LIBSSH2_ERROR)NativeMethods.libssh2_channel_free(
-                this.handle);
+            LIBSSH2_ERROR result;
+
+            while ((result = (LIBSSH2_ERROR)
+                NativeMethods.libssh2_channel_free(this.handle))
+                == LIBSSH2_ERROR.EAGAIN)
+            { };
+
             Debug.Assert(result == LIBSSH2_ERROR.NONE);
         }
     }
@@ -850,8 +855,13 @@ namespace Google.Solutions.Ssh.Native
     {
         protected override void ProtectedReleaseHandle()
         {
-            var result = (LIBSSH2_ERROR)NativeMethods.libssh2_sftp_shutdown(
-                this.handle);
+            LIBSSH2_ERROR result;
+
+            while ((result = (LIBSSH2_ERROR)
+                NativeMethods.libssh2_sftp_shutdown(this.handle))
+                == LIBSSH2_ERROR.EAGAIN)
+            { };
+
             Debug.Assert(result == LIBSSH2_ERROR.NONE);
         }
     }
@@ -862,8 +872,13 @@ namespace Google.Solutions.Ssh.Native
     {
         protected override void ProtectedReleaseHandle()
         {
-            var result = (LIBSSH2_ERROR)NativeMethods.libssh2_sftp_close_handle(
-                this.handle);
+            LIBSSH2_ERROR result;
+
+            while ((result = (LIBSSH2_ERROR)
+                NativeMethods.libssh2_sftp_close_handle(this.handle)) 
+                == LIBSSH2_ERROR.EAGAIN) 
+            { };
+
             Debug.Assert(result == LIBSSH2_ERROR.NONE);
         }
     }

--- a/sources/Google.Solutions.Ssh/SshConnection.cs
+++ b/sources/Google.Solutions.Ssh/SshConnection.cs
@@ -224,14 +224,13 @@ namespace Google.Solutions.Ssh
 
         internal async Task<TResult> RunThrowingOperationAsync<TResult>(
             Func<Libssh2AuthenticatedSession, TResult> sendOperation)
-            where TResult : class
         {
             //
             // Some operations (such as SFTP operations) might throw 
             // exceptions, and these need to be passed thru to the caller
             // (as opposed to letting them bubble up to OnReceiveError).
             //
-            TResult? result = null;
+            TResult result = default;
             Exception? exception = null;
 
             await RunSendOperationAsync(

--- a/sources/Google.Solutions.Ssh/SshFileStream.cs
+++ b/sources/Google.Solutions.Ssh/SshFileStream.cs
@@ -28,29 +28,8 @@ using System.Threading.Tasks;
 
 namespace Google.Solutions.Ssh
 {
-    internal class SshFileStream : Stream // TODO: test
+    internal class SshFileStream : Stream
     {
-        /// <summary>
-        /// Suggested buffer size to use for reading from, or
-        /// writing to the stream.
-        ///
-        /// SFTP effectively limits the size of a packet to 32 KB, see
-        /// <https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-13#section-4>
-        ///
-        /// libssh2 uses a slightly smaller limit of 30000 bytes 
-        /// (MAX_SFTP_OUTGOING_SIZE, MAX_SFTP_READ_SIZE).
-        /// Using a buffer larger than 30000 bytes therefore doen't
-        /// provide much value.
-        ///
-        /// Note that IAP/SSH Relay uses 16KB as maximum message size,
-        /// so a 32000 byte packet will be split into 2 messages. 
-        /// That's still more efficient than using a SFTP packet
-        /// size below 16 KB as it at least limits the number of 
-        /// SSH_FXP_STATUS packets that need to be exchanged.
-        ///
-        /// </summary>
-        public const int CopyBufferSize = 30000;
-
         /// <summary>
         /// Native channel, can only be accessed on the worker thread.
         /// </summary>
@@ -64,7 +43,7 @@ namespace Google.Solutions.Ssh
         /// <summary>
         /// Flags the file has been opened with.
         /// </summary>
-        internal LIBSSH2_FXF_FLAGS Flags { get; }
+        private readonly LIBSSH2_FXF_FLAGS flags;
 
         internal SshFileStream(
             SshConnection connection,
@@ -73,7 +52,7 @@ namespace Google.Solutions.Ssh
         {
             this.Connection = connection;
             this.nativeChannel = nativeChannel;
-            this.Flags = flags;
+            this.flags = flags;
         }
 
         protected override void Dispose(bool disposing)
@@ -88,7 +67,7 @@ namespace Google.Solutions.Ssh
 
         public override bool CanRead
         {
-            get => this.Flags.HasFlag(LIBSSH2_FXF_FLAGS.READ);
+            get => this.flags.HasFlag(LIBSSH2_FXF_FLAGS.READ);
         }
 
         public override int Read(byte[] buffer, int offset, int count)
@@ -145,7 +124,7 @@ namespace Google.Solutions.Ssh
         
         public override bool CanWrite
         {
-            get => this.Flags.HasFlag(LIBSSH2_FXF_FLAGS.WRITE);
+            get => this.flags.HasFlag(LIBSSH2_FXF_FLAGS.WRITE);
         }
 
         public override void Write(byte[] buffer, int offset, int count)

--- a/sources/Google.Solutions.Ssh/SshFileStream.cs
+++ b/sources/Google.Solutions.Ssh/SshFileStream.cs
@@ -1,0 +1,234 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Ssh.Native;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.Ssh
+{
+    internal class SshFileStream : Stream // TODO: test
+    {
+        /// <summary>
+        /// Suggested buffer size to use for reading from, or
+        /// writing to the stream.
+        ///
+        /// SFTP effectively limits the size of a packet to 32 KB, see
+        /// <https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-13#section-4>
+        ///
+        /// libssh2 uses a slightly smaller limit of 30000 bytes 
+        /// (MAX_SFTP_OUTGOING_SIZE, MAX_SFTP_READ_SIZE).
+        /// Using a buffer larger than 30000 bytes therefore doen't
+        /// provide much value.
+        ///
+        /// Note that IAP/SSH Relay uses 16KB as maximum message size,
+        /// so a 32000 byte packet will be split into 2 messages. 
+        /// That's still more efficient than using a SFTP packet
+        /// size below 16 KB as it at least limits the number of 
+        /// SSH_FXP_STATUS packets that need to be exchanged.
+        ///
+        /// </summary>
+        public const int CopyBufferSize = 30000;
+
+        /// <summary>
+        /// Native channel, can only be accessed on the worker thread.
+        /// </summary>
+        private readonly Libssh2SftpFileChannel nativeChannel;
+
+        /// <summary>
+        /// Connection used by this stream.
+        /// </summary>
+        public SshConnection Connection { get; }
+
+        /// <summary>
+        /// Flags the file has been opened with.
+        /// </summary>
+        internal LIBSSH2_FXF_FLAGS Flags { get; }
+
+        internal SshFileStream(
+            SshConnection connection,
+            Libssh2SftpFileChannel nativeChannel,
+            LIBSSH2_FXF_FLAGS flags)
+        {
+            this.Connection = connection;
+            this.nativeChannel = nativeChannel;
+            this.Flags = flags;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            this.nativeChannel.Dispose();
+            base.Dispose(disposing);
+        }
+
+        //----------------------------------------------------------------------
+        // Reading.
+        //----------------------------------------------------------------------
+
+        public override bool CanRead
+        {
+            get => this.Flags.HasFlag(LIBSSH2_FXF_FLAGS.READ);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException(
+                "The stream can only be accessed asynchonously");
+        }
+
+        public override async Task<int> ReadAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken)
+        {
+            if (!this.CanRead)
+            {
+                throw new NotSupportedException("Stream is not readable");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            //
+            // Perform a synchronous read on the worker thread.
+            //
+            return await this.Connection
+                .RunThrowingOperationAsync(session =>
+                {
+                    Debug.Assert(this.Connection.IsRunningOnWorkerThread);
+
+                    using (session.Session.AsBlocking())
+                    {
+                        if (offset == 0 && count == buffer.Length) 
+                        {
+                            //
+                            // Use the supplied buffer.
+                            //
+                            return (int)this.nativeChannel.Read(buffer);
+                        }
+                        else
+                        {
+                            var readBuffer = new byte[count];
+                            var bytesRead = this.nativeChannel.Read(readBuffer);
+                            Array.Copy(readBuffer, 0, buffer, offset, count);
+                            return (int)bytesRead;
+                        }
+                    }
+                })
+                .ConfigureAwait(false);
+        }
+
+        //----------------------------------------------------------------------
+        // Writing.
+        //----------------------------------------------------------------------
+        
+        public override bool CanWrite
+        {
+            get => this.Flags.HasFlag(LIBSSH2_FXF_FLAGS.WRITE);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException(
+                "The stream can only be accessed asynchonously");
+        }
+
+        public override async Task WriteAsync(
+            byte[] buffer,
+            int offset,
+            int count,
+            CancellationToken cancellationToken)
+        {
+            if (!this.CanWrite)
+            {
+                throw new NotSupportedException("Stream is not writable");
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            //
+            // Perform a synchronous write on the worker thread.
+            //
+            await this.Connection
+                .RunThrowingOperationAsync<object?>(session =>
+                {
+                    Debug.Assert(this.Connection.IsRunningOnWorkerThread);
+
+                    using (session.Session.AsBlocking())
+                    {
+                        if (offset == 0)
+                        {
+                            //
+                            // Use the supplied buffer.
+                            //
+                            this.nativeChannel.Write(buffer, count);
+                        }
+                        else
+                        {
+                            var writeBuffer = new byte[count];
+                            Array.Copy(buffer, offset, writeBuffer, 0, count);
+                            this.nativeChannel.Write(writeBuffer, count);
+                        }
+                    }
+
+                    return session;
+                })
+                .ConfigureAwait(false);
+        }
+
+        public override void Flush()
+        {
+        }
+
+        //----------------------------------------------------------------------
+        // Seeking (not supported).
+        //----------------------------------------------------------------------
+
+        public override bool CanSeek
+        {
+            get => false;
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override long Length
+        {
+            get => throw new NotSupportedException();
+        }
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+    }
+}

--- a/sources/Google.Solutions.Ssh/SshFileSystemChannel.cs
+++ b/sources/Google.Solutions.Ssh/SshFileSystemChannel.cs
@@ -35,6 +35,27 @@ namespace Google.Solutions.Ssh
     public class SshFileSystemChannel : SshChannelBase
     {
         /// <summary>
+        /// Recommended buffer size to use for reading from, or
+        /// writing to a stream.
+        ///
+        /// SFTP effectively limits the size of a packet to 32 KB, see
+        /// <https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-13#section-4>
+        ///
+        /// libssh2 uses a slightly smaller limit of 30000 bytes 
+        /// (MAX_SFTP_OUTGOING_SIZE, MAX_SFTP_READ_SIZE).
+        /// Using a buffer larger than 30000 bytes therefore doen't
+        /// provide much value.
+        ///
+        /// Note that IAP/SSH Relay uses 16KB as maximum message size,
+        /// so a 32000 byte packet will be split into 2 messages. 
+        /// That's still more efficient than using a SFTP packet
+        /// size below 16 KB as it at least limits the number of 
+        /// SSH_FXP_STATUS packets that need to be exchanged.
+        ///
+        /// </summary>
+        public const int BufferSize = 30000;
+
+        /// <summary>
         /// Channel handle, must only be accessed on worker thread.
         /// </summary>
         private readonly Libssh2SftpChannel nativeChannel;

--- a/sources/Google.Solutions.Ssh/SshFileSystemChannel.cs
+++ b/sources/Google.Solutions.Ssh/SshFileSystemChannel.cs
@@ -25,7 +25,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Google.Solutions.Ssh
@@ -35,28 +34,14 @@ namespace Google.Solutions.Ssh
     /// </summary>
     public class SshFileSystemChannel : SshChannelBase
     {
-        //
-        // SFTP effectively limits the size of a packet to 32 KB, see
-        // <https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-13#section-4>
-        //
-        // libssh2 uses a slightly smaller limit of 30000 bytes 
-        // (MAX_SFTP_OUTGOING_SIZE, MAX_SFTP_READ_SIZE).
-        // Using a buffer larger than 30000 bytes therefore doen't
-        // provide much value.
-        //
-        // Note that IAP/SSH Relay uses 16KB as maximum message size,
-        // so a 32000 byte packet will be split into 2 messages. 
-        // That's still more efficient than using a SFTP packet
-        // size below 16 KB as it at least limits the number of 
-        // SSH_FXP_STATUS packets that need to be exchanged.
-        //
-        internal const int CopyBufferSize = 30000;
-
         /// <summary>
         /// Channel handle, must only be accessed on worker thread.
         /// </summary>
         private readonly Libssh2SftpChannel nativeChannel;
 
+        /// <summary>
+        /// Connection used by this channel.
+        /// </summary>
         public override SshConnection Connection { get; }
 
         internal SshFileSystemChannel(
@@ -95,115 +80,73 @@ namespace Google.Solutions.Ssh
         // Publics.
         //---------------------------------------------------------------------
 
+        /// <summary>
+        /// List contents of a directory.
+        /// </summary>
         public Task<IReadOnlyCollection<Libssh2SftpFileInfo>> ListFilesAsync(
             string remotePath)
         {
             Precondition.ExpectNotEmpty(remotePath, nameof(remotePath));
 
-            return this.Connection
-                .RunThrowingOperationAsync(c =>
-                {
-                    Debug.Assert(this.Connection.IsRunningOnWorkerThread);
+            return this.Connection.RunThrowingOperationAsync(c =>
+            {
+                Debug.Assert(this.Connection.IsRunningOnWorkerThread);
 
-                    using (c.Session.AsBlocking())
-                    {
-                        return this.nativeChannel.ListFiles(remotePath);
-                    }
-                });
+                using (c.Session.AsBlocking())
+                {
+                    return this.nativeChannel.ListFiles(remotePath);
+                }
+            });
         }
 
-        public Task UploadFileAsync(
+        /// <summary>
+        /// Create or open a file.
+        /// </summary>
+        public Task<Stream> CreateFileAsync(
             string remotePath,
-            Stream source,
-            LIBSSH2_FXF_FLAGS flags,
-            FilePermissions permissions,
-            IProgress<uint> progress,
-            CancellationToken cancellationToken)
+            FileMode mode,
+            FileAccess access,
+            FilePermissions permissions)
         {
             Precondition.ExpectNotEmpty(remotePath, nameof(remotePath));
-            Precondition.ExpectNotNull(source, nameof(source));
-            Precondition.ExpectNotNull(progress, nameof(progress));
 
-            Debug.Assert(source.CanRead);
+            var flags = mode switch
+            {
+                FileMode.Create => LIBSSH2_FXF_FLAGS.CREAT,
+                FileMode.CreateNew => LIBSSH2_FXF_FLAGS.CREAT | LIBSSH2_FXF_FLAGS.EXCL,
+                FileMode.OpenOrCreate => LIBSSH2_FXF_FLAGS.CREAT,
+                FileMode.Open => (LIBSSH2_FXF_FLAGS)0,
+                FileMode.Truncate => LIBSSH2_FXF_FLAGS.TRUNC,
+                FileMode.Append => LIBSSH2_FXF_FLAGS.APPEND,
+                
+                _ => throw new ArgumentException(nameof(mode)),
+            };
 
-            return this.Connection
-                .RunThrowingOperationAsync<object>(c =>
+            if (access.HasFlag(FileAccess.Read))
+            {
+                flags |= LIBSSH2_FXF_FLAGS.READ;
+            }
+
+            if (access.HasFlag(FileAccess.Write))
+            {
+                flags |= LIBSSH2_FXF_FLAGS.WRITE;
+            }
+
+            return this.Connection.RunThrowingOperationAsync<Stream>(c =>
+            {
+                Debug.Assert(this.Connection.IsRunningOnWorkerThread);
+
+                using (c.Session.AsBlocking())
                 {
-                    Debug.Assert(this.Connection.IsRunningOnWorkerThread);
-
-                    //
-                    // Upload the entire file as one operation, possibly
-                    // blocking other channels.
-                    //
-                    // Temporarily disable the timeout.
-                    //
-                    using (c.Session.AsBlocking())
-                    using (var file = this.nativeChannel.CreateFile(
+                    return new SshFileStream(
+                        this.Connection,
+                        this.nativeChannel.CreateFile(
                             remotePath,
                             flags,
-                            permissions))
-                    {
-                        var buffer = new byte[CopyBufferSize];
-                        int bytesRead;
-
-                        while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
-
-                            file.Write(buffer, bytesRead);
-
-                            progress.Report((uint)bytesRead);
-                        }
-
-                        return bytesRead;
-                    }
-                });
-        }
-
-        public Task DownloadFileAsync(
-            string remotePath,
-            Stream target,
-            IProgress<uint> progress,
-            CancellationToken cancellationToken)
-        {
-            Precondition.ExpectNotEmpty(remotePath, nameof(remotePath));
-            Precondition.ExpectNotNull(target, nameof(target));
-            Precondition.ExpectNotNull(progress, nameof(progress));
-
-            Debug.Assert(target.CanWrite);
-
-            return this.Connection
-                .RunThrowingOperationAsync<object>(c =>
-                {
-                    Debug.Assert(this.Connection.IsRunningOnWorkerThread);
-
-                    //
-                    // Upload the entire file as one operation, possibly
-                    // blocking other channels.
-                    //
-                    // Temporarily disable the timeout.
-                    //
-                    using (c.Session.AsBlocking())
-                    using (var file = this.nativeChannel.CreateFile(
-                            remotePath,
-                            LIBSSH2_FXF_FLAGS.READ,
-                            (FilePermissions)0))
-                    {
-                        var buffer = new byte[CopyBufferSize];
-                        uint bytesRead;
-
-                        while ((bytesRead = file.Read(buffer)) > 0)
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
-
-                            target.Write(buffer, 0, (int)bytesRead);
-
-                            progress.Report((uint)bytesRead);
-                        }
-
-                        return bytesRead;
-                    }
-                });
+                            permissions),
+                        flags);
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
- Extend `SshFileSystemChannel` to return a `Stream` when creating or opening a file
- Add `Stream` implementation that reads or writes via SFTP
- Add `CopyToAsync` extension method