### PR TITLE
b/390040853 Stop pumping pseudo-console events after dispose

### DIFF
--- a/sources/Google.Solutions.Platform/Dispatch/Win32PseudoConsole.cs
+++ b/sources/Google.Solutions.Platform/Dispatch/Win32PseudoConsole.cs
@@ -113,7 +113,7 @@ namespace Google.Solutions.Platform.Dispatch
         private async Task PumpEventsAsync()
         {
             var buffer = new char[1024];
-            while (true)
+            while (!this.IsDisposed)
             {
                 try
                 {
@@ -132,16 +132,23 @@ namespace Google.Solutions.Platform.Dispatch
                     {
                         this.OutputAvailable?.Invoke(
                             this,
-                            new PseudoTerminalDataEventArgs(new string(buffer, 0, charsRead)));
+                            new PseudoTerminalDataEventArgs(
+                                new string(buffer, 0, charsRead)));
                     }
                 }
                 catch (Exception) when (this.IsDisposed)
-                { }
+                {
+                    //
+                    // The pseudo console was closed or disposed while the
+                    // async read was pending. 
+                    //
+                }
                 catch (Exception e)
                 {
                     this.FatalError?.Invoke(
                         this,
                         new PseudoTerminalErrorEventArgs(e));
+                    return;
                 }
             }
         }


### PR DESCRIPTION
Fix a situation where the pump enters an endless
loop because the object has been disposed.