### PR TITLE
b/517847435 Handle GitHub API rate limit rate exhaustion

### DIFF
--- a/sources/Google.Solutions.Apis.Test/Client/TestRestClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Client/TestRestClient.cs
@@ -22,9 +22,11 @@
 using Google.Solutions.Apis.Client;
 using Google.Solutions.Common.Test;
 using Google.Solutions.Common.Util;
+using Google.Solutions.Testing.Apis;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,7 +37,7 @@ namespace Google.Solutions.Apis.Test.Client
     public class TestRestClient : CommonFixtureBase
     {
         private const string SampleRestUrl = "https://accounts.google.com/.well-known/openid-configuration";
-        private const string NotFoundUrl = "http://accounts.google.com/.well-known/openid-configuration";
+        private const string NotFoundUrl = "https://gstatic.com/generate_404";
         private const string NoContentUrl = "https://gstatic.com/generate_204";
         private static readonly UserAgent userAgent = new UserAgent(
             "test",
@@ -73,26 +75,16 @@ namespace Google.Solutions.Apis.Test.Client
         }
 
         [Test]
-        [Ignore("Unreliable in CI")]
         public void Get_WhenUrlReturns404()
         {
             var client = new RestClient(userAgent, null);
 
-            try
-            {
-                client.GetAsync<SampleResource>(
-                    NotFoundUrl + "-invalid",
-                    CancellationToken.None).Wait();
-
-                Assert.Fail("Expected call to fail");
-            }
-            catch (Exception e) when (e.Is<HttpRequestException>())
-            {
-            }
-            catch (Exception e)
-            {
-                Assert.Fail($"Did not expect exception of type {e.GetType()}");
-            }
+            var e = ExceptionAssert.ThrowsAggregateException<RestClientException>(
+                () => client.GetAsync<SampleResource>(
+                        NotFoundUrl,
+                        CancellationToken.None)
+                    .Wait());
+            Assert.That(e!.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
         }
     }
 }

--- a/sources/Google.Solutions.Apis.Test/Client/TestRestClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Client/TestRestClient.cs
@@ -51,7 +51,7 @@ namespace Google.Solutions.Apis.Test.Client
         [Test]
         public async Task Get_WhenUrlPointsToJson()
         {
-            var client = new RestClient(userAgent);
+            var client = new RestClient(userAgent, null);
             var result = await client.GetAsync<SampleResource>(
                     SampleRestUrl,
                     CancellationToken.None)
@@ -63,7 +63,7 @@ namespace Google.Solutions.Apis.Test.Client
         [Test]
         public async Task Get_WhenUrlPointsToNoContent()
         {
-            var client = new RestClient(userAgent);
+            var client = new RestClient(userAgent, null);
             var result = await client.GetAsync<SampleResource>(
                     NoContentUrl,
                     CancellationToken.None)
@@ -76,7 +76,7 @@ namespace Google.Solutions.Apis.Test.Client
         [Ignore("Unreliable in CI")]
         public void Get_WhenUrlReturns404()
         {
-            var client = new RestClient(userAgent);
+            var client = new RestClient(userAgent, null);
 
             try
             {

--- a/sources/Google.Solutions.Apis/Client/RestClient.cs
+++ b/sources/Google.Solutions.Apis/Client/RestClient.cs
@@ -19,6 +19,7 @@
 // under the License.
 //
 
+using Google.Apis.Auth.OAuth2;
 using Google.Solutions.Common;
 using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.Common.Util;
@@ -26,6 +27,8 @@ using Newtonsoft.Json;
 using System;
 using System.IO;
 using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -54,17 +57,25 @@ namespace Google.Solutions.Apis.Client
             this.client.Timeout = DefaultTimeout;
         }
 
-        public RestClient(UserAgent userAgent)
+        public RestClient(
+            UserAgent userAgent,
+            ClientSecrets? clientCredentials)
             : this(
                   new HttpClient(),
                   userAgent)
         {
+            this.ClientCredentials = clientCredentials;
         }
 
         /// <summary>
         /// User agent to add to HTTP requests.
         /// </summary>
         public UserAgent UserAgent { get; }
+
+        /// <summary>
+        /// Client credentials to pass as Basic authentication header.
+        /// </summary>
+        public ClientSecrets? ClientCredentials { get; }
 
         /// <summary>
         /// Perform a GET request.
@@ -77,9 +88,18 @@ namespace Google.Solutions.Apis.Client
             using (CommonTraceSource.Log.TraceMethod().WithParameters(url))
             using (var request = new HttpRequestMessage(HttpMethod.Get, url))
             {
-                if (this.UserAgent != null)
+                request.Headers.UserAgent.ParseAdd(this.UserAgent.ToString());
+
+                if (this.ClientCredentials != null)
                 {
-                    request.Headers.UserAgent.ParseAdd(this.UserAgent.ToString());
+                    request.Headers.Authorization = new AuthenticationHeaderValue(
+                        "Basic",
+                        Convert.ToBase64String(
+                            Encoding.ASCII.GetBytes(
+                                string.Join(
+                                    ":",
+                                    this.ClientCredentials.ClientId,
+                                    this.ClientCredentials.ClientSecret))));
                 }
 
                 try

--- a/sources/Google.Solutions.Apis/Client/RestClient.cs
+++ b/sources/Google.Solutions.Apis/Client/RestClient.cs
@@ -25,7 +25,9 @@ using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.Common.Util;
 using Newtonsoft.Json;
 using System;
+using System.Globalization;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -111,7 +113,12 @@ namespace Google.Solutions.Apis.Client
                             cancellationToken)
                         .ConfigureAwait(false))
                     {
-                        response.EnsureSuccessStatusCode();
+                        if (!response.IsSuccessStatusCode)
+                        {
+                            throw new RestClientException(
+                                response.StatusCode,
+                                response.ReasonPhrase);
+                        }
 
                         var stream = await response.Content
                             .ReadAsStreamAsync()
@@ -144,6 +151,18 @@ namespace Google.Solutions.Apis.Client
         public void Dispose()
         {
             this.client.Dispose();
+        }
+    }
+
+    public class RestClientException : HttpRequestException
+    {
+        public HttpStatusCode StatusCode { get; }
+
+        internal RestClientException(
+            HttpStatusCode statusCode, 
+            string message) : base(message)
+        {
+            this.StatusCode = statusCode;
         }
     }
 }

--- a/sources/Google.Solutions.Apis/Client/RestClient.cs
+++ b/sources/Google.Solutions.Apis/Client/RestClient.cs
@@ -92,7 +92,9 @@ namespace Google.Solutions.Apis.Client
             {
                 request.Headers.UserAgent.ParseAdd(this.UserAgent.ToString());
 
-                if (this.ClientCredentials != null)
+                if (this.ClientCredentials != null &&
+                    !string.IsNullOrEmpty(this.ClientCredentials.ClientId) &&
+                    !string.IsNullOrEmpty(this.ClientCredentials.ClientSecret))
                 {
                     request.Headers.Authorization = new AuthenticationHeaderValue(
                         "Basic",
@@ -117,7 +119,10 @@ namespace Google.Solutions.Apis.Client
                         {
                             throw new RestClientException(
                                 response.StatusCode,
-                                response.ReasonPhrase);
+                                response.ReasonPhrase ?? 
+                                    $"Response status code does not indicate " +
+                                    $"success: {(int)response.StatusCode} " +
+                                    $"({response.StatusCode}).");
                         }
 
                         var stream = await response.Content

--- a/sources/Google.Solutions.IapDesktop.Application/Client/ExternalRestClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Client/ExternalRestClient.cs
@@ -19,7 +19,6 @@
 // under the License.
 //
 
-using Google.Apis.Auth.OAuth2;
 using Google.Solutions.Apis.Client;
 using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.IapDesktop.Application.Host;
@@ -50,14 +49,11 @@ namespace Google.Solutions.IapDesktop.Application.Client
         // Use the same client for all connections to benefit
         // from connection pooling.
         //
-        private readonly RestClient client;
+        private readonly RestClient client = new RestClient(Install.UserAgent, null);
 
-        public ExternalRestClient(ClientSecrets? clientCredentials = null)
-        {
-            this.client = new RestClient(Install.UserAgent, clientCredentials);
-        }
-
-        public async Task<TModel?> GetAsync<TModel>(Uri url, CancellationToken cancellationToken)
+        public async Task<TModel?> GetAsync<TModel>(
+            Uri url,
+            CancellationToken cancellationToken)
             where TModel : class
         {
             using (ApplicationTraceSource.Log.TraceMethod().WithParameters(url))

--- a/sources/Google.Solutions.IapDesktop.Application/Client/ExternalRestClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Client/ExternalRestClient.cs
@@ -19,6 +19,7 @@
 // under the License.
 //
 
+using Google.Apis.Auth.OAuth2;
 using Google.Solutions.Apis.Client;
 using Google.Solutions.Common.Diagnostics;
 using Google.Solutions.IapDesktop.Application.Host;
@@ -49,7 +50,12 @@ namespace Google.Solutions.IapDesktop.Application.Client
         // Use the same client for all connections to benefit
         // from connection pooling.
         //
-        private readonly RestClient client = new RestClient(Install.UserAgent);
+        private readonly RestClient client;
+
+        public ExternalRestClient(ClientSecrets? clientCredentials = null)
+        {
+            this.client = new RestClient(Install.UserAgent, clientCredentials);
+        }
 
         public async Task<TModel?> GetAsync<TModel>(Uri url, CancellationToken cancellationToken)
             where TModel : class

--- a/sources/Google.Solutions.IapDesktop.Application/Client/GitHubRestClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Application/Client/GitHubRestClient.cs
@@ -1,0 +1,101 @@
+﻿//
+// Copyright 2026 Google LLC
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// 
+//   http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+
+using Google.Apis.Auth.OAuth2;
+using Google.Solutions.Apis.Client;
+using Google.Solutions.Common.Diagnostics;
+using Google.Solutions.IapDesktop.Application.Host;
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Google.Solutions.IapDesktop.Application.Client
+{
+    /// <summary>
+    /// Client for the GitHub API that makes unauthenticated requests
+    /// by default, and authenticated requests when receiving 
+    /// 401 or 403 errors.
+    /// </summary>
+    public class GitHubRestClient : IExternalRestClient
+    {
+        //
+        // Use the same clients for all connections to benefit
+        // from connection pooling.
+        //
+        private readonly RestClient unauthenticatedClient;
+        private readonly RestClient authenticatedClient;
+
+        public GitHubRestClient(ClientSecrets clientCredentials)
+        {
+            this.unauthenticatedClient = new RestClient(
+                Install.UserAgent, 
+                null);
+            this.authenticatedClient = new RestClient(
+                Install.UserAgent, 
+                clientCredentials);
+        }
+
+        public async Task<TModel?> GetAsync<TModel>(
+            Uri url, 
+            CancellationToken cancellationToken)
+            where TModel : class
+        {
+            try
+            {
+                //
+                // Try request without credentials.
+                //
+                // NB. By trying without credentials first, we make sure that
+                //     credential revocation can't lead to a denial of service.
+                //
+                using (ApplicationTraceSource.Log.TraceMethod().WithParameters(url))
+                {
+                    return await this.unauthenticatedClient
+                        .GetAsync<TModel>(url.ToString(), cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+            catch (RestClientException e) when (
+                e.StatusCode == HttpStatusCode.Unauthorized||
+                e.StatusCode == HttpStatusCode.Forbidden) 
+            {
+                //
+                // Retry request with credentials.
+                //
+                using (ApplicationTraceSource.Log.TraceMethod().WithParameters(
+                    url, 
+                    "authenticated"))
+                {
+                    return await this.authenticatedClient
+                        .GetAsync<TModel>(url.ToString(), cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            this.unauthenticatedClient.Dispose();
+            this.authenticatedClient.Dispose();
+        }
+    }
+}

--- a/sources/Google.Solutions.IapDesktop/OAuthClient.cs.default
+++ b/sources/Google.Solutions.IapDesktop/OAuthClient.cs.default
@@ -47,10 +47,15 @@ namespace Google.Solutions.IapDesktop
         };
 
         /// <summary>
-        /// API Key (for OS Login only).
+        /// OAuth client secrets used for the GitHub releases API to 
+        /// extend request quota.
         /// </summary>
-        internal static ApiKey ApiKey = new ApiKey("<<your-key-here>>");
-        
+        internal static readonly ClientSecrets GitHubSecrets = new ClientSecrets()
+        {
+            ClientId = "<<your-client-id-here>>",
+            ClientSecret = "<<your-client-secret-here>>"
+        };
+
         /// <summary>
         /// Repository to source updates from.
         /// </summary>

--- a/sources/Google.Solutions.IapDesktop/Program.cs
+++ b/sources/Google.Solutions.IapDesktop/Program.cs
@@ -621,7 +621,7 @@ namespace Google.Solutions.IapDesktop
                 mainLayer.AddSingleton<IOsLoginClient, OsLoginClient>();
                 mainLayer.AddSingleton<IIapClient, IapClient>();
                 mainLayer.AddSingleton<IReleaseFeed>(new GithubClient(
-                    new ExternalRestClient(),
+                    new GitHubRestClient(OAuthClient.GitHubSecrets),
                     OAuthClient.RepositoryName));
 
                 mainLayer.AddTransient<IAddressResolver, AddressResolver>();


### PR DESCRIPTION
Retry requests with authentication when the rate limit for 
unauthenticated requests is exceeded