### PR TITLE
b/409123329 Disabling test

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestPlatformCredentialAuthentication.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session.Test/Protocol/Ssh/TestPlatformCredentialAuthentication.cs
@@ -244,6 +244,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Test.Protocol.Ssh
         }
 
         [Test]
+        [Ignore("Unreliable in CI because of IAM propagation delay")]
         public async Task Workforce_WhenInRole_ThenAuthenticationWithOsLoginSucceeds(
             [Values(SshKeyType.Rsa3072, SshKeyType.EcdsaNistp256)] SshKeyType keyType,
             [LinuxInstance(EnableOsLogin = true)] ResourceTask<InstanceLocator> instance,


### PR DESCRIPTION
Disabling OS Login-based test because the IAM propagation delay makes it unreliable in CI.