### PR TITLE
b/380931103 Pause operation dialog when showing error

### DIFF
--- a/sources/Google.Solutions.Mvvm.Test/Controls/TestOperationProgressDialog.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Controls/TestOperationProgressDialog.cs
@@ -1,0 +1,70 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Mvvm.Controls;
+using NUnit.Framework;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace Google.Solutions.Mvvm.Test.Controls
+{
+    [TestFixture]
+    [Apartment(ApartmentState.STA)]
+    public class TestOperationProgressDialog
+    {
+        [Test]
+        public void StartCopyOperation()
+        {
+            using (var form = new Form())
+            {
+                form.Show();
+                using (var op = new OperationProgressDialog()
+                    .StartCopyOperation(form, 1, 2))
+                {
+                    op.OnBytesCompleted(1);
+                    op.OnBytesCompleted(2);
+                    op.OnItemCompleted();
+                }
+            }
+        }
+
+        [Test]
+        public void IsBlockedByError()
+        {
+            using (var form = new Form())
+            {
+                form.Show();
+                using (var op = new OperationProgressDialog()
+                    .StartCopyOperation(form, 1, 2))
+                {
+                    Assert.IsFalse(op.IsBlockedByError);
+
+                    op.IsBlockedByError = true;
+                    op.IsBlockedByError = true;
+
+                    Assert.IsTrue(op.IsBlockedByError);
+
+                    op.IsBlockedByError = false;
+                }
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -733,6 +733,13 @@ namespace Google.Solutions.Mvvm.Controls
                     }
                     catch (Exception e) when (!e.IsCancellation())
                     {
+                        //
+                        // Update dialog to avoid a situation where the
+                        // dialog still indicates that the copy is progressing
+                        // while we're showing an error dialog at the same time.
+                        //
+                        progressDialog.IsBlockedByError = true;
+
                         var parameters = new TaskDialogParameters(
                             "Copy files",
                             $"Unable to copy {file.Name}",
@@ -753,6 +760,7 @@ namespace Google.Solutions.Mvvm.Controls
                     }
                     finally
                     {
+                        progressDialog.IsBlockedByError = false;
                         progressDialog.OnItemCompleted();
                     }
                 }

--- a/sources/Google.Solutions.Mvvm/Controls/OperationProgressDialog.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/OperationProgressDialog.cs
@@ -62,6 +62,12 @@ namespace Google.Solutions.Mvvm.Controls
         /// Report that a chunk of bytes has been completed.
         /// </summary>
         void OnBytesCompleted(ulong delta);
+
+        /// <summary>
+        /// Indicate that the operation is temporarily blocked
+        /// by an error.
+        /// </summary>
+        bool IsBlockedByError { get; set;  }
     }
 
     [SkipCodeCoverage("UI code")]
@@ -101,6 +107,7 @@ namespace Google.Solutions.Mvvm.Controls
             private readonly ulong totalSize;
             private ulong itemsCompleted = 0;
             private ulong sizeCompleted = 0;
+            private bool blockedByError = false;
 
             public CancellationToken CancellationToken => this.cancellationTokenSource.Token;
 
@@ -153,6 +160,21 @@ namespace Google.Solutions.Mvvm.Controls
             {
                 this.sizeCompleted += delta;
                 UpdateProgress();
+            }
+
+            public bool IsBlockedByError 
+            {
+                get => this.blockedByError;
+                set 
+                {
+                    if (value != this.blockedByError)
+                    {
+                        this.blockedByError = value;
+                        this.dialog.SetMode(this.blockedByError
+                            ? PDMODE.ERRORSBLOCKING
+                            : PDMODE.RUN);
+                    }
+                }
             }
 
             public void Dispose()


### PR DESCRIPTION
When a file copy error occiurs block the operation dialog while showing an error message.