### PR TITLE
b/390040853 Update to Terminal 1.21.3231

### DIFF
--- a/dependencies/sources/terminal-icushim/icu.c
+++ b/dependencies/sources/terminal-icushim/icu.c
@@ -67,6 +67,13 @@ U_CAPI UText* U_EXPORT2 utext_setup(
     return NULL;
 }
 
+U_CAPI UText* U_EXPORT2 utext_close(
+    _In_ UText* ut)
+{
+    UNREFERENCED_PARAMETER(ut);
+    return NULL;
+}
+
 U_CAPI int64_t U_EXPORT2 uregex_start64(
     _In_ URegularExpression* regexp,
     _In_ int32_t groupNum,

--- a/dependencies/sources/terminal-icushim/icu.def
+++ b/dependencies/sources/terminal-icushim/icu.def
@@ -3,6 +3,7 @@ EXPORTS
 	uregex_open
 	uregex_close
 	utext_setup
+	utext_close
 	uregex_start64
 	uregex_setTimeLimit
 	uregex_setStackLimit

--- a/dependencies/sources/terminal-icushim/makefile
+++ b/dependencies/sources/terminal-icushim/makefile
@@ -22,9 +22,9 @@ CONFIGURATION = Release
 PLATFORM = x86
 
 # The tag should be increased whenever one of the dependencies is changed
-TAG = 2
+TAG = 3
 
-ICUSHIM_VERSION=1.0.0.$(TAG)
+ICUSHIM_VERSION=1.21.3231.$(TAG)
 ICUSHIM_PACKAGE_ID = Google.Solutions.IcuShim
 
 !if ("$(PLATFORM)" == "x86")

--- a/dependencies/sources/terminal/makefile
+++ b/dependencies/sources/terminal/makefile
@@ -21,13 +21,13 @@
 CONFIGURATION = Release
 
 # The tag should be increased whenever one of the dependencies is changed
-TAG = 2
+TAG = 3
 
 #
 # Use the pre-built and signed Microsoft binaries.
 #
-TERMINAL_VERSION = 1.19.10821
-TERMINAL_TAG = 1.19.10821.0
+TERMINAL_VERSION = 1.21.3231.$(TAG)
+TERMINAL_TAG = 1.21.3231.0
 TERMINAL_PACKAGE_X86=https://github.com/microsoft/terminal/releases/download/v$(TERMINAL_TAG)/Microsoft.WindowsTerminal_$(TERMINAL_TAG)_x86.zip
 TERMINAL_PACKAGE_X64=https://github.com/microsoft/terminal/releases/download/v$(TERMINAL_TAG)/Microsoft.WindowsTerminal_$(TERMINAL_TAG)_x64.zip
 TERMINAL_PACKAGE_ARM64=https://github.com/microsoft/terminal/releases/download/v$(TERMINAL_TAG)/Microsoft.WindowsTerminal_$(TERMINAL_TAG)_arm64.zip


### PR DESCRIPTION
* Update `Google.Solutions.ThirdParty.Terminal` to use `microsoft/terminal/releases/tag/v1.21.3231.0`
* Add `utext_close` to ICU Shim to satisfy imports of that version