### PR TITLE
b/380753702 Prevent access to selected node while loading

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/ToolWindows/ProjectExplorer/ProjectExplorerViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ToolWindows/ProjectExplorer/ProjectExplorerViewModel.cs
@@ -333,6 +333,15 @@ namespace Google.Solutions.IapDesktop.Application.ToolWindows.ProjectExplorer
                         this.RootNode.DebugIsValidNode(this.selectedNode),
                     "Node detached");
 
+                if (this.selectedNode is CloudViewModelNode cloudNode &&
+                    !cloudNode.IsLoaded)
+                {
+                    //
+                    // Not fully initialized yet.
+                    //
+                    return null;
+                }
+
                 return this.selectedNode;
             }
             set


### PR DESCRIPTION
This fixes an issue where opening the authorized keys-view fails when loading the cloud node hasn't completed yet.