### PR TITLE
b/380168415 Use different backcolor for splitter

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/Theme/VSThemeRuleSet.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Theme/VSThemeRuleSet.cs
@@ -186,6 +186,19 @@ namespace Google.Solutions.IapDesktop.Application.Theme
             }
         }
 
+        private void StyleSplitContainer(SplitContainer container)
+        {
+            if (!container.IsSplitterFixed)
+            {
+                //
+                // Make sure the splitter is visible and doesn't use
+                // the same back color as list views and other container
+                // controls.
+                //
+                container.BackColor = this.theme.Palette.Button.Background;
+            }
+        }
+
         private void StylePropertyGrid(PropertyGrid grid)
         {
             grid.CategorySplitterColor = this.theme.Palette.GridHeading.Background;
@@ -441,6 +454,7 @@ namespace Google.Solutions.IapDesktop.Application.Theme
             controlTheme.AddRule<PropertyGrid>(c => StylePropertyGrid(c));
             controlTheme.AddRule<TreeView>(c => StyleTreeView(c));
             controlTheme.AddRule<ListView>(c => StyleListView(c));
+            controlTheme.AddRule<SplitContainer>(c => StyleSplitContainer(c));
             controlTheme.AddRule<PropertyGrid>(c => StylePropertyGrid(c));
             controlTheme.AddRule<ToolStrip>(c => StyleToolStrip(c));
             controlTheme.AddRule<Button>(c => StyleButton(c));

--- a/sources/Google.Solutions.Mvvm/Controls/NotificationBarPanel.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/NotificationBarPanel.cs
@@ -40,17 +40,20 @@ namespace Google.Solutions.Mvvm.Controls
         private readonly Label infoLabel = new Label();
         private readonly PictureBox icon = new PictureBox();
 
+        public NotificationBarPanel()
+        {
+            base.Dock = DockStyle.Fill;
+            base.FixedPanel = FixedPanel.Panel1;
+            base.Panel1.BackColor = SystemColors.Info;
+            base.IsSplitterFixed = true;
+        }
+
         //---------------------------------------------------------------------
         // Overrides.
         //---------------------------------------------------------------------
 
         protected override void OnCreateControl()
         {
-            base.Dock = DockStyle.Fill;
-            base.FixedPanel = FixedPanel.Panel1;
-            base.IsSplitterFixed = true;
-            base.Panel1.BackColor = SystemColors.Info;
-
             this.infoLabel.AutoEllipsis = true;
             this.infoLabel.AutoSize = false;
             this.infoLabel.TextAlign = ContentAlignment.MiddleLeft;


### PR DESCRIPTION
Use a backcolor that differs from other container controls to ensure that the splitter is visible.