### PR TITLE
Update integration tests to work with new agent versions

### DIFF
--- a/sources/Google.Solutions.Apis.Test/Compute/TestComputeEngineClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Compute/TestComputeEngineClient.cs
@@ -275,7 +275,7 @@ namespace Google.Solutions.Apis.Test.Compute
                 var log = await stream
                     .ReadAsync(CancellationToken.None)
                     .ConfigureAwait(false);
-                if (log.Contains("Initializing Google Guest Agent"))
+                if (log.Contains(GuestAgent.SerialLogMessage))
                 {
                     return;
                 }

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/ToolWindows/SerialOutput/TestSerialOutputModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/ToolWindows/SerialOutput/TestSerialOutputModel.cs
@@ -25,6 +25,7 @@ using Google.Solutions.Apis.Compute;
 using Google.Solutions.Apis.Locator;
 using Google.Solutions.Common.Text;
 using Google.Solutions.IapDesktop.Extensions.Management.ToolWindows.SerialOutput;
+using Google.Solutions.Testing.Apis;
 using Google.Solutions.Testing.Apis.Integration;
 using Google.Solutions.Testing.Application.Test;
 using Moq;
@@ -64,7 +65,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Test.ToolWindows.Ser
 
             Assert.That(string.IsNullOrWhiteSpace(model.Output), Is.False);
             Assert.That(model.DisplayName, Is.EqualTo("display-name"));
-            Assert.That(model.Output, Does.Contain("windows-startup-script-ps1"));
+            Assert.That(model.Output, Does.Contain(GuestAgent.SerialLogMessage));
         }
 
         //---------------------------------------------------------------------

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/ToolWindows/SerialOutput/TestSerialOutputViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/ToolWindows/SerialOutput/TestSerialOutputViewModel.cs
@@ -26,6 +26,7 @@ using Google.Solutions.IapDesktop.Application.Windows;
 using Google.Solutions.IapDesktop.Core.ObjectModel;
 using Google.Solutions.IapDesktop.Core.ProjectModel;
 using Google.Solutions.IapDesktop.Extensions.Management.ToolWindows.SerialOutput;
+using Google.Solutions.Testing.Apis;
 using Google.Solutions.Testing.Apis.Integration;
 using Google.Solutions.Testing.Application.Mocks;
 using Google.Solutions.Testing.Application.Test;
@@ -199,7 +200,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Test.ToolWindows.Ser
 
             Assert.That(viewModel.IsEnableTailingButtonEnabled, Is.True);
             Assert.That(viewModel.IsOutputBoxEnabled, Is.True);
-            Assert.That(viewModel.Output, Does.Contain("Initializing Google Guest Agent"));
+            Assert.That(viewModel.Output, Does.Contain(GuestAgent.SerialLogMessage));
 
             Assert.That(viewModel.WindowTitle, Does.Contain(SerialOutputViewModel.DefaultWindowTitle));
             Assert.That(viewModel.WindowTitle, Does.Contain(instanceLocator.Name));

--- a/sources/Google.Solutions.Testing.Apis/GuestAgent.cs
+++ b/sources/Google.Solutions.Testing.Apis/GuestAgent.cs
@@ -1,0 +1,33 @@
+﻿//
+// Copyright 2026 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+
+namespace Google.Solutions.Testing.Apis
+{
+    public static class GuestAgent
+    {
+        /// <summary>
+        /// Message in serial log that the agent emits during startup.
+        /// </summary>
+        public const string SerialLogMessage =
+            "Initializing Google Guest Agent";
+    }
+}


### PR DESCRIPTION
The GCE guest agent output changed in recent versions, update tests to match new output.