### PR TITLE
b/434038856 Acknowledge read data at least once per MB

### DIFF
--- a/sources/Google.Solutions.Iap.Test/Protocol/TestEchoOverIapBase.cs
+++ b/sources/Google.Solutions.Iap.Test/Protocol/TestEchoOverIapBase.cs
@@ -45,7 +45,7 @@ namespace Google.Solutions.Iap.Test.Protocol
             }
         }
 
-        protected async Task WhenSendingMessagesToEchoServer_MessagesAreReceivedVerbatim(
+        protected async Task SendAndReceive(
             InstanceLocator locator,
             IAuthorization authorization,
             int messageSize,

--- a/sources/Google.Solutions.Iap.Test/Protocol/TestEchoOverIapDirectTunnel.cs
+++ b/sources/Google.Solutions.Iap.Test/Protocol/TestEchoOverIapDirectTunnel.cs
@@ -50,7 +50,7 @@ namespace Google.Solutions.Iap.Test.Protocol
         }
 
         [Test]
-        public async Task WhenSendingMessagesToEchoServer_MessagesAreReceivedVerbatim(
+        public async Task SendAndReceive(
             [LinuxInstance(InitializeScript = InitializeScripts.InstallEchoServer)] ResourceTask<InstanceLocator> vm,
             [Credential(Role = PredefinedRole.IapTunnelUser)] ResourceTask<IAuthorization> auth,
             [Values(
@@ -67,13 +67,29 @@ namespace Google.Solutions.Iap.Test.Protocol
                 SshRelayStream.MinReadSize * 2)] int readSize,
             [Values(1, 3)] int count)
         {
-            await WhenSendingMessagesToEchoServer_MessagesAreReceivedVerbatim(
+            await SendAndReceive(
                     await vm,
                     await auth,
                     messageSize,
                     writeSize,
                     readSize,
                     count)
+                .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task SendAndReceive_WhenReadVolumeExceedsAmountWhereAckMustBeSent(
+            [LinuxInstance(InitializeScript = InitializeScripts.InstallEchoServer)] ResourceTask<InstanceLocator> vm,
+            [Credential(Role = PredefinedRole.IapTunnelUser)] ResourceTask<IAuthorization> auth,
+            [Values(1500000, 2000000)] int size)
+        {
+            await SendAndReceive(
+                    await vm,
+                    await auth,
+                    size,
+                    SshRelayStream.MaxWriteSize,
+                    SshRelayStream.MaxWriteSize,
+                    1)
                 .ConfigureAwait(false);
         }
     }

--- a/sources/Google.Solutions.Iap.Test/Protocol/TestEchoOverIapIndirectTunnel.cs
+++ b/sources/Google.Solutions.Iap.Test/Protocol/TestEchoOverIapIndirectTunnel.cs
@@ -66,7 +66,7 @@ namespace Google.Solutions.Iap.Test.Protocol
         }
 
         [Test]
-        public async Task WhenSendingMessagesToEchoServer_MessagesAreReceivedVerbatim(
+        public async Task SendAndReceive(
             [LinuxInstance(InitializeScript = InitializeScripts.InstallEchoServer)] ResourceTask<InstanceLocator> vm,
             [Credential(Role = PredefinedRole.IapTunnelUser)] ResourceTask<IAuthorization> auth,
             [Values(
@@ -77,13 +77,29 @@ namespace Google.Solutions.Iap.Test.Protocol
                 (int)SshRelayFormat.Data.MaxPayloadLength * 2)] int messageSize,
             [Values(1, 3)] int count)
         {
-            await WhenSendingMessagesToEchoServer_MessagesAreReceivedVerbatim(
+            await SendAndReceive(
                     await vm,
                     await auth,
                     messageSize,
                     messageSize,
                     messageSize,
                     count)
+                .ConfigureAwait(false);
+        }
+
+        [Test]
+        public async Task SendAndReceive_WhenReadVolumeExceedsAmountWhereAckMustBeSent(
+            [LinuxInstance(InitializeScript = InitializeScripts.InstallEchoServer)] ResourceTask<InstanceLocator> vm,
+            [Credential(Role = PredefinedRole.IapTunnelUser)] ResourceTask<IAuthorization> auth,
+            [Values(1500000, 2000000)] int size)
+        {
+            await SendAndReceive(
+                    await vm,
+                    await auth,
+                    size,
+                    SshRelayStream.MaxWriteSize,
+                    SshRelayStream.MaxWriteSize,
+                    1)
                 .ConfigureAwait(false);
         }
     }

--- a/sources/Google.Solutions.Iap/Protocol/SshRelaySession.cs
+++ b/sources/Google.Solutions.Iap/Protocol/SshRelaySession.cs
@@ -54,6 +54,13 @@ namespace Google.Solutions.Iap.Protocol
     {
         private const uint MaxReconnects = 2;
 
+        /// <summary>
+        /// Maximum amount of data that can be read before an ACK
+        /// must be sent. The hard limit seems to be in the 1.5MB
+        /// range.
+        /// </summary>
+        internal const ulong MaxReadDataPerAck = 1024 * 1024;
+
         public ISshRelayTarget Endpoint { get; }
 
         //


### PR DESCRIPTION
When reading more than 1 MB of data without sending an acknowledgement, the server may stall further reads.

When tunneling chatty protocols such as SSH or RDP, the risk of reaching this limit are miniscule, but it can happen when tunneling SQL Server connections or performing larger HTTP downloads.

ref #1644