### PR TITLE
b/382116424 Use secure property for Windows build number 

### DIFF
--- a/sources/installer/Product.wxs
+++ b/sources/installer/Product.wxs
@@ -68,7 +68,12 @@
         Type="raw"/>
     </Property>
 
-    <Property Id="WINDOWS_CURRENTBUILDNUMBER">
+    <Property Id="WINDOWS_CURRENTBUILDNUMBER" Secure="yes">
+      <!-- 
+        Property must be marked as secure, otherwise Windows Installer 
+        might (depending on policies and elevation state) reject to pass 
+        it to the install sequence.
+      --> 
       <RegistrySearch 
         Id="CurrentBuildNumberSearch"
         Root="HKLM"


### PR DESCRIPTION
Mark `WINDOWS_CURRENTBUILDNUMBER` property as secure, otherwise
it might not be passed to the execute sequence for certain users (depending
on machine policies and elevation state), causing the launch condition to fail.

Re #1580