### PR TITLE
b/433036592 Handle unknown instance status

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Core/ProjectModel/ProjectWorkspace.cs
+++ b/sources/Google.Solutions.IapDesktop.Core/ProjectModel/ProjectWorkspace.cs
@@ -226,7 +226,7 @@ namespace Google.Solutions.IapDesktop.Core.ProjectModel
                                 zoneLocator.Name,
                                 i.Name),
                             TraitDetector.DetectTraits(i),
-                            i.Status))
+                            i.Status ?? "UNKNOWN"))
                         .ToList();
 
                     zones.Add(new ZoneNode(


### PR DESCRIPTION
Apply a default when the GCE API fails to return
a proper instance status.