### PR TITLE
b/380752047 Cancel file uploads when SSH session closed

### DIFF
--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -708,6 +708,9 @@ namespace Google.Solutions.Mvvm.Controls
                         //
                         // Perform the file copy in the background.
                         //
+                        // NB. If the underlying file system session is closed, 
+                        //     we expect I/O operations to be cancelled.
+                        //
                         await Task
                             .Run(async () =>
                                 {

--- a/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/FileBrowser.cs
@@ -734,7 +734,15 @@ namespace Google.Solutions.Mvvm.Controls
                                 })
                             .ConfigureAwait(true);
                     }
-                    catch (Exception e) when (!e.IsCancellation())
+                    catch (Exception e) when (e.IsCancellation())
+                    {
+                        //
+                        // Ignore, and don't touch the UI because
+                        // it might no longer be in a good state.
+                        //
+                        return;
+                    }
+                    catch (Exception e)
                     {
                         var parameters = new TaskDialogParameters(
                             "Copy files",
@@ -749,7 +757,8 @@ namespace Google.Solutions.Mvvm.Controls
                             DialogResult.Ignore));
                         parameters.Buttons.Add(TaskDialogStandardButton.Cancel);
 
-                        if (this.TaskDialog.ShowDialog(this, parameters) == DialogResult.Cancel)
+                        if (this.TaskDialog.ShowDialog(this, parameters) 
+                            == DialogResult.Cancel)
                         {
                             return;
                         }

--- a/sources/Google.Solutions.Ssh/SshException.cs
+++ b/sources/Google.Solutions.Ssh/SshException.cs
@@ -49,7 +49,7 @@ namespace Google.Solutions.Ssh
         }
     }
 
-    public class SshConnectionClosedException : Exception
+    public class SshConnectionClosedException : OperationCanceledException
     {
         internal SshConnectionClosedException()
             : base(

--- a/sources/Google.Solutions.Ssh/SshWorkerThread.cs
+++ b/sources/Google.Solutions.Ssh/SshWorkerThread.cs
@@ -232,6 +232,7 @@ namespace Google.Solutions.Ssh
                         using (var authenticatedSession = connectedSession.Authenticate(
                             this.credential,
                             this.keyboardHandler))
+                        using (Disposable.For(() => OnBeforeCloseSession()))
                         {
                             //
                             // Make sure the readyToSend handle remains valid throughout
@@ -397,8 +398,6 @@ namespace Google.Solutions.Ssh
                                     }
                                 } // while
                             } // nonblocking
-
-                            OnBeforeCloseSession();
                         }
                     }
                 }


### PR DESCRIPTION
- Cancel pending send operations
- Handle cancellation in UI

This fixes an issue where closing an SSH terminal causes pending I/O tasks to hang, and the operation progress dialog of uploads to become stuck.