### PR TITLE
b/376156037 Disable borders around list views, tree views

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Theme/VSThemeRuleSet.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Theme/VSThemeRuleSet.cs
@@ -154,7 +154,6 @@ namespace Google.Solutions.IapDesktop.Application.Theme
         {
             listView.BackColor = this.theme.Palette.ToolWindowInnerTabInactive.Background;
             listView.ForeColor = this.theme.Palette.ToolWindowInnerTabInactive.Text;
-            listView.BorderStyle = BorderStyle.FixedSingle;
 
             if (this.theme.IsDark)
             {

--- a/sources/Google.Solutions.IapDesktop.Application/ToolWindows/ProjectExplorer/ProjectExplorerView.Designer.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ToolWindows/ProjectExplorer/ProjectExplorerView.Designer.cs
@@ -137,7 +137,6 @@ namespace Google.Solutions.IapDesktop.Application.Windows.ProjectExplorer
             this.treeView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.treeView.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.treeView.ContextMenuStrip = this.contextMenu;
             this.treeView.HideSelection = false;
             this.treeView.ImageIndex = 0;

--- a/sources/Google.Solutions.Mvvm/Theme/WindowsRuleSet.cs
+++ b/sources/Google.Solutions.Mvvm/Theme/WindowsRuleSet.cs
@@ -27,6 +27,7 @@ using Google.Solutions.Platform.Interop;
 using System;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 
@@ -106,6 +107,7 @@ namespace Google.Solutions.Mvvm.Theme
         private void StyleTreeView(TreeView treeView)
         {
             treeView.HotTracking = true;
+            treeView.BorderStyle = BorderStyle.None;
 
             //
             // NB. When called after AllowDarkModeForWindow, this also applies
@@ -117,6 +119,7 @@ namespace Google.Solutions.Mvvm.Theme
         private void StyleListView(ListView listView)
         {
             listView.HotTracking = false;
+            listView.BorderStyle = BorderStyle.None;
 
             //
             // NB. When called after AllowDarkModeForWindow, this also applies


### PR DESCRIPTION
Disable borders for a "flatter" view. This also prevents the thick border
around the tree view after opening the file browser in dark mode.