### PR TITLE
b/519863596 Fix merge-order for instance settings

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/Settings/ConnectionSettingsRepository.cs
@@ -97,7 +97,6 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.Settings
             //
             return new MergedSettingsStore(new[]
                 {
-                    CreateProjectSettingsStore(instance.Project),
                     CreateZoneSettingsStore(new ZoneLocator(instance.ProjectId, instance.Zone)),
                     new RegistrySettingsStore(key)
                 },


### PR DESCRIPTION
Remove duplicate occurance of project settings
when creating the merged settings store for an
instance