### PR TITLE
b/448524227 Suppress assembly resolution warning

### DIFF
--- a/sources/Google.Solutions.IapDesktop.props
+++ b/sources/Google.Solutions.IapDesktop.props
@@ -23,6 +23,11 @@
 
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+
+    <!-- suppress warnings about System.Net.Http conflict resolution -->
+    <MSBuildWarningsAsMessages>
+      $(MSBuildWarningsAsMessages);MSB3277
+    </MSBuildWarningsAsMessages>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugType>full</DebugType>

--- a/sources/Google.Solutions.Mvvm.Test/Binding/TestView.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Binding/TestView.cs
@@ -49,7 +49,7 @@ namespace Google.Solutions.Mvvm.Test.Binding
 
         private class SampleView : Form, IView<SampleViewModel>
         {
-            public SampleViewModel ViewModel { get; private set; }
+            public SampleViewModel? ViewModel { get; private set; }
 
             public void Bind(SampleViewModel viewModel, IBindingContext bindingContext)
             {

--- a/sources/Google.Solutions.Mvvm.Test/Controls/TestBindableTreeView.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Controls/TestBindableTreeView.cs
@@ -40,14 +40,14 @@ namespace Google.Solutions.Mvvm.Test.Controls
         private class ModelNode : ViewModelBase
         {
             private int imageIndex;
-            private string name;
+            private string? name;
             private bool expanded = false;
 
             public ObservableCollection<ModelNode> Children = new ObservableCollection<ModelNode>();
 
             public string Name
             {
-                get => this.name;
+                get => this.name!;
                 set
                 {
                     this.name = value;
@@ -93,8 +93,10 @@ namespace Google.Solutions.Mvvm.Test.Controls
 
         //---------------------------------------------------------------------
 
+#pragma warning disable CS8618 // Non-nullable field 
         private ModelTreeView tree;
         private Form form;
+#pragma warning restore CS8618 
 
         [SetUp]
         public void SetUp()

--- a/sources/Google.Solutions.Ssh.Test/TestSftpChannel.cs
+++ b/sources/Google.Solutions.Ssh.Test/TestSftpChannel.cs
@@ -325,7 +325,7 @@ namespace Google.Solutions.Ssh.Test
                         Assert.AreEqual(0, outputStream.Length);
 
                         Assert.Throws<NotSupportedException>(
-                            () => outputStream.Read(new byte[1], 0, 1));
+                            () => _ = outputStream.Read(new byte[1], 0, 1));
 
                         var data = Encoding.ASCII.GetBytes("'Some data'");
                         outputStream.Write(data, 1, data.Length - 2);


### PR DESCRIPTION
Suppress benign warning about System.Net.Http conflict resolution, introduced by the upgrade to the latest client libraries.