### PR TITLE
b/394184904 Show more accurate error message when OAuth exchange fails

### DIFF
--- a/sources/Google.Solutions.Apis/Auth/Gaia/GaiaOidcClient.cs
+++ b/sources/Google.Solutions.Apis/Auth/Gaia/GaiaOidcClient.cs
@@ -275,8 +275,8 @@ namespace Google.Solutions.Apis.Auth.Gaia
                 else
                 {
                     throw new AuthorizationFailedException(
-                        "Authorization failed because your computer is not enrolled in Endpoint " +
-                        "Verification.\n\n" + e.Error.ErrorDescription);
+                        "Authorization failed because a context-aware access requirement " +
+                        "was not met.\n\n" + e.Error.ErrorDescription);
 
                 }
             }

--- a/sources/Google.Solutions.Terminal/Controls/VirtualTerminal.cs
+++ b/sources/Google.Solutions.Terminal/Controls/VirtualTerminal.cs
@@ -433,6 +433,7 @@ namespace Google.Solutions.Terminal.Controls
                 // If we're receiving output during a WM_RBUTTONDOWN,
                 // then the output must be such unsanitized clipboard
                 // contents.
+                //
                 data = SanitizeTextForPasting(data);
             }
 


### PR DESCRIPTION
A servicerestricted error isn't necessarily caused by a missing EV enrollment, but can be caused by other CAA requirements not being met.