### PR TITLE
b/517858664 Handle copy/paste accelerators in WM_KEYUP

### DIFF
--- a/sources/Google.Solutions.Terminal/Controls/VirtualTerminal.cs
+++ b/sources/Google.Solutions.Terminal/Controls/VirtualTerminal.cs
@@ -919,22 +919,13 @@ namespace Google.Solutions.Terminal.Controls
                             //     be delivered as two separate WM_KEYUP messages (one for
                             //     Control, one for the character).
                             //
-                            try
+                            var selection = NativeMethods.TerminalGetSelection(terminalHandle);
+                            if (!string.IsNullOrWhiteSpace(selection))
                             {
-                                var selection = NativeMethods.TerminalGetSelection(terminalHandle);
-                                if (!string.IsNullOrWhiteSpace(selection))
-                                {
-                                    ClipboardUtil.SetText(selection);
-                                }
+                                ClipboardUtil.SetText(selection);
+                            }
 
-                                NativeMethods.TerminalClearSelection(terminalHandle);
-                            }
-                            catch (ExternalException)
-                            {
-                                //
-                                // Clipboard busy, ignore.
-                                //
-                            }
+                            NativeMethods.TerminalClearSelection(terminalHandle);
 
                             //
                             // Ignore the subsequent WM_CHAR.
@@ -953,19 +944,10 @@ namespace Google.Solutions.Terminal.Controls
                             //     be delivered as two separate WM_KEYUP messages (one for
                             //     Control, one for the character).
                             //
-                            try
+                            var contents = ClipboardUtil.GetText();
+                            if (!string.IsNullOrWhiteSpace(contents))
                             {
-                                var contents = Clipboard.GetText();
-                                if (!string.IsNullOrWhiteSpace(contents))
-                                {
-                                    OnUserInput(SanitizeTextForPasting(contents));
-                                }
-                            }
-                            catch (ExternalException)
-                            {
-                                //
-                                // Clipboard busy, ignore.
-                                //
+                                OnUserInput(SanitizeTextForPasting(contents));
                             }
 
                             //

--- a/sources/Google.Solutions.Terminal/Controls/VirtualTerminal.cs
+++ b/sources/Google.Solutions.Terminal/Controls/VirtualTerminal.cs
@@ -716,7 +716,6 @@ namespace Google.Solutions.Terminal.Controls
 
         private bool terminalWindowDestructionBegun = false;
         private bool ignoreWmCharBecauseOfAccelerator = false;
-        private string? selectionToCopyInKeyUp = null;
         private WindowMessage? currentSubclassedMessage;
 
         private void TerminalSubclassWndProc(ref Message m)
@@ -911,23 +910,66 @@ namespace Google.Solutions.Terminal.Controls
                             NativeMethods.TerminalIsSelectionActive(terminalHandle))
                         {
                             //
-                            // Begin "copy" operation.
+                            // Copy selection to clipboard.
                             //
-                            // Cache the selected text so that we can process it
-                            // in WM_KEYUP.
+                            // NB. Instead of performing the operation in WM_KEYUP, we perform
+                            //     it here and then ignore the corresponding WM_KEYUP message.
+                            //     This is because depending on the order in which the user releases
+                            //     the key and modifier key, the corresponding key-up event may
+                            //     be delivered as two separate WM_KEYUP messages (one for
+                            //     Control, one for the character).
                             //
-                            // NB. We must not pass this key event to the terminal.
+                            try
+                            {
+                                var selection = NativeMethods.TerminalGetSelection(terminalHandle);
+                                if (!string.IsNullOrWhiteSpace(selection))
+                                {
+                                    ClipboardUtil.SetText(selection);
+                                }
+
+                                NativeMethods.TerminalClearSelection(terminalHandle);
+                            }
+                            catch (ExternalException)
+                            {
+                                //
+                                // Clipboard busy, ignore.
+                                //
+                            }
+
+                            //
+                            // Ignore the subsequent WM_CHAR.
                             //
                             this.ignoreWmCharBecauseOfAccelerator = true;
-                            this.selectionToCopyInKeyUp =
-                                NativeMethods.TerminalGetSelection(terminalHandle);
                         }
                         else if (IsAcceleratorForPasting((Keys)keyParams.VirtualKey))
                         {
                             //
-                            // We'll handle the paste in WM_KEYUP.
+                            // Paste clipboard contents.
                             //
-                            // NB. We must not pass this key event to the terminal.
+                            // NB. Instead of performing the operation in WM_KEYUP, we perform
+                            //     it here and then ignore the corresponding WM_KEYUP message.
+                            //     This is because depending on the order in which the user releases
+                            //     the key and modifier key, the corresponding key-up event may
+                            //     be delivered as two separate WM_KEYUP messages (one for
+                            //     Control, one for the character).
+                            //
+                            try
+                            {
+                                var contents = Clipboard.GetText();
+                                if (!string.IsNullOrWhiteSpace(contents))
+                                {
+                                    OnUserInput(SanitizeTextForPasting(contents));
+                                }
+                            }
+                            catch (ExternalException)
+                            {
+                                //
+                                // Clipboard busy, ignore.
+                                //
+                            }
+
+                            //
+                            // Ignore the subsequent WM_CHAR.
                             //
                             this.ignoreWmCharBecauseOfAccelerator = true;
                         }
@@ -965,50 +1007,8 @@ namespace Google.Solutions.Terminal.Controls
                     {
                         var keyParams = new WmKeyUpDownParams(m);
 
-                        if (IsAcceleratorForCopyingCurrentSelection((Keys)keyParams.VirtualKey) &&
-                            this.selectionToCopyInKeyUp != null)
-                        {
-                            //
-                            // Continue the "copy" operation begun in WM_KEYDOWN.
-                            //
-                            // NB. We must not pass this key event to the
-                            // terminal.
-                            //
-                            try
-                            {
-                                if (!string.IsNullOrWhiteSpace(this.selectionToCopyInKeyUp))
-                                {
-                                    ClipboardUtil.SetText(this.selectionToCopyInKeyUp);
-                                }
-                            }
-                            catch (ExternalException)
-                            {
-                                //
-                                // Clipboard busy, ignore.
-                                //
-                            }
-
-                            NativeMethods.TerminalClearSelection(terminalHandle);
-                            this.selectionToCopyInKeyUp = null;
-                        }
-                        else if (IsAcceleratorForPasting((Keys)keyParams.VirtualKey))
-                        {
-                            try
-                            {
-                                var contents = Clipboard.GetText();
-                                if (!string.IsNullOrWhiteSpace(contents))
-                                {
-                                    OnUserInput(SanitizeTextForPasting(contents));
-                                }
-                            }
-                            catch (ExternalException)
-                            {
-                                //
-                                // Clipboard busy, ignore.
-                                //
-                            }
-                        }
-                        else if (
+                        if (IsAcceleratorForCopyingCurrentSelection((Keys)keyParams.VirtualKey) ||
+                            IsAcceleratorForPasting((Keys)keyParams.VirtualKey) ||
                             IsAcceleratorForScrollingToTop((Keys)keyParams.VirtualKey) ||
                             IsAcceleratorForScrollingToBottom((Keys)keyParams.VirtualKey) ||
                             IsAcceleratorForScrollingUpOnePage((Keys)keyParams.VirtualKey) ||


### PR DESCRIPTION
Move accelerators logic from WM_KEYDOWN to WM_KEYUP, ensuring that accelerators are handled regardless of the order in which the modifier key and character key are released.