### PR TITLE
b/418214603 Prevent KeyCode.None from triggering defaut command

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Application/ToolWindows/ProjectExplorer/ProjectExplorerView.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/ToolWindows/ProjectExplorer/ProjectExplorerView.cs
@@ -436,7 +436,7 @@ namespace Google.Solutions.IapDesktop.Application.Windows.ProjectExplorer
             {
                 this.contextMenuCommands.Value.ExecuteDefaultCommand();
             }
-            else
+            else if (e.KeyCode != Keys.None)
             {
                 this.contextMenuCommands.Value.ExecuteCommandByKey(e.KeyCode);
             }


### PR DESCRIPTION
This fixes an issue where moving the focus to IAP Desktop by double-clicking a Project Explorer node caused the ConnectInstance command to be executed twice -- once for a KeyCode.None and once for a double-click.