### PR TITLE
b/402564632 Copy selection on mouse click

### DIFF
--- a/sources/Google.Solutions.Mvvm/Controls/ClipboardUtil.cs
+++ b/sources/Google.Solutions.Mvvm/Controls/ClipboardUtil.cs
@@ -40,11 +40,26 @@ namespace Google.Solutions.Mvvm.Controls
                 return string.Empty;
             }
         }
+
         public static void SetText(string text)
         {
             try
             {
                 Clipboard.SetText(text);
+            }
+            catch (ExternalException)
+            {
+                //
+                // Clipboard busy, ignore.
+                //
+            }
+        }
+
+        public static void Clear()
+        {
+            try
+            {
+                Clipboard.Clear();
             }
             catch (ExternalException)
             {

--- a/sources/Google.Solutions.Terminal/Controls/VirtualTerminal.cs
+++ b/sources/Google.Solutions.Terminal/Controls/VirtualTerminal.cs
@@ -930,7 +930,7 @@ namespace Google.Solutions.Terminal.Controls
                             {
                                 if (!string.IsNullOrWhiteSpace(this.selectionToCopyInKeyUp))
                                 {
-                                    Clipboard.SetText(this.selectionToCopyInKeyUp);
+                                    ClipboardUtil.SetText(this.selectionToCopyInKeyUp);
                                 }
                             }
                             catch (ExternalException)
@@ -995,6 +995,39 @@ namespace Google.Solutions.Terminal.Controls
                         break;
                     }
 
+                case WindowMessage.WM_LBUTTONDOWN:
+                case WindowMessage.WM_RBUTTONDOWN:
+                    {
+                        if (NativeMethods.TerminalIsSelectionActive(terminalHandle))
+                        {
+                            //
+                            // Get (and clear) selected text.
+                            //
+                            var selection = NativeMethods.TerminalGetSelection(terminalHandle);
+
+                            if (string.IsNullOrWhiteSpace(selection))
+                            {
+                                //
+                                // Clear clipboard instead of copying some whitespace.
+                                // This is concistent with how the Windows console
+                                // handles this case.
+                                //
+                                ClipboardUtil.Clear();
+                            }
+                            else
+                            { 
+                                ClipboardUtil.SetText(selection);
+                            }
+                        }
+
+                        //
+                        // Continue processing message.
+                        //
+                        // NB. In case of WM_RBUTTONDOWN, the terminal will cause 
+                        //     the copied text to be pasted right away.
+                        //
+                        goto default;
+                    }
 
                 case WindowMessage.WM_MOUSEWHEEL:
                     {


### PR DESCRIPTION
Copy current selection on (left/right) mouse click, unless the selection is all-whitespace.

This aligns the behavior with the Windows terminal.