### PR TITLE
Use `gcloud storage` instead of `gsutil`

### DIFF
--- a/dependencies/image/Dockerfile
+++ b/dependencies/image/Dockerfile
@@ -147,6 +147,7 @@ RUN Add-Type -AssemblyName "System.IO.Compression.FileSystem"; `
     [Environment]::SetEnvironmentVariable(\"PATH\", $OldPath + \";${ExtractedPackage}\bin\", \"Machine\"); `
     $env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine'); `
     gcloud components install gsutil
+    #as gcloud is already installed no need to install gsutil again
 
 #
 # Install cygwin and packages

--- a/dependencies/image/Dockerfile
+++ b/dependencies/image/Dockerfile
@@ -146,8 +146,6 @@ RUN Add-Type -AssemblyName "System.IO.Compression.FileSystem"; `
     $OldPath = [Environment]::GetEnvironmentVariable(\"PATH\", \"Machine\"); `
     [Environment]::SetEnvironmentVariable(\"PATH\", $OldPath + \";${ExtractedPackage}\bin\", \"Machine\"); `
     $env:PATH = [Environment]::GetEnvironmentVariable('PATH', 'Machine'); `
-    gcloud components install gsutil
-    #as gcloud is already installed no need to install gsutil again
 
 #
 # Install cygwin and packages

--- a/dependencies/makefile
+++ b/dependencies/makefile
@@ -67,7 +67,7 @@ publish: $(PACKAGES)
     !nuget add $** -Source $(MAKEDIR)\NuGetPackages
 
 !if ( "$(KOKORO_BUILD_NUMBER)" != "" ) 
-    gsutil cp -r NuGetPackages/* gs://$(PACKAGES_BUCKET)/NuGetPackages/
+    gcloud storage cp --recursive NuGetPackages/* gs://$(PACKAGES_BUCKET)/NuGetPackages/
 !endif
 
 clean distclean: $(DIRS)


### PR DESCRIPTION
Update Dockerfile to use `gcloud storage` instead of `gsutil`.

Supersedes #1676

#gsutil-migration