### PR TITLE
b/392743633 Use TYMED_ISTREAM for file downloads

### DIFF
--- a/sources/Google.Solutions.Mvvm.Test/Interop/TestComStream.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Interop/TestComStream.cs
@@ -1,0 +1,339 @@
+﻿//
+// Copyright 2025 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Solutions.Common.Interop;
+using Google.Solutions.Mvvm.Interop;
+using Moq;
+using NUnit.Framework;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+using System.Text;
+
+namespace Google.Solutions.Mvvm.Test.Interop
+{
+    [TestFixture]
+    public class TestComStream
+    {
+        //--------------------------------------------------------------------
+        // Read.
+        //--------------------------------------------------------------------
+
+        [Test]
+        public void Read_WhenDataAvailable()
+        {
+            using (var bytesRead = GlobalAllocSafeHandle.GlobalAlloc((uint)IntPtr.Size))
+            using (var stream = new ComStream(
+                new MemoryStream(Encoding.ASCII.GetBytes("abcd"))))
+            {
+                var istream = (IStream)stream;
+
+                var buffer = new byte[16];
+                istream.Read(buffer, buffer.Length, bytesRead.DangerousGetHandle());
+
+                Assert.AreEqual(4, Marshal.ReadInt32(bytesRead.DangerousGetHandle()));
+            }
+        }
+
+        [Test]
+        public void Read_WhenAtEnd()
+        {
+            using (var bytesRead = GlobalAllocSafeHandle.GlobalAlloc((uint)IntPtr.Size))
+            using (var stream = new ComStream(new MemoryStream(Array.Empty<byte>())))
+            {
+                var istream = (IStream)stream;
+
+                var buffer = new byte[16];
+                istream.Read(buffer, buffer.Length, bytesRead.DangerousGetHandle());
+
+                Assert.AreEqual(0, Marshal.ReadInt32(bytesRead.DangerousGetHandle()));
+            }
+        }
+
+        [Test]
+        public void Read_WhenSpeculatedSeekSucceeds()
+        {
+            var nonSeekableStream = new Mock<Stream>();
+            nonSeekableStream.SetupGet(s => s.Position).Returns(0);
+            nonSeekableStream.SetupGet(s => s.CanSeek).Returns(false);
+
+            using (var stream = new ComStream(nonSeekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Seek(0, ComStream.STREAM_SEEK_SET, IntPtr.Zero);
+
+                var buffer = new byte[16];
+                istream.Read(buffer, buffer.Length, IntPtr.Zero);
+            }
+        }
+
+        [Test]
+        public void Read_WhenSpeculatedSeekFails()
+        {
+            var nonSeekableStream = new Mock<Stream>();
+            nonSeekableStream.SetupGet(s => s.Position).Returns(1);
+            nonSeekableStream.SetupGet(s => s.CanSeek).Returns(false);
+
+            using (var stream = new ComStream(nonSeekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Seek(0, ComStream.STREAM_SEEK_SET, IntPtr.Zero);
+
+                var buffer = new byte[16];
+                Assert.Throws<NotSupportedException>(
+                    () => istream.Read(buffer, buffer.Length, IntPtr.Zero));
+            }
+        }
+
+        //--------------------------------------------------------------------
+        // Write.
+        //--------------------------------------------------------------------
+
+        [Test]
+        public void Write()
+        {
+            using (var bytesWritten = GlobalAllocSafeHandle.GlobalAlloc((uint)IntPtr.Size))
+            using (var stream = new ComStream(new MemoryStream()))
+            {
+                var istream = (IStream)stream;
+
+                var buffer = Encoding.ASCII.GetBytes("abcd");
+                istream.Write(buffer, 4, bytesWritten.DangerousGetHandle());
+
+                Assert.AreEqual(4, Marshal.ReadInt32(bytesWritten.DangerousGetHandle()));
+            }
+        }
+
+        [Test]
+        public void Write_WhenSpeculatedSeekSucceeds()
+        {
+            var nonSeekableStream = new Mock<Stream>();
+            nonSeekableStream.SetupGet(s => s.Position).Returns(0);
+            nonSeekableStream.SetupGet(s => s.CanSeek).Returns(false);
+
+            using (var stream = new ComStream(nonSeekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Seek(0, ComStream.STREAM_SEEK_SET, IntPtr.Zero);
+
+                var buffer = Encoding.ASCII.GetBytes("abcd");
+                istream.Write(buffer, 4, IntPtr.Zero);
+            }
+        }
+
+        [Test]
+        public void Write_WhenSpeculatedSeekFails()
+        {
+            var nonSeekableStream = new Mock<Stream>();
+            nonSeekableStream.SetupGet(s => s.Position).Returns(1);
+            nonSeekableStream.SetupGet(s => s.CanSeek).Returns(false);
+
+            using (var stream = new ComStream(nonSeekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Seek(2, ComStream.STREAM_SEEK_CUR, IntPtr.Zero);
+
+                var buffer = Encoding.ASCII.GetBytes("abcd");
+                Assert.Throws<NotSupportedException>(
+                    () => istream.Write(buffer, 4, IntPtr.Zero));
+            }
+        }
+
+        //--------------------------------------------------------------------
+        // Seek - w/o speculation.
+        //--------------------------------------------------------------------
+
+        [Test]
+        public void Seek_Set_WhenStreamCanSeek()
+        {
+            var seekableStream = new Mock<Stream>();
+            seekableStream.SetupGet(s => s.CanSeek).Returns(true);
+
+            using (var stream = new ComStream(seekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Seek(4, ComStream.STREAM_SEEK_SET, IntPtr.Zero);
+
+                Assert.IsNull(stream.SpeculatedPosition);
+            }
+
+            seekableStream.Verify(s => s.Seek(4, SeekOrigin.Begin));
+        }
+
+        [Test]
+        public void Seek_Cur_WhenStreamCanSeek()
+        {
+            var seekableStream = new Mock<Stream>();
+            seekableStream.SetupGet(s => s.CanSeek).Returns(true);
+
+            using (var stream = new ComStream(seekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Seek(4, ComStream.STREAM_SEEK_CUR, IntPtr.Zero);
+
+                Assert.IsNull(stream.SpeculatedPosition);
+            }
+
+            seekableStream.Verify(s => s.Seek(4, SeekOrigin.Current));
+        }
+
+        [Test]
+        public void Seek_End_WhenStreamCanSeek()
+        {
+            var seekableStream = new Mock<Stream>();
+            seekableStream.SetupGet(s => s.CanSeek).Returns(true);
+
+            using (var stream = new ComStream(seekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Seek(4, ComStream.STREAM_SEEK_END, IntPtr.Zero);
+
+                Assert.IsNull(stream.SpeculatedPosition);
+            }
+
+            seekableStream.Verify(s => s.Seek(4, SeekOrigin.End));
+        }
+
+        //--------------------------------------------------------------------
+        // Seek - w/ speculation.
+        //--------------------------------------------------------------------
+
+        [Test]
+        public void Seek_Set_WhenStreamCannotSeek()
+        {
+            var seekableStream = new Mock<Stream>();
+            seekableStream.SetupGet(s => s.CanSeek).Returns(false);
+
+            using (var stream = new ComStream(seekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Seek(4, ComStream.STREAM_SEEK_SET, IntPtr.Zero);
+                Assert.AreEqual(4, stream.SpeculatedPosition);
+            }
+        }
+
+        [Test]
+        public void Seek_Cur_WhenStreamCannotSeek()
+        {
+            var seekableStream = new Mock<Stream>();
+            seekableStream.SetupGet(s => s.CanSeek).Returns(false);
+            seekableStream.SetupGet(s => s.Position).Returns(4);
+
+            using (var stream = new ComStream(seekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Seek(-2, ComStream.STREAM_SEEK_CUR, IntPtr.Zero);
+                Assert.AreEqual(2, stream.SpeculatedPosition);
+            }
+        }
+
+        [Test]
+        public void Seek_End_WhenStreamCannotSeek()
+        {
+            var seekableStream = new Mock<Stream>();
+            seekableStream.SetupGet(s => s.CanSeek).Returns(false);
+            seekableStream.SetupGet(s => s.Position).Returns(4);
+            seekableStream.SetupGet(s => s.Length).Returns(8);
+
+            using (var stream = new ComStream(seekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Seek(-2, ComStream.STREAM_SEEK_END, IntPtr.Zero);
+                Assert.AreEqual(6, stream.SpeculatedPosition);
+            }
+        }
+
+        //--------------------------------------------------------------------
+        // Stat.
+        //--------------------------------------------------------------------
+
+        [Test]
+        public void Stat_WhenReadOnly()
+        {
+            var seekableStream = new Mock<Stream>();
+            seekableStream.SetupGet(s => s.CanRead).Returns(true);
+            seekableStream.SetupGet(s => s.CanWrite).Returns(false);
+            seekableStream.SetupGet(s => s.Length).Returns(8);
+
+            using (var stream = new ComStream(seekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Stat(out var stat, 0);
+
+                Assert.AreEqual(ComStream.STGM_READ, stat.grfMode);
+                Assert.AreEqual(8, stat.cbSize);
+                Assert.AreEqual(ComStream.STGTY_STREAM, stat.type);
+            }
+        }
+
+        [Test]
+        public void Stat_WhenWriteOnly()
+        {
+            var seekableStream = new Mock<Stream>();
+            seekableStream.SetupGet(s => s.CanRead).Returns(false);
+            seekableStream.SetupGet(s => s.CanWrite).Returns(true);
+            seekableStream.SetupGet(s => s.Length).Returns(8);
+
+            using (var stream = new ComStream(seekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Stat(out var stat, 0);
+
+                Assert.AreEqual(ComStream.STGM_WRITE, stat.grfMode);
+                Assert.AreEqual(8, stat.cbSize);
+                Assert.AreEqual(ComStream.STGTY_STREAM, stat.type);
+            }
+        }
+
+        [Test]
+        public void Stat_WhenReadWrite()
+        {
+            var seekableStream = new Mock<Stream>();
+            seekableStream.SetupGet(s => s.CanRead).Returns(true);
+            seekableStream.SetupGet(s => s.CanWrite).Returns(true);
+            seekableStream.SetupGet(s => s.Length).Returns(8);
+
+            using (var stream = new ComStream(seekableStream.Object))
+            {
+                var istream = (IStream)stream;
+
+                istream.Stat(out var stat, 0);
+
+                Assert.AreEqual(ComStream.STGM_READWRITE, stat.grfMode);
+                Assert.AreEqual(8, stat.cbSize);
+                Assert.AreEqual(ComStream.STGTY_STREAM, stat.type);
+            }
+        }
+    }
+}

--- a/sources/Google.Solutions.Mvvm/Interop/ComStream.cs
+++ b/sources/Google.Solutions.Mvvm/Interop/ComStream.cs
@@ -1,0 +1,266 @@
+﻿//
+// Copyright 2025 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace Google.Solutions.Mvvm.Interop
+{
+    /// <summary>
+    /// Wraps a managed stream as a COM IStream.
+    /// </summary>
+    internal sealed class ComStream : IStream, IDisposable
+    {
+        private readonly Stream stream;
+
+        public ComStream(Stream stream)
+        {
+            this.stream = stream;
+        }
+
+        internal long? SpeculatedPosition { get; private set; } = null;
+        
+        /// <summary>
+        /// Verify and retire a speculation that a previous seek was
+        /// unnecessary.
+        /// </summary>
+        private void RetireSpeculatedSeek()
+        {
+            if (this.SpeculatedPosition != null &&
+                this.SpeculatedPosition != this.stream.Position)
+            {
+                throw new NotSupportedException(
+                    "The stream does not support seeking");
+            }
+
+            this.SpeculatedPosition = null;
+        }
+
+        //--------------------------------------------------------------------
+        // IStream.
+        //--------------------------------------------------------------------
+
+        /// <summary>
+        /// Reads a specified number of bytes from the stream object into memory
+        /// starting at the current seek pointer.
+        /// </summary>
+        void IStream.Read(byte[] buffer, int count, IntPtr bytesReadPtr)
+        {
+            RetireSpeculatedSeek();
+
+            var bytesRead = this.stream.Read(buffer, 0, (int)count);
+            if (bytesReadPtr != IntPtr.Zero)
+            {
+                Marshal.WriteInt32(bytesReadPtr, bytesRead);
+            }
+        }
+
+        /// <summary>
+        /// Writes a specified number of bytes into the stream object starting 
+        /// at the current seek pointer.
+        /// </summary>
+        void IStream.Write(byte[] buffer, int count, IntPtr bytesWrittenPtr)
+        {
+            RetireSpeculatedSeek();
+
+            this.stream.Write(buffer, 0, count);
+            if (bytesWrittenPtr != IntPtr.Zero)
+            {
+                // 
+                // It's safe to assume that we wrote the entire buffer.
+                //
+                Marshal.WriteInt32(bytesWrittenPtr, count);
+            }
+        }
+
+        /// <summary>
+        /// Changes the seek pointer to a new location relative to the 
+        /// beginning of the stream, to the end of the stream, or to the 
+        /// current seek pointer.
+        /// </summary>
+        void IStream.Seek(long offset, int origin, IntPtr newPositionPtr)
+        {
+            var seekOrigin = origin switch
+            {
+                STREAM_SEEK_SET => SeekOrigin.Begin,
+                STREAM_SEEK_CUR => SeekOrigin.Current,
+                STREAM_SEEK_END => SeekOrigin.End,
+                _ => throw new ArgumentOutOfRangeException(nameof(origin))
+            };
+
+            long position;
+            if (this.stream.CanSeek)
+            {
+                position = this.stream.Seek(offset, seekOrigin);
+            }
+            else 
+            {
+                //
+                // Assume we're at the right position already.
+                // 
+                // - If this is a NOP-seek (like Current + 0 offset),
+                //   a subsequent Read or Write will succeed.
+                //   
+                // - If this is a Reset-seek performed at the end,
+                //   we won't see any subsequent Read or Write, so
+                //   we're okay too.
+                //
+                // This is sufficient to satisfy a client that merely
+                // uses seeking to ensure the stream is set to the
+                // beginning before starting to read.
+                //
+                this.SpeculatedPosition = position = seekOrigin switch
+                {
+                    SeekOrigin.Begin => offset,
+                    SeekOrigin.Current => this.stream.Position + offset,
+                    SeekOrigin.End => this.stream.Length + offset,
+                    _ => throw new ArgumentOutOfRangeException(nameof(origin))
+                };
+            }
+
+            if (newPositionPtr != IntPtr.Zero)
+            {
+                Marshal.WriteInt64(newPositionPtr, position);
+            }
+        }
+
+        /// <summary>
+        /// Changes the size of the stream object.
+        /// </summary>
+        void IStream.SetSize(long newSize)
+        {
+            this.stream.SetLength(newSize);
+        }
+
+        /// <summary>
+        /// Retrieves the STATSTG structure for this stream.
+        /// </summary>
+        void IStream.Stat(
+            out System.Runtime.InteropServices.ComTypes.STATSTG streamStats, 
+            int grfStatFlag)
+        {
+            streamStats = new System.Runtime.InteropServices.ComTypes.STATSTG
+            {
+                type = STGTY_STREAM,
+                cbSize = this.stream.Length,
+                grfMode = 0 
+            };
+
+            if (this.stream.CanRead && this.stream.CanWrite)
+            {
+                streamStats.grfMode |= STGM_READWRITE;
+            }
+            else if (this.stream.CanRead)
+            {
+                streamStats.grfMode |= STGM_READ;
+            }
+            else if (this.stream.CanWrite)
+            {
+                streamStats.grfMode |= STGM_WRITE;
+            }
+            else
+            {
+                //
+                // A stream that is neither readable nor writable is a closed stream.
+                //
+                throw new IOException("Stream is closed");
+            }
+        }
+
+        /// <summary>
+        /// Copies a specified number of bytes from the current seek pointer
+        /// in the stream to the current seek pointer in another stream.
+        /// </summary>
+        void IStream.CopyTo(IStream pstm, long cb, IntPtr pcbRead, IntPtr pcbWritten)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Discards all changes that have been made to a transacted stream 
+        /// since the last Commit(Int32) call.
+        /// </summary>
+        void IStream.Revert()
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Restricts access to a specified range of bytes in the stream.
+        /// </summary>
+        void IStream.LockRegion(long libOffset, long cb, int dwLockType)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Removes the access restriction on a range of bytes
+        /// </summary>
+        void IStream.UnlockRegion(long libOffset, long cb, int dwLockType)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Ensures that any changes made to a stream object that is open in 
+        /// transacted mode are reflected in the parent storage.
+        /// </summary>
+        void IStream.Commit(int grfCommitFlags)
+        {
+            throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Creates a new stream object with its own seek pointer that references 
+        /// the same bytes as the original stream.
+        /// </summary>
+        void IStream.Clone(out IStream? copy)
+        {
+            copy = null;
+            throw new NotSupportedException();
+        }
+
+        //--------------------------------------------------------------------
+        // IDisposable.
+        //--------------------------------------------------------------------
+
+        public void Dispose()
+        {
+            this.stream.Dispose();
+        }
+
+        //--------------------------------------------------------------------
+        // P/Invoke constants.
+        //--------------------------------------------------------------------
+
+        internal const int STREAM_SEEK_SET = 0;
+        internal const int STREAM_SEEK_CUR = 1;
+        internal const int STREAM_SEEK_END = 2;
+
+        internal const int STGTY_STREAM = 2;
+
+        internal const int STGM_READ = 0;
+        internal const int STGM_WRITE = 1;
+        internal const int STGM_READWRITE = 2;
+    }
+}

--- a/sources/Google.Solutions.Mvvm/Shell/VirtualFileDataObject.cs
+++ b/sources/Google.Solutions.Mvvm/Shell/VirtualFileDataObject.cs
@@ -22,6 +22,7 @@
 using Google.Solutions.Common.Interop;
 using Google.Solutions.Common.Util;
 using Google.Solutions.Mvvm.Controls;
+using Google.Solutions.Mvvm.Interop;
 using Google.Solutions.Platform.Interop;
 using System;
 using System.Collections.Generic;
@@ -137,17 +138,9 @@ namespace Google.Solutions.Mvvm.Shell
                 //     has completed.
                 //
 
-                //
-                // NB. DataObject (in SaveStreamToHandle) assumes that Stream.Read()
-                //     always reads the requested amount of data, but Stream
-                //     implementations are allowed to return _less_ than that.
-                //     To compensate, wrap the stream.
-                //
-
                 if (this.currentFile >= 0 && this.currentFile < this.Files.Count)
                 {
-                    var contentStream = new FullReadGuaranteeingStream(
-                        this.Files[this.currentFile].OpenStream());
+                    var contentStream = this.Files[this.currentFile].OpenStream();
                     this.openedContentStreams.Add(contentStream);
 
                     //
@@ -171,6 +164,15 @@ namespace Google.Solutions.Mvvm.Shell
             return base.GetData(format, autoConvert);
         }
 
+        /// <summary>
+        /// Get data to drop.
+        /// 
+        /// NB. This method differs in 2 ways from the base class implementation:
+        ///
+        ///     1. It extracts the index of the file that is currently
+        ///        being processed. This
+        ///     2. It adds support for TYMED_ISTREAM.
+        /// </summary>
         void UCOMIDataObject.GetData(ref FORMATETC formatetc, out STGMEDIUM medium)
         {
             if (this.disposed)
@@ -179,12 +181,6 @@ namespace Google.Solutions.Mvvm.Shell
                 medium.tymed = TYMED.TYMED_NULL;
                 return;
             }
-
-            //
-            // NB. The only purpose of overriding this method is to get the
-            //     index of the file that is currently being processed. This
-            //     information is encoded in the FORMATETC parameter.
-            //
 
             if (formatetc.cfFormat ==
                 (short)DataFormats.GetFormat(ShellDataFormats.CFSTR_FILECONTENTS).Id)
@@ -196,15 +192,36 @@ namespace Google.Solutions.Mvvm.Shell
             }
 
             //
-            // Now it would be good to call base.GetData(...), but that's not possible
-            // because the method is an EIMI. Therefore, we replicate its logic here.
+            // Populate the medium.
             //
 
             medium = default;
-            if (GetTymedUseable(formatetc.tymed))
+            if (!GetTymedUseable(formatetc.tymed))
             {
-                if ((formatetc.tymed & TYMED.TYMED_HGLOBAL) != 0)
+                Marshal.ThrowExceptionForHR((int)HRESULT.DV_E_TYMED);
+            }
+
+            var formatName = DataFormats.GetFormat(formatetc.cfFormat).Name;
+            this.IsOperationInProgress = true;
+
+            try
+            {
+                if ((formatetc.tymed & TYMED.TYMED_ISTREAM) != 0 &&
+                    GetData(formatName, false) is Stream dataStream)
                 {
+                    //
+                    // Wrap the managed stream as a COM IStream.
+                    //
+                    var streamPtr = Marshal.GetIUnknownForObject(new ComStream(dataStream));
+
+                    medium.tymed = TYMED.TYMED_ISTREAM;
+                    medium.unionmember = streamPtr;
+                }
+                else if ((formatetc.tymed & TYMED.TYMED_HGLOBAL) != 0)
+                {
+                    //
+                    // Let the base class copy the stream into an HGLOBAL.
+                    //
                     medium.tymed = TYMED.TYMED_HGLOBAL;
                     medium.unionmember = NativeMethods.GlobalAlloc(GHND | GMEM_DDESHARE, 1);
                     if (medium.unionmember == IntPtr.Zero)
@@ -218,40 +235,39 @@ namespace Google.Solutions.Mvvm.Shell
                         // Copy data. This will invoke GetData(format, autoConvert), which
                         // in turn uses the cached index to provide the right data.
                         //
-                        this.IsOperationInProgress = true;
 
                         ((UCOMIDataObject)this).GetDataHere(ref formatetc, ref medium);
                         return;
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         NativeMethods.GlobalFree(new HandleRef(medium, medium.unionmember));
                         medium.unionmember = IntPtr.Zero;
-
-                        if (e is COMException comEx && (
-                            comEx.HResult == DV_E_FORMATETC ||
-                            comEx.HResult == (int)HRESULT.E_FAIL))
-                        {
-                            //
-                            // These can happen during format negotiation and 
-                            // aren't worth raising an event for.
-                            //
-                        }
-                        else if (this.IsAsync)
-                        {
-                            this.AsyncOperationFailed?.Invoke(this, new ExceptionEventArgs(e));
-                        }
-
                         throw;
                     }
                 }
-
-                medium.tymed = formatetc.tymed;
-                ((UCOMIDataObject)this).GetDataHere(ref formatetc, ref medium);
+                else
+                {
+                    Marshal.ThrowExceptionForHR((int)HRESULT.DV_E_TYMED);
+                }
             }
-            else
+            catch (Exception e) 
             {
-                Marshal.ThrowExceptionForHR(DV_E_TYMED);
+                if (e is COMException comEx && (
+                    comEx.HResult == (int)HRESULT.DV_E_FORMATETC ||
+                    comEx.HResult == (int)HRESULT.E_FAIL))
+                {
+                    //
+                    // These can happen during format negotiation and 
+                    // aren't worth raising an event for.
+                    //
+                }
+                else if (this.IsAsync)
+                {
+                    this.AsyncOperationFailed?.Invoke(this, new ExceptionEventArgs(e));
+                }
+
+                throw;
             }
 
             bool GetTymedUseable(TYMED tymed)
@@ -526,94 +542,6 @@ namespace Google.Solutions.Mvvm.Shell
             }
         }
 
-        /// <summary>
-        /// Stream that always reads the full amount of requested data,
-        /// even if the Stream contract doesn't require that.
-        /// </summary>
-        private class FullReadGuaranteeingStream : Stream
-        {
-            private readonly Stream stream;
-
-            public FullReadGuaranteeingStream(Stream stream)
-            {
-                this.stream = stream;
-            }
-
-            public override bool CanRead
-            {
-                get => this.stream.CanRead;
-            }
-
-            public override bool CanSeek
-            {
-                get => this.stream.CanSeek;
-            }
-
-            public override bool CanWrite
-            {
-                get => this.stream.CanWrite;
-            }
-
-            public override long Length
-            {
-                get => this.stream.Length;
-            }
-
-            public override long Position
-            {
-                get => this.stream.Position;
-                set => this.stream.Position = value;
-            }
-
-            public override void Flush()
-            {
-                this.stream.Flush();
-            }
-
-            public override long Seek(long offset, SeekOrigin origin)
-            {
-                return this.stream.Seek(offset, origin);
-            }
-
-            public override void SetLength(long value)
-            {
-                this.stream?.SetLength(value);
-            }
-
-            public override int Read(byte[] buffer, int offset, int count)
-            {
-                //
-                // Keep reading until we reached the requested number
-                // of bytes or the end of the stream.
-                //
-                var totalBytesRead = 0;
-                while (totalBytesRead < count)
-                {
-                    var bytesRead = this.stream.Read(
-                        buffer,
-                        offset + totalBytesRead,
-                        count - totalBytesRead);
-                    if (bytesRead > 0)
-                    {
-                        totalBytesRead += bytesRead;
-                    }
-                }
-
-                return totalBytesRead;
-            }
-
-            public override void Write(byte[] buffer, int offset, int count)
-            {
-                this.stream.Write(buffer, offset, count);
-            }
-
-            protected override void Dispose(bool disposing)
-            {
-                base.Dispose(disposing);
-                this.stream.Dispose();
-            }
-        }
-
         //----------------------------------------------------------------------
         // Interop declarations.
         //----------------------------------------------------------------------
@@ -629,9 +557,6 @@ namespace Google.Solutions.Mvvm.Shell
         private const uint GMEM_ZEROINIT = 0x0040;
         private const uint GHND = (GMEM_MOVEABLE | GMEM_ZEROINIT);
         private const uint GMEM_DDESHARE = 0x2000;
-
-        private const int DV_E_TYMED = unchecked((int)0x80040069);
-        private const int DV_E_FORMATETC = unchecked((int)0x80040064);
 
         [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
         internal struct FILEDESCRIPTORW

--- a/sources/Google.Solutions.Mvvm/Shell/VirtualFileDataObject.cs
+++ b/sources/Google.Solutions.Mvvm/Shell/VirtualFileDataObject.cs
@@ -240,6 +240,8 @@ namespace Google.Solutions.Mvvm.Shell
                         {
                             NativeMethods.GlobalFree(new HandleRef(medium, medium.unionmember));
                             medium.unionmember = IntPtr.Zero;
+
+                            throw;
                         }
                     }
                     else

--- a/sources/Google.Solutions.Mvvm/Shell/VirtualFileDataObject.cs
+++ b/sources/Google.Solutions.Mvvm/Shell/VirtualFileDataObject.cs
@@ -194,12 +194,7 @@ namespace Google.Solutions.Mvvm.Shell
             //
             // Populate the medium.
             //
-
             medium = default;
-            if (!GetTymedUseable(formatetc.tymed))
-            {
-                Marshal.ThrowExceptionForHR((int)HRESULT.DV_E_TYMED);
-            }
 
             var formatName = DataFormats.GetFormat(formatetc.cfFormat).Name;
             this.IsOperationInProgress = true;
@@ -210,7 +205,7 @@ namespace Google.Solutions.Mvvm.Shell
                     GetData(formatName, false) is Stream dataStream)
                 {
                     //
-                    // Wrap the managed stream as a COM IStream.
+                    // Return data as a COM IStream.
                     //
                     var streamPtr = Marshal.GetIUnknownForObject(new ComStream(dataStream));
 
@@ -220,7 +215,8 @@ namespace Google.Solutions.Mvvm.Shell
                 else if ((formatetc.tymed & TYMED.TYMED_HGLOBAL) != 0)
                 {
                     //
-                    // Let the base class copy the stream into an HGLOBAL.
+                    // Return data as an HGLOBAL. The base class can do
+                    // that for us.
                     //
                     medium.tymed = TYMED.TYMED_HGLOBAL;
                     medium.unionmember = NativeMethods.GlobalAlloc(GHND | GMEM_DDESHARE, 1);
@@ -268,28 +264,6 @@ namespace Google.Solutions.Mvvm.Shell
                 }
 
                 throw;
-            }
-
-            bool GetTymedUseable(TYMED tymed)
-            {
-                var allowed = new TYMED[5]
-                {
-                    TYMED.TYMED_HGLOBAL,
-                    TYMED.TYMED_ISTREAM,
-                    TYMED.TYMED_ENHMF,
-                    TYMED.TYMED_MFPICT,
-                    TYMED.TYMED_GDI
-                };
-
-                for (var i = 0; i < allowed.Length; i++)
-                {
-                    if ((tymed & allowed[i]) != 0)
-                    {
-                        return true;
-                    }
-                }
-
-                return false;
             }
         }
 

--- a/sources/Google.Solutions.Platform/Interop/Hresult.cs
+++ b/sources/Google.Solutions.Platform/Interop/Hresult.cs
@@ -27,6 +27,9 @@ namespace Google.Solutions.Platform.Interop
         S_FALSE = 1,
         E_UNEXPECTED = unchecked((int)0x8000ffff),
         E_FAIL = unchecked((int)0x80004005),
+
+        DV_E_TYMED = unchecked((int)0x80040069),
+        DV_E_FORMATETC = unchecked((int)0x80040064),
     }
 
     public static class HresultExtensions

--- a/sources/Google.Solutions.Ssh/SftpFileStream.cs
+++ b/sources/Google.Solutions.Ssh/SftpFileStream.cs
@@ -104,7 +104,8 @@ namespace Google.Solutions.Ssh
                 }
                 else
                 {
-                    return 0;
+                    throw new InvalidOperationException(
+                        "The file size is not available");
                 }
             }
         }


### PR DESCRIPTION
When downloading a file over SFTP (using drag/drop or copy/paste),
use `TYMED_ISTREAM` instead of `TYMED_HGLOBAL` is possible. 

`TYMED_HGLOBAL` works okay for small files, but requies excessive
memory when downloading large files. Using `TYMED_ISTREAM`
avoids that.

- Add `TYMED_ISTREAM` support to `VirtualFileDataObject` to 
  compensate for the missing support in the BCL.
- Add `ComStream` to wrap managed streams as a COM `IStream`