### PR TITLE
b/376106075 Vary default for automatic logon based on group policy

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettings.cs
@@ -113,7 +113,19 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
                     "is configured to always prompt for passwords upon connection (a server-side " +
                     "group policy)",
                 Categories.RdpSecurity,
-                Protocol.Rdp.RdpAutomaticLogon._Default);
+
+                //
+                // Adjust default based on local RDP policy. If the local policy
+                // disables saving, then there's a good chance that VMs might be
+                // configured to do the same.
+                //
+                // We don't treat this as a policy though, so users can change
+                // the setting.
+                //
+
+                LocalRdpPolicy.IsPasswordSavingDisabled
+                    ? Protocol.Rdp.RdpAutomaticLogon.Disabled
+                    : Protocol.Rdp.RdpAutomaticLogon._Default);
             this.RdpNetworkLevelAuthentication = store.Read<RdpNetworkLevelAuthentication>(
                 "NetworkLevelAuthentication",
                 "Network level authentication",

--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/LocalRdpPolicy.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/LocalRdpPolicy.cs
@@ -1,0 +1,48 @@
+﻿//
+// Copyright 2024 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Microsoft.Win32;
+
+namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
+{
+    internal class LocalRdpPolicy
+    {
+        /// <summary>
+        /// Check if the 'Do not allow passwords to be saved' group
+        /// policy is enforced.
+        /// </summary>
+        public static bool IsPasswordSavingDisabled
+        {
+            get
+            {
+                using (var hklm = RegistryKey.OpenBaseKey(
+                    RegistryHive.LocalMachine,
+                    RegistryView.Default))
+                using (var policyKey = hklm.OpenSubKey(
+                    @"SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services"))
+                {
+                    return policyKey?.GetValue("DisablePasswordSaving")
+                        is int value && value == 1;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Vary the default based on the local `DisablePasswordSaving` policy. When this policy is enforced, disable automatic logons to reduce the potenial for redundant password prompts.