### PR TITLE
b/397280361 Read all available output on shell channel

### DIFF
--- a/sources/Google.Solutions.Ssh/Native/Libssh2ChannelBase.cs
+++ b/sources/Google.Solutions.Ssh/Native/Libssh2ChannelBase.cs
@@ -108,6 +108,10 @@ namespace Google.Solutions.Ssh.Native
                 {
                     return (uint)bytesRead;
                 }
+                else if (((LIBSSH2_ERROR)bytesRead) == LIBSSH2_ERROR.EAGAIN)
+                {
+                    return 0;
+                }
                 else
                 {
                     throw this.Session.CreateException((LIBSSH2_ERROR)bytesRead);

--- a/sources/Google.Solutions.Ssh/SshWorkerThread.cs
+++ b/sources/Google.Solutions.Ssh/SshWorkerThread.cs
@@ -339,6 +339,9 @@ namespace Google.Solutions.Ssh
                                             // 
                                             // Perform whatever receiving operation we need to do.
                                             //
+                                            // NB. We already reset the WSA event, so we must now read
+                                            // all data that's available.
+                                            //
                                             OnReadyToReceive(authenticatedSession);
                                         }
                                         else if (waitResult == NativeMethods.WSA_WAIT_EVENT_0 + 1)


### PR DESCRIPTION
When WSAWaitForMultipleEvents indicates that there's data on the shell channel, read as much data as available because the WSA event won't remain signalled.

This fixes an issue where the terminal output can suddenly stall if the server produces output more quickly than the client can read it.