### PR TITLE
b/434023421 Temporarily disable tests for signSshPublicKey

### DIFF
--- a/sources/Google.Solutions.Apis.Test/Compute/TestOsLoginClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Compute/TestOsLoginClient.cs
@@ -323,6 +323,7 @@ namespace Google.Solutions.Apis.Test.Compute
         }
 
         [Test]
+        [Ignore("b/434023421")]
         public async Task SignPublicKey_WhenUsingWorkforceSessionAndUserInRole_ThenSucceeds(
             [Credential(Type = PrincipalType.WorkforceIdentity, Role = PredefinedRole.ServiceUsageConsumer)]
             ResourceTask<IAuthorization> authorizationTask)
@@ -346,6 +347,7 @@ namespace Google.Solutions.Apis.Test.Compute
         }
 
         [Test]
+        [Ignore("b/434023421")]
         public async Task SignPublicKey_WhenUsingGaiaSession_ThenSucceeds(
             [Credential(Role = PredefinedRole.ComputeViewer)]
             ResourceTask<IAuthorization> authorizationTask)


### PR DESCRIPTION
The server-side API changed in a backwards-incompatible way. Temporarily disable the tests until the library has been updated.