### PR TITLE
b/392726558 Ignore case, whitespace when filtering VMs

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application.Test/ToolWindows/ProjectExplorer/TestProjectExplorerViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/ToolWindows/ProjectExplorer/TestProjectExplorerViewModel.cs
@@ -324,7 +324,9 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.ProjectExplor
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task InstanceFilter_WhenInstanceFilterChanged_ThenViewModelIsUpdated()
+        public async Task InstanceFilter_WhenInstanceFilterChanged_ThenViewModelIsUpdated(
+            [Values("linux-zone", "Linux-Zone", "\tLINUX", " nux ")] 
+            string filterMatchingLinuxInstance)
         {
             var computeClient = CreateComputeEngineClient();
             var viewModel = CreateViewModel(
@@ -343,7 +345,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.ProjectExplor
             var instances = await GetInstancesAsync(viewModel).ConfigureAwait(true);
             Assert.AreEqual(2, instances.Count);
 
-            viewModel.InstanceFilter = SampleLinuxInstanceInZone1.Name.Substring(4);
+            viewModel.InstanceFilter = filterMatchingLinuxInstance;
             instances = await GetInstancesAsync(viewModel).ConfigureAwait(true);
             Assert.AreEqual(1, instances.Count);
 

--- a/sources/Google.Solutions.IapDesktop.Application/ToolWindows/ProjectExplorer/ProjectExplorerViewModel.Nodes.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ToolWindows/ProjectExplorer/ProjectExplorerViewModel.Nodes.cs
@@ -459,7 +459,9 @@ namespace Google.Solutions.IapDesktop.Application.ToolWindows.ProjectExplorer
                 return allNodes
                     .Cast<InstanceViewModelNode>()
                     .Where(i => this.ViewModel.InstanceFilter == null ||
-                                i.InstanceNode.DisplayName.Contains(this.ViewModel.instanceFilter))
+                                i.InstanceNode.DisplayName.IndexOf(
+                                    this.ViewModel.InstanceFilter,
+                                    StringComparison.OrdinalIgnoreCase) >= 0)
                     .Where(i => (i.InstanceNode.OperatingSystem &
                                 this.ViewModel.OperatingSystemsFilter) != 0);
             }


### PR DESCRIPTION
- Ignore leading and trailing whitespace in filter term
- Perform a case-insensitive comparison against the VM name