### PR TITLE
Simplify test names

### DIFF
--- a/sources/Google.Solutions.Apis.Test/Auth/Gaia/TestGaiaOidcClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Auth/Gaia/TestGaiaOidcClient.cs
@@ -537,7 +537,7 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
         }
 
         [Test]
-        public async Task AuthorizeWithBrowser_WhenScopeNotGranted_ThenReturnsSession()
+        public async Task AuthorizeWithBrowser_WhenScopeNotGranted()
         {
             var store = new OfflineStore();
             var client = new GaiaOidcClientWithMockFlow(
@@ -577,7 +577,7 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
         }
 
         [Test]
-        public async Task AuthorizeWithBrowser_WhenTokenExchangeSucceeds_ThenReturnsSession()
+        public async Task AuthorizeWithBrowser_WhenTokenExchangeSucceeds()
         {
             var store = new OfflineStore();
             var client = new GaiaOidcClientWithMockFlow(
@@ -629,7 +629,7 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task TryAuthorizeSilently_WhenTokenExchangeFails_ThenReturnsNull()
+        public async Task TryAuthorizeSilently_WhenTokenExchangeFails()
         {
             var store = new OfflineStore()
             {
@@ -663,7 +663,7 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
         }
 
         [Test]
-        public async Task TryAuthorizeSilently_WhenTokenExchangeSucceeds_ThenReturnsSession()
+        public async Task TryAuthorizeSilently_WhenTokenExchangeSucceeds()
         {
             var store = new OfflineStore()
             {

--- a/sources/Google.Solutions.Apis.Test/Auth/Gaia/TestGaiaOidcClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Auth/Gaia/TestGaiaOidcClient.cs
@@ -211,7 +211,7 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
         }
 
         [Test]
-        public void CreateSession_WhenTokenResponseLacksIdTokenAndOfflineCredentialIsNull_ThenThrowsException()
+        public void CreateSession_WhenTokenResponseLacksIdTokenAndOfflineCredentialIsNull()
         {
             var oldIdToken = new UnverifiedGaiaJsonWebToken(
                 new Google.Apis.Auth.GoogleJsonWebSignature.Header(),
@@ -237,7 +237,7 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
         }
 
         [Test]
-        public void CreateSession_WhenTokenResponseLacksIdTokenAndOfflineCredentialContainsUnusableIdToken_ThenThrowsException()
+        public void CreateSession_WhenTokenResponseLacksIdTokenAndOfflineCredentialContainsUnusableIdToken()
         {
             var oldIdToken = new UnverifiedGaiaJsonWebToken(
                 new Google.Apis.Auth.GoogleJsonWebSignature.Header(),
@@ -269,7 +269,7 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
         }
 
         [Test]
-        public void CreateSession_WhenTokenResponseLacksIdTokenAndOfflineCredentialLacksIdToken_ThenThrowsException()
+        public void CreateSession_WhenTokenResponseLacksIdTokenAndOfflineCredentialLacksIdToken()
         {
             var tokenResponse = new TokenResponse()
             {
@@ -475,7 +475,7 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
         }
 
         [Test]
-        public async Task AuthorizeWithBrowser_WhenBrowserFlowFails_ThenThrowsException()
+        public async Task AuthorizeWithBrowser_WhenBrowserFlowFails()
         {
             var store = new OfflineStore();
             var client = new GaiaOidcClientWithMockFlow(
@@ -501,7 +501,7 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
         }
 
         [Test]
-        public async Task AuthorizeWithBrowser_WhenTokenExchangeFails_ThenThrowsException()
+        public async Task AuthorizeWithBrowser_WhenTokenExchangeFails()
         {
             var store = new OfflineStore();
             var client = new GaiaOidcClientWithMockFlow(

--- a/sources/Google.Solutions.Apis.Test/Auth/Gaia/TestGaiaOidcSession.cs
+++ b/sources/Google.Solutions.Apis.Test/Auth/Gaia/TestGaiaOidcSession.cs
@@ -81,7 +81,7 @@ namespace Google.Solutions.Apis.Test.Auth.Gaia
         //---------------------------------------------------------------------
 
         [Test]
-        public void Splice_WhenNewSessionNotCompatible_ThenThrowsException()
+        public void Splice_WhenNewSessionNotCompatible()
         {
             var idToken = new UnverifiedGaiaJsonWebToken(
                 new GoogleJsonWebSignature.Header(),

--- a/sources/Google.Solutions.Apis.Test/Auth/Iam/TestStsService.cs
+++ b/sources/Google.Solutions.Apis.Test/Auth/Iam/TestStsService.cs
@@ -37,7 +37,7 @@ namespace Google.Solutions.Apis.Test.Auth.Iam
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task IntrospectToken_WhenClientCredentialsMissing_ThenThrowsException()
+        public async Task IntrospectToken_WhenClientCredentialsMissing()
         {
             using (var service = new StsService(
                 new BaseClientService.Initializer()))
@@ -63,7 +63,7 @@ namespace Google.Solutions.Apis.Test.Auth.Iam
         }
 
         [Test]
-        public async Task IntrospectToken_WhenClientCredentialsInvalid_ThenThrowsException()
+        public async Task IntrospectToken_WhenClientCredentialsInvalid()
         {
             using (var service = new StsService(
                 new BaseClientService.Initializer()))

--- a/sources/Google.Solutions.Apis.Test/Auth/Iam/TestWorkforcePoolClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Auth/Iam/TestWorkforcePoolClient.cs
@@ -183,7 +183,7 @@ namespace Google.Solutions.Apis.Test.Auth.Iam
         }
 
         [Test]
-        public async Task Authorize_WhenTokenExchangeSucceeds_ThenReturnsSession()
+        public async Task Authorize_WhenTokenExchangeSucceeds()
         {
             var store = new OfflineStore();
             var client = new WorkforcePoolClientWithMockFlow(
@@ -237,7 +237,7 @@ namespace Google.Solutions.Apis.Test.Auth.Iam
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task TryAuthorizeSilently_WhenTokenExchangeFails_ThenReturnsNull()
+        public async Task TryAuthorizeSilently_WhenTokenExchangeFails()
         {
             var store = new OfflineStore()
             {
@@ -272,7 +272,7 @@ namespace Google.Solutions.Apis.Test.Auth.Iam
         }
 
         [Test]
-        public async Task TryAuthorizeSilently_WhenTokenExchangeSucceeds_ThenReturnsSession()
+        public async Task TryAuthorizeSilently_WhenTokenExchangeSucceeds()
         {
             var store = new OfflineStore()
             {

--- a/sources/Google.Solutions.Apis.Test/Auth/Iam/TestWorkforcePoolClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Auth/Iam/TestWorkforcePoolClient.cs
@@ -118,7 +118,7 @@ namespace Google.Solutions.Apis.Test.Auth.Iam
         }
 
         [Test]
-        public async Task Authorize_WhenBrowserFlowFails_ThenThrowsException()
+        public async Task Authorize_WhenBrowserFlowFails()
         {
             var store = new OfflineStore();
             var client = new WorkforcePoolClientWithMockFlow(
@@ -145,7 +145,7 @@ namespace Google.Solutions.Apis.Test.Auth.Iam
         }
 
         [Test]
-        public async Task Authorize_WhenTokenExchangeFails_ThenThrowsException()
+        public async Task Authorize_WhenTokenExchangeFails()
         {
             var store = new OfflineStore();
             var client = new WorkforcePoolClientWithMockFlow(

--- a/sources/Google.Solutions.Apis.Test/Auth/Iam/TestWorkforcePoolProviderLocator.cs
+++ b/sources/Google.Solutions.Apis.Test/Auth/Iam/TestWorkforcePoolProviderLocator.cs
@@ -65,7 +65,7 @@ namespace Google.Solutions.Apis.Test.Auth.Iam
         }
 
         [Test]
-        public void TryParse_WhenStringValid_ThenReturnsTrue()
+        public void TryParse_WhenStringValid()
         {
             Assert.That(WorkforcePoolProviderLocator.TryParse(
                 "locations/LOCATION/workforcePools/POOL/providers/PROVIDER",

--- a/sources/Google.Solutions.Apis.Test/Auth/Iam/TestWorkforcePoolSession.cs
+++ b/sources/Google.Solutions.Apis.Test/Auth/Iam/TestWorkforcePoolSession.cs
@@ -85,7 +85,7 @@ namespace Google.Solutions.Apis.Test.Auth.Iam
         //---------------------------------------------------------------------
 
         [Test]
-        public void Splice_WhenNewSessionNotCompatible_ThenThrowsException()
+        public void Splice_WhenNewSessionNotCompatible()
         {
             var session = new WorkforcePoolSession(
                 CreateUserCredential("rt", "at"),

--- a/sources/Google.Solutions.Apis.Test/Auth/TestLoopbackCodeReceiver.cs
+++ b/sources/Google.Solutions.Apis.Test/Auth/TestLoopbackCodeReceiver.cs
@@ -61,7 +61,7 @@ namespace Google.Solutions.Apis.Test.Auth
         }
 
         [Test]
-        public void WhenPathLacksSlash_ThenConstructorThrowsException()
+        public void WhenPathLacksSlash()
         {
             Assert.Throws<ArgumentException>(
                 () => new LoopbackCodeReceiver(

--- a/sources/Google.Solutions.Apis.Test/Auth/TestOidcClientBase.cs
+++ b/sources/Google.Solutions.Apis.Test/Auth/TestOidcClientBase.cs
@@ -91,7 +91,7 @@ namespace Google.Solutions.Apis.Test.Auth
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task TryAuthorizeSilently_WhenOfflineCredentialNotFound_ThenReturnsNull()
+        public async Task TryAuthorizeSilently_WhenOfflineCredentialNotFound()
         {
             // Empty store.
             var store = new Mock<IOidcOfflineCredentialStore>();

--- a/sources/Google.Solutions.Apis.Test/Client/TestRequestExtensions.cs
+++ b/sources/Google.Solutions.Apis.Test/Client/TestRequestExtensions.cs
@@ -81,7 +81,7 @@ namespace Google.Solutions.Apis.Test.Client
         }
 
         [Test]
-        public async Task ExecuteAndAwaitOperation_WhenOperationFailsWithErrorDetails_ThenThrowsExceptionWithReason()
+        public async Task ExecuteAndAwaitOperation_WhenOperationFailsWithErrorDetails()
         {
             var request = new Mock<IClientServiceRequest<Operation>>();
             request

--- a/sources/Google.Solutions.Apis.Test/Client/TestServiceEndpoint.cs
+++ b/sources/Google.Solutions.Apis.Test/Client/TestServiceEndpoint.cs
@@ -67,7 +67,7 @@ namespace Google.Solutions.Apis.Test.Client
         //---------------------------------------------------------------------
 
         [Test]
-        public void GetDirections__WhenMtlsEnabled_ThenReturnsMtlsEndpoint()
+        public void GetDirections__WhenMtlsEnabled()
         {
             var endpoint = new ServiceEndpoint<SampleAdapter>(
                 ServiceRoute.Public,
@@ -84,7 +84,7 @@ namespace Google.Solutions.Apis.Test.Client
         }
 
         [Test]
-        public void GetDirections_WhenMtlsEnabledButMtlsEndpointisNull_ThenReturnsTlsEndpoint()
+        public void GetDirections_WhenMtlsEnabledButMtlsEndpointisNull()
         {
             var endpoint = new ServiceEndpoint<SampleAdapter>(
                 ServiceRoute.Public,

--- a/sources/Google.Solutions.Apis.Test/Compute/TestInternalDnsName.cs
+++ b/sources/Google.Solutions.Apis.Test/Compute/TestInternalDnsName.cs
@@ -32,7 +32,7 @@ namespace Google.Solutions.Apis.Test.Compute
         //---------------------------------------------------------------------
 
         [Test]
-        public void TryParse_WhenNameIsZonal_ThenReturnsZonalName()
+        public void TryParse_WhenNameIsZonal()
         {
             var name = "instance-1.zone-1.c.project-1.internal";
             Assert.That(InternalDnsName.TryParse(name, out var parsed), Is.True);
@@ -43,7 +43,7 @@ namespace Google.Solutions.Apis.Test.Compute
         }
 
         [Test]
-        public void TryParse_WhenNameIsGlobal_ThenReturnsGlobalName()
+        public void TryParse_WhenNameIsGlobal()
         {
             var name = "instance-1.c.project-1.internal";
             Assert.That(InternalDnsName.TryParse(name, out var parsed), Is.True);

--- a/sources/Google.Solutions.Apis.Test/Compute/TestMetadataExtensions.cs
+++ b/sources/Google.Solutions.Apis.Test/Compute/TestMetadataExtensions.cs
@@ -180,14 +180,14 @@ namespace Google.Solutions.Apis.Test.Compute
         //---------------------------------------------------------------------
 
         [Test]
-        public void GetValue_WhenMetadataIsNull_ThenReturnsNull()
+        public void GetValue_WhenMetadataIsNull()
         {
             var metadata = new Metadata();
             Assert.That(metadata.GetValue("key"), Is.Null);
         }
 
         [Test]
-        public void GetValue_WhenItemNotPresent_ThenReturnsNull()
+        public void GetValue_WhenItemNotPresent()
         {
             var metadata = new Metadata()
             {
@@ -204,7 +204,7 @@ namespace Google.Solutions.Apis.Test.Compute
         }
 
         [Test]
-        public void GetValue_WhenItemPresent_ThenReturnsValue()
+        public void GetValue_WhenItemPresent()
         {
 
             var metadata = new Metadata()
@@ -227,19 +227,19 @@ namespace Google.Solutions.Apis.Test.Compute
         //---------------------------------------------------------------------
 
         [Test]
-        public void GetFlag_WhenMetadataIsNull_ThenReturnsNull()
+        public void GetFlag_WhenMetadataIsNull()
         {
             Assert.That(MetadataExtensions.GetFlag((Metadata?)null, "flag"), Is.Null);
         }
 
         [Test]
-        public void GetFlag_WhenMetadataItemsIsNull_ThenReturnsNull()
+        public void GetFlag_WhenMetadataItemsIsNull()
         {
             Assert.That(new Metadata().GetFlag("flag"), Is.Null);
         }
 
         [Test]
-        public void GetFlag_WhenValueNull_ThenReturnsNull()
+        public void GetFlag_WhenValueNull()
         {
             var metadata = new Metadata()
             {
@@ -320,7 +320,7 @@ namespace Google.Solutions.Apis.Test.Compute
         //---------------------------------------------------------------------
 
         [Test]
-        public void AsString_WhenMetadataIsEmpty_ThenReturnsEmptyList()
+        public void AsString_WhenMetadataIsEmpty()
         {
             var metadata = new Metadata();
 
@@ -328,7 +328,7 @@ namespace Google.Solutions.Apis.Test.Compute
         }
 
         [Test]
-        public void AsString_WhenMetadataContainsEntries_ThenReturnsList()
+        public void AsString_WhenMetadataContainsEntries()
         {
             var metadata = new Metadata()
             {

--- a/sources/Google.Solutions.Apis.Test/Compute/TestResourceMetadataExtensions.cs
+++ b/sources/Google.Solutions.Apis.Test/Compute/TestResourceMetadataExtensions.cs
@@ -282,7 +282,7 @@ namespace Google.Solutions.Apis.Test.Compute
         }
 
         [Test]
-        public async Task AddMetadata_WhenUpdateKeepsConflicting_ThenThrowsException()
+        public async Task AddMetadata_WhenUpdateKeepsConflicting()
         {
             var key = Guid.NewGuid().ToString();
             var projectsResource = TestProject.CreateComputeService().Projects;

--- a/sources/Google.Solutions.Apis.Test/Compute/TestResourceMetadataExtensions.cs
+++ b/sources/Google.Solutions.Apis.Test/Compute/TestResourceMetadataExtensions.cs
@@ -313,7 +313,7 @@ namespace Google.Solutions.Apis.Test.Compute
         //---------------------------------------------------------------------
 
         [Test]
-        public void GetFlag_WhenProjectMetadataIsNull_ThenGetFlagReturnsNull()
+        public void GetFlag_WhenProjectMetadataIsNull()
         {
             Assert.That(new Project().GetFlag("flag"), Is.Null);
         }
@@ -323,13 +323,13 @@ namespace Google.Solutions.Apis.Test.Compute
         //---------------------------------------------------------------------
 
         [Test]
-        public void GetFlag_WhenInstanceMetadataIsNull_ThenGetFlagReturnsNull()
+        public void GetFlag_WhenInstanceMetadataIsNull()
         {
             Assert.That(new Instance().GetFlag(new Project(), "flag"), Is.Null);
         }
 
         [Test]
-        public void GetFlag_WhenInstanceFlagTrue_ThenGetFlagReturnsTrue()
+        public void GetFlag_WhenInstanceFlagTrue()
         {
             var project = new Project();
             var instance = new Instance()
@@ -351,7 +351,7 @@ namespace Google.Solutions.Apis.Test.Compute
         }
 
         [Test]
-        public void GetFlag_WhenProjectFlagTrueAndInstanceFlagNull_ThenGetFlagReturnsTrue()
+        public void GetFlag_WhenProjectFlagTrueAndInstanceFlagNull()
         {
             var project = new Project()
             {
@@ -373,7 +373,7 @@ namespace Google.Solutions.Apis.Test.Compute
         }
 
         [Test]
-        public void GetFlag_WhenProjectFlagTrueAndInstanceFlagFalse_ThenGetFlagReturnsFalse()
+        public void GetFlag_WhenProjectFlagTrueAndInstanceFlagFalse()
         {
             var project = new Project()
             {
@@ -408,7 +408,7 @@ namespace Google.Solutions.Apis.Test.Compute
         }
 
         [Test]
-        public void GetFlag_WhenProjectFlagFalseAndInstanceFlagTrue_ThenGetFlagReturnsTrue()
+        public void GetFlag_WhenProjectFlagFalseAndInstanceFlagTrue()
         {
             var project = new Project()
             {

--- a/sources/Google.Solutions.Apis.Test/Crm/TestResourceManagerClient.cs
+++ b/sources/Google.Solutions.Apis.Test/Crm/TestResourceManagerClient.cs
@@ -300,23 +300,18 @@ namespace Google.Solutions.Apis.Test.Crm
         //---------------------------------------------------------------------
 
         [Test]
-        public void ProjectFilter_WhenTermContainsSpecialCharacters_ThenByProjectIdReturnsFilter()
+        public void ProjectFilter_WhenTermContainsSpecialCharacters()
         {
             Assert.That(
                 ProjectFilter.ByProjectId("foo:'\"-bar").ToString(),
                 Is.EqualTo("id:\"foo-bar\""));
-        }
-
-        [Test]
-        public void ProjectFilter_WhenTermContainsSpecialCharacters_ThenByTermReturnsFilter()
-        {
             Assert.That(
                 ProjectFilter.ByTerm("foo:'\"-bar").ToString(),
                 Is.EqualTo("name:\"*foo-bar*\" OR id:\"*foo-bar*\""));
         }
 
         [Test]
-        public void ProjectFilter_WhenTermEmpty_ThenByTermReturnsFilter()
+        public void ProjectFilter_WhenTermEmpty()
         {
             Assert.That(
                 ProjectFilter.ByTerm(string.Empty).ToString(),

--- a/sources/Google.Solutions.Apis.Test/Locator/TestAccessLevelLocator.cs
+++ b/sources/Google.Solutions.Apis.Test/Locator/TestAccessLevelLocator.cs
@@ -94,7 +94,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenObjectsNotEquivalent_ThenEqualsReturnsFalse()
+        public void Equals_WhenObjectsNotEquivalent()
         {
             var ref1 = new AccessLevelLocator("proj-1", "level-1");
             var ref2 = new AccessLevelLocator("proj-2", "level-1");
@@ -110,7 +110,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToString_WhenCreatedFromPath_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromPath()
         {
             var path = "accessPolicies/policy-1/accessLevels/level-1";
 

--- a/sources/Google.Solutions.Apis.Test/Locator/TestDiskTypeLocator.cs
+++ b/sources/Google.Solutions.Apis.Test/Locator/TestDiskTypeLocator.cs
@@ -206,7 +206,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenObjectsNotEquivalent_ThenEqualsReturnsFalse()
+        public void Equals_WhenObjectsNotEquivalent()
         {
             var ref1 = new DiskTypeLocator("proj", "zone1", "pd-standard");
             var ref2 = new DiskTypeLocator("proj", "zone2", "pd-standard");
@@ -222,7 +222,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToString_WhenCreatedFromPath_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromPath()
         {
             var path = "projects/project-1/zones/us-central1-a/diskTypes/pd-standard";
 
@@ -231,7 +231,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void ToString_WhenCreatedFromUrl_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromUrl()
         {
             var path = "projects/project-1/zones/us-central1-a/diskTypes/pd-standard";
 

--- a/sources/Google.Solutions.Apis.Test/Locator/TestImageLocator.cs
+++ b/sources/Google.Solutions.Apis.Test/Locator/TestImageLocator.cs
@@ -214,7 +214,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenObjectsNotEquivalent_ThenEqualsReturnsFalse()
+        public void Equals_WhenObjectsNotEquivalent()
         {
             var ref1 = new ImageLocator("proj-1", "image-1");
             var ref2 = new ImageLocator("proj-2", "image-1");
@@ -230,7 +230,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToString_WhenCreatedFromPath_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromPath()
         {
             var path = "projects/project-1/global/images/image-1";
 
@@ -239,7 +239,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void ToString_WhenCreatedFromUrl_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromUrl()
         {
             var path = "projects/project-1/global/images/image-1";
 

--- a/sources/Google.Solutions.Apis.Test/Locator/TestInstanceLocator.cs
+++ b/sources/Google.Solutions.Apis.Test/Locator/TestInstanceLocator.cs
@@ -206,7 +206,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToString_WhenCreatedFromPath_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromPath()
         {
             var path = "projects/project-1/zones/us-central-1/instances/instance-1";
 
@@ -215,7 +215,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void ToString_WhenCreatedFromUrl_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromUrl()
         {
             var path = "projects/project-1/zones/us-central-1/instances/instance-1";
 
@@ -230,7 +230,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenObjectsNotEquivalent_ThenEqualsReturnsFalse()
+        public void Equals_WhenObjectsNotEquivalent()
         {
             var ref1 = new InstanceLocator("proj", "zone", "inst");
             var ref2 = new InstanceLocator("proj", "zone", "other");
@@ -242,7 +242,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void Equals_WhenReferencesAreOfDifferentType_ThenEqualsReturnsFalse()
+        public void Equals_WhenReferencesAreOfDifferentType()
         {
             var ref1 = new InstanceLocator("proj", "zone", "inst");
             var ref2 = new InstanceLocator("proj", "zone", "instance-1");

--- a/sources/Google.Solutions.Apis.Test/Locator/TestLicenseLocator.cs
+++ b/sources/Google.Solutions.Apis.Test/Locator/TestLicenseLocator.cs
@@ -175,7 +175,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenObjectsNotEquivalent_ThenEqualsReturnsFalse()
+        public void Equals_WhenObjectsNotEquivalent()
         {
             var ref1 = new LicenseLocator("proj-1", "windows-10-enterprise-byol");
             var ref2 = new LicenseLocator("proj-2", "windows-10-enterprise-byol");
@@ -191,7 +191,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToString_WhenCreatedFromPath_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromPath()
         {
             var path = "projects/project-1/global/licenses/windows-10-enterprise-byol";
 
@@ -200,7 +200,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void ToString_WhenCreatedFromUrl_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromUrl()
         {
             var path = "projects/project-1/global/licenses/windows-10-enterprise-byol";
 
@@ -215,7 +215,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsWindowsLicense_WhenLicenseIsFromWindowsCloud_ThenIsWindowsLicenseReturnsTrue()
+        public void IsWindowsLicense_WhenLicenseIsFromWindowsCloud()
         {
             var locator = LicenseLocator.Parse(
                 "https://www.googleapis.com/compute/v1/projects/windows-cloud/global/licenses/windows-10-enterprise-byol");
@@ -223,7 +223,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void IsWindowsLicense_WhenLicenseIsNotFromWindowsCloud_ThenIsWindowsLicenseReturnsFalse()
+        public void IsWindowsLicense_WhenLicenseIsNotFromWindowsCloud()
         {
             var locator = LicenseLocator.Parse(
                 "projects/my-project/global/licenses/windows-10-enterprise-byol");
@@ -231,7 +231,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void IsWindowsLicense_WhenLicenseHasByolSuffix_ThenIsWindowsByolLicenseReturnsTrue()
+        public void IsWindowsLicense_WhenLicenseHasByolSuffix()
         {
             var locator = LicenseLocator.Parse(
                 "https://www.googleapis.com/compute/v1/projects/windows-cloud/global/licenses/windows-10-enterprise-byol");
@@ -239,7 +239,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void IsWindowsLicense_WhenLicenseHasNoByolSuffix_ThenIsWindowsByolLicenseReturnsFalse()
+        public void IsWindowsLicense_WhenLicenseHasNoByolSuffix()
         {
             var locator = LicenseLocator.Parse(
                 "projects/windows-cloud/global/licenses/windows-2016");

--- a/sources/Google.Solutions.Apis.Test/Locator/TestMachineTypeLocator.cs
+++ b/sources/Google.Solutions.Apis.Test/Locator/TestMachineTypeLocator.cs
@@ -206,7 +206,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenObjectsNotEquivalent_ThenEqualsReturnsFalse()
+        public void Equals_WhenObjectsNotEquivalent()
         {
             var ref1 = new MachineTypeLocator("proj", "zone1", "n2d-standard-64");
             var ref2 = new MachineTypeLocator("proj", "zone2", "n2d-standard-64");
@@ -222,7 +222,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToString_WhenCreatedFromPath_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromPath()
         {
             var path = "projects/project-1/zones/us-central1-a/machineTypes/n2d-standard-64";
 
@@ -231,7 +231,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void ToString_WhenCreatedFromUrl_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromUrl()
         {
             var path = "projects/project-1/zones/us-central1-a/machineTypes/n2d-standard-64";
 

--- a/sources/Google.Solutions.Apis.Test/Locator/TestNodeTypeLocator.cs
+++ b/sources/Google.Solutions.Apis.Test/Locator/TestNodeTypeLocator.cs
@@ -206,7 +206,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenObjectsNotEquivalent_ThenEqualsReturnsFalse()
+        public void Equals_WhenObjectsNotEquivalent()
         {
             var ref1 = new NodeTypeLocator("proj", "zone1", "c2-node-60-240");
             var ref2 = new NodeTypeLocator("proj", "zone2", "c2-node-60-240");
@@ -222,7 +222,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToString_WhenCreatedFromPath_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromPath()
         {
             var path = "projects/project-1/zones/us-central1-a/nodeTypes/c2-node-60-240";
 
@@ -231,7 +231,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void ToString_WhenCreatedFromUrl_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromUrl()
         {
             var path = "projects/project-1/zones/us-central1-a/nodeTypes/c2-node-60-240";
 

--- a/sources/Google.Solutions.Apis.Test/Locator/TestOrganizationLocator.cs
+++ b/sources/Google.Solutions.Apis.Test/Locator/TestOrganizationLocator.cs
@@ -67,7 +67,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToString_WhenCreatedFromPath_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromPath()
         {
             var path = "organizations/12345678900001";
             Assert.That(OrganizationLocator.TryParse(path, out var locator), Is.True);

--- a/sources/Google.Solutions.Apis.Test/Locator/TestProjectLocator.cs
+++ b/sources/Google.Solutions.Apis.Test/Locator/TestProjectLocator.cs
@@ -164,7 +164,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenObjectsNotEquivalent_ThenEqualsReturnsFalse()
+        public void Equals_WhenObjectsNotEquivalent()
         {
             var ref1 = new ProjectLocator("proj-1");
             var ref2 = new ProjectLocator("proj-2");
@@ -180,7 +180,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToString_WhenCreatedFromPath_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromPath()
         {
             var path = "projects/project-1";
 
@@ -189,7 +189,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void ToString_WhenCreatedFromUrl_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromUrl()
         {
             var path = "projects/project-1";
 

--- a/sources/Google.Solutions.Apis.Test/Locator/TestRegionLocator.cs
+++ b/sources/Google.Solutions.Apis.Test/Locator/TestRegionLocator.cs
@@ -168,7 +168,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenObjectsNotEquivalent_ThenEqualsReturnsFalse()
+        public void Equals_WhenObjectsNotEquivalent()
         {
             var ref1 = new RegionLocator("proj-1", "us-central1");
             var ref2 = new RegionLocator("proj-2", "us-central1");
@@ -184,7 +184,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToString_WhenCreatedFromPath_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromPath()
         {
             var path = "projects/project-1/regions/us-central1";
 
@@ -193,7 +193,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void ToString_WhenCreatedFromUrl_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromUrl()
         {
             var path = "projects/project-1/regions/us-central1";
 

--- a/sources/Google.Solutions.Apis.Test/Locator/TestZoneLocator.cs
+++ b/sources/Google.Solutions.Apis.Test/Locator/TestZoneLocator.cs
@@ -176,7 +176,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenObjectsNotEquivalent_ThenEqualsReturnsFalse()
+        public void Equals_WhenObjectsNotEquivalent()
         {
             var ref1 = new ZoneLocator("proj-1", "us-central1-a");
             var ref2 = new ZoneLocator("proj-2", "us-central1-a");
@@ -192,7 +192,7 @@ namespace Google.Solutions.Apis.Test.Locator
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToString_WhenCreatedFromPath_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromPath()
         {
             var path = "projects/project-1/zones/us-central1-a";
 
@@ -201,7 +201,7 @@ namespace Google.Solutions.Apis.Test.Locator
         }
 
         [Test]
-        public void ToString_WhenCreatedFromUrl_ThenToStringReturnsPath()
+        public void ToString_WhenCreatedFromUrl()
         {
             var path = "projects/project-1/zones/us-central1-a";
 

--- a/sources/Google.Solutions.Common.Test/Diagnostics/TestDumpObjectExtensions.cs
+++ b/sources/Google.Solutions.Common.Test/Diagnostics/TestDumpObjectExtensions.cs
@@ -28,13 +28,13 @@ namespace Google.Solutions.Common.Test.Diagnostics
     public class TestDumpObjectExtensions
     {
         [Test]
-        public void DumpProperties_WhenObjectIsNull_ThenReturnsEmptyString()
+        public void DumpProperties_WhenObjectIsNull()
         {
             Assert.That(((object?)null).DumpProperties(), Is.EqualTo(string.Empty));
         }
 
         [Test]
-        public void DumpProperties_WhenObjectIsNotNull_ThenReturnsString()
+        public void DumpProperties_WhenObjectIsNotNull()
         {
             Assert.That(
                 new {

--- a/sources/Google.Solutions.Common.Test/Linq/TestDictionaryExtensions.cs
+++ b/sources/Google.Solutions.Common.Test/Linq/TestDictionaryExtensions.cs
@@ -33,7 +33,7 @@ namespace Google.Solutions.Common.Test.Linq
         //---------------------------------------------------------------------
 
         [Test]
-        public void WhenKeyFound_ThenTryGetReturnsValue()
+        public void WhenKeyFound()
         {
             var dict = new Dictionary<string, string>()
             {
@@ -43,7 +43,7 @@ namespace Google.Solutions.Common.Test.Linq
         }
 
         [Test]
-        public void WhenKeyNotFound_ThenTryGetReturnsNull()
+        public void WhenKeyNotFound()
         {
             var dict = new Dictionary<string, string>();
             Assert.That(dict.TryGet("key"), Is.Null);

--- a/sources/Google.Solutions.Common.Test/Linq/TestEnumerableExtensions.cs
+++ b/sources/Google.Solutions.Common.Test/Linq/TestEnumerableExtensions.cs
@@ -77,7 +77,7 @@ namespace Google.Solutions.Common.Test.Linq
         //---------------------------------------------------------------------
 
         [Test]
-        public void Chunk_WhenListSmallerThanChunk_ThenChunkReturnsSingleList()
+        public void Chunk_WhenListSmallerThanChunk()
         {
             var list = new[] { "a", "b", "c" };
             var chunks = list.Chunk(4);
@@ -87,7 +87,7 @@ namespace Google.Solutions.Common.Test.Linq
         }
 
         [Test]
-        public void Chunk_WhenListFillsTwoChunks_ThenChunkReturnsTwoLists()
+        public void Chunk_WhenListFillsTwoChunks()
         {
             var list = new[] { "a", "b", "c", "d" };
             var chunks = list.Chunk(2);
@@ -98,7 +98,7 @@ namespace Google.Solutions.Common.Test.Linq
         }
 
         [Test]
-        public void Chunk_WhenListLargerThanSingleChunk_ThenChunkReturnsTwoLists()
+        public void Chunk_WhenListLargerThanSingleChunk()
         {
             var list = new[] { "a", "b", "c" };
             var chunks = list.Chunk(2);
@@ -113,7 +113,7 @@ namespace Google.Solutions.Common.Test.Linq
         //---------------------------------------------------------------------
 
         [Test]
-        public void ConcatItem_WhenEnumEmpty_ThenConcatItemReturnsSingleItem()
+        public void ConcatItem_WhenEnumEmpty()
         {
             var e = Enumerable.Empty<string>()
                 .ConcatItem("test");

--- a/sources/Google.Solutions.Common.Test/Runtime/TestReferenceCountedDisposableBase.cs
+++ b/sources/Google.Solutions.Common.Test/Runtime/TestReferenceCountedDisposableBase.cs
@@ -62,7 +62,7 @@ namespace Google.Solutions.Common.Test.Runtime
         //---------------------------------------------------------------------
 
         [Test]
-        public void Dispose_WhenDisposedTwice_ThenDisposeThrowsException()
+        public void Dispose_WhenDisposedTwice()
         {
             var d = new SampleDisposable();
             d.Dispose();

--- a/sources/Google.Solutions.Common.Test/Text/TestStringExtensions.cs
+++ b/sources/Google.Solutions.Common.Test/Text/TestStringExtensions.cs
@@ -32,14 +32,14 @@ namespace Google.Solutions.Common.Test.Text
         //---------------------------------------------------------------------
 
         [Test]
-        public void IndexOf_WhenTextContainsChar_ThenIndexOfReturnsFirstIndex()
+        public void IndexOf_WhenTextContainsChar()
         {
             var text = "a a a";
             Assert.That(text.IndexOf(c => char.IsWhiteSpace(c)), Is.EqualTo(1));
         }
 
         [Test]
-        public void IndexOf_WhenTextDoesNotContainChar_ThenIndexOfReturnsMinusOne()
+        public void IndexOf_WhenTextDoesNotContainChar()
         {
             var text = "a a a";
             Assert.That(text.IndexOf(c => char.IsDigit(c)), Is.EqualTo(-1));
@@ -50,14 +50,14 @@ namespace Google.Solutions.Common.Test.Text
         //---------------------------------------------------------------------
 
         [Test]
-        public void LastIndexOf_WhenTextContainsChar_ThenLastIndexOfReturnsLastIndex()
+        public void LastIndexOf_WhenTextContainsChar()
         {
             var text = "a a a";
             Assert.That(text.LastIndexOf(c => char.IsWhiteSpace(c)), Is.EqualTo(3));
         }
 
         [Test]
-        public void LastIndexOf_WhenTextDoesNotContainChar_ThenLastIndexOfReturnsMinusOne()
+        public void LastIndexOf_WhenTextDoesNotContainChar()
         {
             var text = "a a a";
             Assert.That(text.LastIndexOf(c => char.IsDigit(c)), Is.EqualTo(-1));
@@ -68,14 +68,14 @@ namespace Google.Solutions.Common.Test.Text
         //---------------------------------------------------------------------
 
         [Test]
-        public void Truncate_WhenStringShortEnough_ThenTruncateReturnsStringVerbatim()
+        public void Truncate_WhenStringShortEnough()
         {
             Assert.That("".Truncate(3), Is.EqualTo(""));
             Assert.That("foo".Truncate(3), Is.EqualTo("foo"));
         }
 
         [Test]
-        public void Truncate_WhenStringTooLong_ThenTruncateReturnsStringWithEllipsis()
+        public void Truncate_WhenStringTooLong()
         {
             Assert.That("abcd".Truncate(3), Is.EqualTo("abc..."));
         }
@@ -85,21 +85,21 @@ namespace Google.Solutions.Common.Test.Text
         //---------------------------------------------------------------------
 
         [Test]
-        public void NullIfEmpty_WhenStringIsNull_ThenNullIfEmptyReturnsNull()
+        public void NullIfEmpty_WhenStringIsNull()
         {
             string? s = null;
             Assert.That(s.NullIfEmpty(), Is.Null);
         }
 
         [Test]
-        public void NullIfEmpty_WhenStringIsEmpty_ThenNullIfEmptyReturnsNull()
+        public void NullIfEmpty_WhenStringIsEmpty()
         {
             var s = string.Empty;
             Assert.That(s.NullIfEmpty(), Is.Null);
         }
 
         [Test]
-        public void NullIfEmpty_WhenStringIsWhitespace_ThenNullIfEmptyReturnsString()
+        public void NullIfEmpty_WhenStringIsWhitespace()
         {
             var s = " ";
             Assert.That(s.NullIfEmpty(), Is.EqualTo(" "));
@@ -110,28 +110,28 @@ namespace Google.Solutions.Common.Test.Text
         //---------------------------------------------------------------------
 
         [Test]
-        public void NullIfEmptyOrWhitespace_WhenStringIsNull_ThenNullIfEmptyOrWhitespaceReturnsNull()
+        public void NullIfEmptyOrWhitespace_WhenStringIsNull()
         {
             string? s = null;
             Assert.That(s.NullIfEmptyOrWhitespace(), Is.Null);
         }
 
         [Test]
-        public void NullIfEmptyOrWhitespace_WhenStringIsEmpty_ThenNullIfEmptyOrWhitespaceReturnsNull()
+        public void NullIfEmptyOrWhitespace_WhenStringIsEmpty()
         {
             var s = string.Empty;
             Assert.That(s.NullIfEmptyOrWhitespace(), Is.Null);
         }
 
         [Test]
-        public void NullIfEmptyOrWhitespace_WhenStringIsWhitespace_ThenNullIfEmptyOrWhitespaceReturnsNull()
+        public void NullIfEmptyOrWhitespace_WhenStringIsWhitespace()
         {
             var s = " ";
             Assert.That(s.NullIfEmptyOrWhitespace(), Is.Null);
         }
 
         [Test]
-        public void NullIfEmptyOrWhitespace_WhenStringIsNotWhitespace_ThenNullIfEmptyOrWhitespaceReturnsString()
+        public void NullIfEmptyOrWhitespace_WhenStringIsNotWhitespace()
         {
             var s = " a ";
             Assert.That(s.NullIfEmptyOrWhitespace(), Is.EqualTo(" a "));

--- a/sources/Google.Solutions.Common.Test/Text/TestTypographicQuotes.cs
+++ b/sources/Google.Solutions.Common.Test/Text/TestTypographicQuotes.cs
@@ -28,14 +28,14 @@ namespace Google.Solutions.Common.Test.Text
     public class TestTypographicQuotes
     {
         [Test]
-        public void ToAsciiQuotes_WhenStringContainsNoTypograhicQuotes_ThenToAsciiQuotesReturnsSameString()
+        public void ToAsciiQuotes_WhenStringContainsNoTypograhicQuotes()
         {
             var s = "This isn't \"typographic\" but `plain´ ASCII";
             Assert.That(TypographicQuotes.ToAsciiQuotes(s), Is.EqualTo(s));
         }
 
         [Test]
-        public void ToAsciiQuotes_WhenStringContainsTypograhicDoubleQuotes_ThenToAsciiQuotesReturnsSanitizedString()
+        public void ToAsciiQuotes_WhenStringContainsTypograhicDoubleQuotes()
         {
             var s = "These are \u201CEnglish\u201d, \u201eGerman\u201c, and \u00bbFrench\u00ab double quotes";
             Assert.That(
@@ -43,7 +43,7 @@ namespace Google.Solutions.Common.Test.Text
         }
 
         [Test]
-        public void ToAsciiQuotes_WhenStringContainsTypograhicSingleQuotes_ThenToAsciiQuotesReturnsSanitizedString()
+        public void ToAsciiQuotes_WhenStringContainsTypograhicSingleQuotes()
         {
             var s = "These are \u2018English\u2019, \u201aGerman\u2018, and \u203aFrench\u2039 single quotes";
             Assert.That(

--- a/sources/Google.Solutions.Common.Test/Threading/TestRundownProtection.cs
+++ b/sources/Google.Solutions.Common.Test/Threading/TestRundownProtection.cs
@@ -29,7 +29,7 @@ namespace Google.Solutions.Common.Test.Threading
     public class TestRundownProtection
     {
         [Test]
-        public async Task Await_WhenRundown_ThenAwaitRundownReturns()
+        public async Task Await_WhenRundown()
         {
             using (var protection = new RundownProtection())
             {

--- a/sources/Google.Solutions.Common.Test/Util/TestDateTimeOffsetExtensions.cs
+++ b/sources/Google.Solutions.Common.Test/Util/TestDateTimeOffsetExtensions.cs
@@ -29,21 +29,21 @@ namespace Google.Solutions.Common.Test.Util
     public class TestDateTimeOffsetExtensions : CommonFixtureBase
     {
         [Test]
-        public void ToUnixTimeMicroseconds_WhenTimestampIsEpoch_ThenToUnixTimeMicrosecondsReturnsZero()
+        public void ToUnixTimeMicroseconds_WhenTimestampIsEpoch()
         {
             var epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
             Assert.That(epoch.ToUnixTimeMicroseconds(), Is.Zero);
         }
 
         [Test]
-        public void ToUnixTimeMicroseconds_WhenTimestampIsZero_ThenFromUnixTimeMicrosecondsReturnsEpoch()
+        public void ToUnixTimeMicroseconds_WhenTimestampIsZero()
         {
             var epoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
             Assert.That(DateTimeOffsetExtensions.FromUnixTimeMicroseconds(0), Is.EqualTo(epoch));
         }
 
         [Test]
-        public void ToUnixTimeMicroseconds_WhenTimestampIsValid_ThenToUnixTimeMicrosecondsReturnsValue()
+        public void ToUnixTimeMicroseconds_WhenTimestampIsValid()
         {
             var firstOfJan = new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero);
 

--- a/sources/Google.Solutions.Common.Test/Util/TestEnumExtensions.cs
+++ b/sources/Google.Solutions.Common.Test/Util/TestEnumExtensions.cs
@@ -42,7 +42,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void IsSingleFlag_WhenZero_ThenIsSingleFlagReturnsFalse()
+        public void IsSingleFlag_WhenZero()
         {
             var e = SampleFlags.Zero;
             Assert.That(e.IsSingleFlag(), Is.False);
@@ -50,7 +50,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void IsSingleFlag_WhenOneFlagSet_ThenIsSingleFlagReturnsTrue()
+        public void IsSingleFlag_WhenOneFlagSet()
         {
             var e = SampleFlags.Four;
             Assert.That(e.IsSingleFlag(), Is.True);
@@ -58,7 +58,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void IsSingleFlag_WhenTwoFlagsSet_ThenIsSingleFlagReturnsFalse()
+        public void IsSingleFlag_WhenTwoFlagsSet()
         {
             var e = SampleFlags.One | SampleFlags.Four;
             Assert.That(e.IsSingleFlag(), Is.False);
@@ -70,25 +70,25 @@ namespace Google.Solutions.Common.Test.Util
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsValidFlagCombination_WhenAllFlagsClear_ThenIsValidFlagCombinationReturnsTrue()
+        public void IsValidFlagCombination_WhenAllFlagsClear()
         {
             Assert.That(SampleFlags.Zero.IsValidFlagCombination(), Is.True);
         }
 
         [Test]
-        public void IsValidFlagCombination_WhenOneFlagSet_ThenIsValidFlagCombinationReturnsTrue()
+        public void IsValidFlagCombination_WhenOneFlagSet()
         {
             Assert.That(SampleFlags.One.IsValidFlagCombination(), Is.True);
         }
 
         [Test]
-        public void IsValidFlagCombination_WhenMultipleFlagsSet_ThenIsValidFlagCombinationReturnsTrue()
+        public void IsValidFlagCombination_WhenMultipleFlagsSet()
         {
             Assert.That((SampleFlags.One | SampleFlags.Four).IsValidFlagCombination(), Is.True);
         }
 
         [Test]
-        public void IsValidFlagCombination_WhenNonexistingFlagSet_ThenIsValidFlagCombinationReturnsFalse()
+        public void IsValidFlagCombination_WhenNonexistingFlagSet()
         {
             Assert.That((SampleFlags.One | (SampleFlags)16).IsValidFlagCombination(), Is.False);
         }
@@ -106,7 +106,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void GetAttribute_WhenValueHasAttribute_ThenGetAttributeReturnsValue()
+        public void GetAttribute_WhenValueHasAttribute()
         {
             var a = SampleEnumWithAttributes.WithAttribute
                 .GetAttribute<System.ComponentModel.DescriptionAttribute>();
@@ -115,7 +115,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void GetAttribute_WhenValueHasNoAttribute_ThenGetAttributeReturnsNull()
+        public void GetAttribute_WhenValueHasNoAttribute()
         {
             var a = SampleEnumWithAttributes.NoAttribute
                 .GetAttribute<System.ComponentModel.DescriptionAttribute>();

--- a/sources/Google.Solutions.Common.Test/Util/TestExceptionExtensions.cs
+++ b/sources/Google.Solutions.Common.Test/Util/TestExceptionExtensions.cs
@@ -57,7 +57,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void Unwrap_WhenAggregateException_ThenUnwrapReturnsFirstInnerException()
+        public void Unwrap_WhenAggregateException()
         {
             var inner1 = new ApplicationException();
             var inner2 = new ApplicationException();
@@ -69,7 +69,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void Unwrap_WhenAggregateExceptionContainsAggregateException_ThenUnwrapReturnsFirstInnerException()
+        public void Unwrap_WhenAggregateExceptionContainsAggregateException()
         {
             var inner1 = new ApplicationException();
             var inner2 = new ApplicationException();
@@ -92,7 +92,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void Unwrap_WhenTargetInvocationException_ThenUnwrapReturnsInnerException()
+        public void Unwrap_WhenTargetInvocationException()
         {
             var inner = new ApplicationException();
             var target = new TargetInvocationException("", inner);

--- a/sources/Google.Solutions.Common.Test/Util/TestInvariant.cs
+++ b/sources/Google.Solutions.Common.Test/Util/TestInvariant.cs
@@ -33,7 +33,7 @@ namespace Google.Solutions.Common.Test.Util
         //---------------------------------------------------------------------
 
         [Test]
-        public void ExpectNotNull_WhenNull_ThenExpectNotNullThrowsException()
+        public void ExpectNotNull_WhenNull()
         {
             Assert.Throws<ArgumentNullException>(
                 () => Invariant.ExpectNotNull<string>(null, "variable"));

--- a/sources/Google.Solutions.Common.Test/Util/TestInvariant.cs
+++ b/sources/Google.Solutions.Common.Test/Util/TestInvariant.cs
@@ -40,7 +40,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void ExpectNotNull_WhenNotNull_ThenExpectNotNullReturnsValue()
+        public void ExpectNotNull_WhenNotNull()
         {
             Assert.That(Invariant.ExpectNotNull("value", "test"), Is.EqualTo("value"));
 

--- a/sources/Google.Solutions.Common.Test/Util/TestPrecondition.cs
+++ b/sources/Google.Solutions.Common.Test/Util/TestPrecondition.cs
@@ -40,7 +40,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void ExpectNotNull_WhenNotNull_ThenExpectNotNullReturnsValue()
+        public void ExpectNotNull_WhenNotNull()
         {
             Assert.That("value".ExpectNotNull("test"), Is.EqualTo("value"));
 
@@ -62,7 +62,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void ExpectNotEmpty_WhenNotEmpty_ThenExpectNotNullReturnsValue()
+        public void ExpectNotEmpty_WhenNotEmpty()
         {
             Assert.That("value".ExpectNotEmpty("test"), Is.EqualTo("value"));
         }
@@ -81,7 +81,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void ExpectNotNullOrZeroSized_WhenNotEmpty_ThenExpectNotNullOrZeroSizedReturnsValue()
+        public void ExpectNotNullOrZeroSized_WhenNotEmpty()
         {
             var array = new[] { 1, 2, 3 };
             Assert.That(array.ExpectNotNullOrZeroSized("test"), Is.SameAs(array));
@@ -99,7 +99,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void Expect_WhenConditionTrue_ThenExpectReturns()
+        public void Expect_WhenConditionTrue()
         {
             Precondition.Expect(true, "");
             Precondition.Expect(true, "");
@@ -119,7 +119,7 @@ namespace Google.Solutions.Common.Test.Util
         }
 
         [Test]
-        public void ExpectInRange_WhenInRange_ThenExpectInRangeReturnsValue()
+        public void ExpectInRange_WhenInRange()
         {
             Assert.That((0f).ExpectInRange(-1f, 1f, "range"), Is.Zero);
             Assert.That((1f).ExpectInRange(-1f, 1f, "range"), Is.EqualTo(1f));

--- a/sources/Google.Solutions.Common.Test/Util/TestPrecondition.cs
+++ b/sources/Google.Solutions.Common.Test/Util/TestPrecondition.cs
@@ -33,7 +33,7 @@ namespace Google.Solutions.Common.Test.Util
         //---------------------------------------------------------------------
 
         [Test]
-        public void ExpectNotNull_WhenNull_ThenExpectNotNullThrowsException()
+        public void ExpectNotNull_WhenNull()
         {
             Assert.Throws<ArgumentNullException>(
                 () => ((string?)null).ExpectNotNull("test"));
@@ -53,7 +53,7 @@ namespace Google.Solutions.Common.Test.Util
         //---------------------------------------------------------------------
 
         [Test]
-        public void ExpectNotEmpty_WhenNullOrEmpty_ThenExpectNotEmptyThrowsException()
+        public void ExpectNotEmpty_WhenNullOrEmpty()
         {
             Assert.Throws<ArgumentNullException>(
                 () => ((string?)null).ExpectNotEmpty("test"));
@@ -72,7 +72,7 @@ namespace Google.Solutions.Common.Test.Util
         //---------------------------------------------------------------------
 
         [Test]
-        public void ExpectNotNullOrZeroSized_WhenNullOrEmpty_ThenExpectNotNullOrZeroSizedThrowsException()
+        public void ExpectNotNullOrZeroSized_WhenNullOrEmpty()
         {
             Assert.Throws<ArgumentNullException>(
                 () => Precondition.ExpectNotNullOrZeroSized((string[]?)null, "test"));
@@ -92,7 +92,7 @@ namespace Google.Solutions.Common.Test.Util
         //---------------------------------------------------------------------
 
         [Test]
-        public void Expect_WhenConditionFalse_ThenExpectThrowsException()
+        public void Expect_WhenConditionFalse()
         {
             Assert.Throws<ArgumentException>(
                 () => Precondition.Expect(false, "test"));
@@ -110,7 +110,7 @@ namespace Google.Solutions.Common.Test.Util
         //---------------------------------------------------------------------
 
         [Test]
-        public void ExpectInRange_WhenOutOfRange_ThenExpectInRangeThrowsException()
+        public void ExpectInRange_WhenOutOfRange()
         {
             Assert.Throws<ArgumentOutOfRangeException>(
                 () => (1.1f).ExpectInRange(0f, 1f, "test"));

--- a/sources/Google.Solutions.Common.Test/Util/TestTypeExtensions.cs
+++ b/sources/Google.Solutions.Common.Test/Util/TestTypeExtensions.cs
@@ -34,21 +34,21 @@ namespace Google.Solutions.Common.Test.Util
         //---------------------------------------------------------------------
 
         [Test]
-        public void FullName_WhenTypeNotGeneric_ThenFullNameReturnsName()
+        public void FullName_WhenTypeNotGeneric()
         {
             Assert.That(
                 typeof(TestTypeExtensions).FullName(), Is.EqualTo(typeof(TestTypeExtensions).Name));
         }
 
         [Test]
-        public void FullName_WhenTypeIsGeneric_ThenFullNameReturnsName()
+        public void FullName_WhenTypeIsGeneric()
         {
             Assert.That(
                 typeof(KeyValuePair<string, int>).FullName(), Is.EqualTo("KeyValuePair<String,Int32>"));
         }
 
         [Test]
-        public void FullName_WhenTypeIsNestedGeneric_ThenFullNameReturnsName()
+        public void FullName_WhenTypeIsNestedGeneric()
         {
             Assert.That(
                 typeof(KeyValuePair<string, Tuple<string, int>>).FullName(), Is.EqualTo("KeyValuePair<String,Tuple<String,Int32>>"));

--- a/sources/Google.Solutions.Iap.Test/Protocol/TestSshRelayFormat.cs
+++ b/sources/Google.Solutions.Iap.Test/Protocol/TestSshRelayFormat.cs
@@ -52,7 +52,7 @@ namespace Google.Solutions.Iap.Test.Protocol
             }
 
             [Test]
-            public void Encode_WhenBufferTooSmall_ThenEncodeThrowsException()
+            public void Encode_WhenBufferTooSmall()
             {
                 var message = new byte[1];
 
@@ -74,7 +74,7 @@ namespace Google.Solutions.Iap.Test.Protocol
             }
 
             [Test]
-            public void Decode_WhenMessageTruncated_ThenDecodeThrowsException()
+            public void Decode_WhenMessageTruncated()
             {
                 var message = new byte[] { 0 };
 

--- a/sources/Google.Solutions.Iap.Test/Protocol/TestSshRelayStream.Reading.cs
+++ b/sources/Google.Solutions.Iap.Test/Protocol/TestSshRelayStream.Reading.cs
@@ -328,7 +328,7 @@ namespace Google.Solutions.Iap.Test.Protocol
 
 
         [Test]
-        public async Task Read_WhenServerClosesConnectionWithNonNormalError_ThenReadThrowsException()
+        public async Task Read_WhenServerClosesConnectionWithNonNormalError()
         {
             var stream = new MockStream()
             {

--- a/sources/Google.Solutions.Iap.Test/Protocol/TestSshRelayStream.Reading.cs
+++ b/sources/Google.Solutions.Iap.Test/Protocol/TestSshRelayStream.Reading.cs
@@ -297,7 +297,7 @@ namespace Google.Solutions.Iap.Test.Protocol
         }
 
         [Test]
-        public async Task Read_WhenServerClosesConnectionGracefully_ThenReadReturnsZero()
+        public async Task Read_WhenServerClosesConnectionGracefully()
         {
             var stream = new MockStream()
             {

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Client/TestGithubClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Client/TestGithubClient.cs
@@ -46,7 +46,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Client
         //---------------------------------------------------------------------
 
         [Test]
-        public void FindLatestRelease_WhenServerReturnsError_ThenFindLatestReleaseThrowsException()
+        public void FindLatestRelease_WhenServerReturnsError()
         {
             var restAdapter = new Mock<IExternalRestClient>();
             restAdapter
@@ -246,7 +246,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Client
         //---------------------------------------------------------------------
 
         [Test]
-        public void ListReleases_WhenServerReturnsError_ThenListReleasesThrowsException()
+        public void ListReleases_WhenServerReturnsError()
         {
             var restAdapter = new Mock<IExternalRestClient>();
             restAdapter

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Client/TestGithubClient.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Client/TestGithubClient.cs
@@ -66,7 +66,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Client
         }
 
         [Test]
-        public async Task FindLatestRelease_WhenServerReturnsEmptyResult_ThenFindLatestReleaseReturnsNull()
+        public async Task FindLatestRelease_WhenServerReturnsEmptyResult()
         {
             var restAdapter = new Mock<IExternalRestClient>();
             restAdapter
@@ -118,7 +118,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Client
         }
 
         [Test]
-        public async Task FindLatestRelease_WhenIncludeCanaryReleasesIsOff_ThenFindLatestReleaseReturnsLatest()
+        public async Task FindLatestRelease_WhenIncludeCanaryReleasesIsOff()
         {
             var restAdapter = new Mock<IExternalRestClient>();
             restAdapter
@@ -144,7 +144,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Client
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task FindLatestRelease_WhenReleaseDoesNotIncludeSurvey_ThenFindLatestReleaseReturnsReleaseWithoutSurvey()
+        public async Task FindLatestRelease_WhenReleaseDoesNotIncludeSurvey()
         {
             var restAdapter = new Mock<IExternalRestClient>();
             restAdapter
@@ -166,7 +166,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Client
         }
 
         [Test]
-        public async Task FindLatestRelease_WhenSurveyDownloadFails_ThenFindLatestReleaseReturnsReleaseWithoutSurvey()
+        public async Task FindLatestRelease_WhenSurveyDownloadFails()
         {
             var restAdapter = new Mock<IExternalRestClient>();
             restAdapter
@@ -201,7 +201,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Client
         }
 
         [Test]
-        public async Task FindLatestRelease_WhenReleaseIncludesSurvey_ThenFindLatestReleaseReturnsReleaseWithSurvey()
+        public async Task FindLatestRelease_WhenReleaseIncludesSurvey()
         {
             var restAdapter = new Mock<IExternalRestClient>();
             restAdapter
@@ -266,7 +266,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Client
         }
 
         [Test]
-        public async Task ListReleases_WhenServerReturnsEmptyResult_ThenListReleasesReturnsEmptyList()
+        public async Task ListReleases_WhenServerReturnsEmptyResult()
         {
             var restAdapter = new Mock<IExternalRestClient>();
             restAdapter
@@ -285,7 +285,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Client
         }
 
         [Test]
-        public async Task ListReleases_WhenServerReturnsMultiplePages_ThenListReleasesReturnsOrderedList()
+        public async Task ListReleases_WhenServerReturnsMultiplePages()
         {
             var restAdapter = new Mock<IExternalRestClient>();
             restAdapter

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Host/TestCommandLineOptions.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Host/TestCommandLineOptions.cs
@@ -30,7 +30,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
     public class TestCommandLineOptions : ApplicationFixtureBase
     {
         [Test]
-        public void Parse_WhenArgsEmpty_ThenParseReturnsValidOptions()
+        public void Parse_WhenArgsEmpty()
         {
             var options = CommandLineOptions.Parse(Array.Empty<string>());
 
@@ -44,7 +44,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
         //---------------------------------------------------------------------
 
         [Test]
-        public void Parse_WhenUrlSpecified_ThenParseReturnsValidOptions()
+        public void Parse_WhenUrlSpecified()
         {
             var options = CommandLineOptions.Parse(
                 new[] { "/url", "iap-rdp:///project-1/us-central1-a/vm-1" });
@@ -54,7 +54,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
         }
 
         [Test]
-        public void Parse_WhenUrlAndDebugSpecified_ThenParseReturnsValidOptions()
+        public void Parse_WhenUrlAndDebugSpecified()
         {
             var options = CommandLineOptions.Parse(
                 new[] { "/url", "iap-rdp:///project-1/us-central1-a/vm-1", "/debug" });
@@ -64,7 +64,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
         }
 
         [Test]
-        public void Parse_WhenDebugAndUrlSpecified_ThenParseReturnsValidOptions()
+        public void Parse_WhenDebugAndUrlSpecified()
         {
             var options = CommandLineOptions.Parse(
                 new[] { "/debug", "/url", "iap-rdp:///project-1/us-central1-a/vm-1" });
@@ -110,7 +110,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
         //---------------------------------------------------------------------
 
         [Test]
-        public void Parse_WhenProfileSpecified_ThenParseReturnsValidOptions()
+        public void Parse_WhenProfileSpecified()
         {
             var options = CommandLineOptions.Parse(
                 new[] { "/profile", "profile-1" });
@@ -120,7 +120,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
         }
 
         [Test]
-        public void Parse_WhenProfileAndDebugAndUrlSpecified_ThenParseReturnsValidOptions()
+        public void Parse_WhenProfileAndDebugAndUrlSpecified()
         {
             var options = CommandLineOptions.Parse(
                 new[] {
@@ -155,7 +155,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
         //---------------------------------------------------------------------
 
         [Test]
-        public void Parse_WhenPostInstallSpecified_ThenParseReturnsValidOptions()
+        public void Parse_WhenPostInstallSpecified()
         {
             var options = CommandLineOptions.Parse(
                 new[] { "/profile", "profile-1", "/postinstall", "/debug" });
@@ -168,14 +168,14 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToString_WhenAllOptionsClear_ThenToStringReturnsEmptyString()
+        public void ToString_WhenAllOptionsClear()
         {
             var options = new CommandLineOptions();
             Assert.That(options.ToString(), Is.EqualTo(string.Empty));
         }
 
         [Test]
-        public void ToString_WhenOptionsSpecified_ThenToStringReturnsQuotedString()
+        public void ToString_WhenOptionsSpecified()
         {
             var options = new CommandLineOptions()
             {

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Host/TestInstall.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Host/TestInstall.cs
@@ -229,7 +229,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
         //---------------------------------------------------------------------
 
         [Test]
-        public void CreateProfile_WhenProfileNameIsNotValid_ThenCreateProfileThrowsException()
+        public void CreateProfile_WhenProfileNameIsNotValid()
         {
             using (var keyPath = RegistryKeyPath.ForCurrentTest())
             {
@@ -240,7 +240,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
         }
 
         [Test]
-        public void CreateProfile_WhenProfileNameIsNull_ThenCreateProfileThrowsException()
+        public void CreateProfile_WhenProfileNameIsNull()
         {
             using (var keyPath = RegistryKeyPath.ForCurrentTest())
             {
@@ -271,7 +271,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
         //---------------------------------------------------------------------
 
         [Test]
-        public void OpenProfile_WhenProfileNameIsNotValid_ThenOpenProfileThrowsException()
+        public void OpenProfile_WhenProfileNameIsNotValid()
         {
             using (var keyPath = RegistryKeyPath.ForCurrentTest())
             {
@@ -282,7 +282,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Host
         }
 
         [Test]
-        public void OpenProfile_WhenProfileDoesNotExist_ThenOpenProfileThrowsException()
+        public void OpenProfile_WhenProfileDoesNotExist()
         {
             using (var keyPath = RegistryKeyPath.ForCurrentTest())
             {

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Profile/Auth/TestAuthorization.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Profile/Auth/TestAuthorization.cs
@@ -48,7 +48,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile.Auth
         //---------------------------------------------------------------------
 
         [Test]
-        public void Session_WhenNotAuthorized_ThenSessionThrowsException()
+        public void Session_WhenNotAuthorized()
         {
             var client = CreateClient();
             var authorization = new Authorization(

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Profile/Settings/TestAccessSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Profile/Settings/TestAccessSettingsRepository.cs
@@ -369,7 +369,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile.Settings
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsPolicyPresent_WhenMachineAndUserPolicyKeysAreNull_ThenIsPolicyPresentReturnsFalse()
+        public void IsPolicyPresent_WhenMachineAndUserPolicyKeysAreNull()
         {
             using (var settingsPath = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings))
             {
@@ -383,7 +383,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile.Settings
         }
 
         [Test]
-        public void IsPolicyPresent_WhenMachinePolicyKeyExists_ThenIsPolicyPresentReturnsTrue()
+        public void IsPolicyPresent_WhenMachinePolicyKeyExists()
         {
             using (var settingsPath = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings))
             using (var machinePolicyPath = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.MachinePolicy))
@@ -398,7 +398,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile.Settings
         }
 
         [Test]
-        public void IsPolicyPresent_WhenUserPolicyKeyExists_ThenIsPolicyPresentReturnsTrue()
+        public void IsPolicyPresent_WhenUserPolicyKeyExists()
         {
             using (var settingsPath = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings))
             using (var userPolicyPath = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.UserPolicy))

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Profile/Settings/TestApplicationSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Profile/Settings/TestApplicationSettingsRepository.cs
@@ -86,7 +86,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile.Settings
         //---------------------------------------------------------------------
 
         [Test]
-        public void ProxyUrl_WhenProxyUrlInvalid_ThenSetValueThrowsArgumentOutOfRangeException()
+        public void ProxyUrl_WhenProxyUrlInvalid()
         {
             using (var settingsPath = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings))
             {
@@ -176,7 +176,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile.Settings
         //---------------------------------------------------------------------
 
         [Test]
-        public void ProxyPacUrl_WhenProxyPacUrlInvalid_ThenSetValueThrowsArgumentOutOfRangeException()
+        public void ProxyPacUrl_WhenProxyPacUrlInvalid()
         {
             using (var settingsPath = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings))
             {

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Profile/Settings/TestApplicationSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Profile/Settings/TestApplicationSettingsRepository.cs
@@ -356,7 +356,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile.Settings
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsPolicyPresent_WhenMachineAnduserPolicyKeysAreNull_ThenIsPolicyPresentReturnsFalse()
+        public void IsPolicyPresent_WhenMachineAnduserPolicyKeysAreNull()
         {
             using (var settingsPath = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings))
             {
@@ -371,7 +371,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile.Settings
         }
 
         [Test]
-        public void IsPolicyPresent_WhenMachinePolicyKeyExists_ThenIsPolicyPresentReturnsTrue()
+        public void IsPolicyPresent_WhenMachinePolicyKeyExists()
         {
             using (var settingsPath = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings))
             using (var machinePolicyPath = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.MachinePolicy))
@@ -387,7 +387,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile.Settings
         }
 
         [Test]
-        public void IsPolicyPresent_WhenuserPolicyKeyExists_ThenIsPolicyPresentReturnsTrue()
+        public void IsPolicyPresent_WhenuserPolicyKeyExists()
         {
             using (var settingsPath = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings))
             using (var userPolicyPath = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.UserPolicy))

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Profile/Settings/TestAuthSettingsRepository.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Profile/Settings/TestAuthSettingsRepository.cs
@@ -85,7 +85,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile.Settings
         }
 
         [Test]
-        public void TryRead_WhenBlobContainsFullTokenResponse_ThenTryReadReturnsTrue()
+        public void TryRead_WhenBlobContainsFullTokenResponse()
         {
             var value = @"{
                 'access_token':'ya29.a0A...',
@@ -119,7 +119,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile.Settings
         }
 
         [Test]
-        public void TryRead_WhenBlobOnlyContainsGaiaRefreshToken_ThenTryReadReturnsTrue()
+        public void TryRead_WhenBlobOnlyContainsGaiaRefreshToken()
         {
             var value = @"{
                 'refresh_token':'rt',
@@ -147,7 +147,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile.Settings
         }
 
         [Test]
-        public void TryRead_WhenBlobOnlyContainsStsRefreshToken_ThenTryReadReturnsTrue()
+        public void TryRead_WhenBlobOnlyContainsStsRefreshToken()
         {
             var value = @"{
                 'refresh_token':'rt',

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Profile/TestUpdatePolicy.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Profile/TestUpdatePolicy.cs
@@ -177,7 +177,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile
         }
 
         [Test]
-        public void GetReleaseTrackForRelease_WhenDescriptionContainsCriticalTag_ThenGetReleaseTrackReturnsCritical()
+        public void GetReleaseTrackForRelease_WhenDescriptionContainsCriticalTag()
         {
             var description = "This release is [track:critical]!!1!";
 
@@ -190,7 +190,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile
         }
 
         [Test]
-        public void GetReleaseTrackForRelease_WhenPrerelease_ThenGetReleaseTrackReturnsCanary()
+        public void GetReleaseTrackForRelease_WhenPrerelease()
         {
             var description = "This release is on the canary track!!1!";
 
@@ -208,7 +208,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsUpdateAdvised_WhenReleaseHasNoVersion_ThenIsUpdateAdvisedReturnsFalse()
+        public void IsUpdateAdvised_WhenReleaseHasNoVersion()
         {
             var release = new Mock<IRelease>();
             var policy = new UpdatePolicy(
@@ -221,7 +221,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile
         }
 
         [Test]
-        public void IsUpdateAdvised_WhenReleaseOlderThanInstalled_ThenIsUpdateAdvisedReturnsFalse()
+        public void IsUpdateAdvised_WhenReleaseOlderThanInstalled()
         {
             var release = new Mock<IRelease>();
             release.SetupGet(r => r.TagVersion).Returns(new Version(1, 0));
@@ -236,7 +236,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile
         }
 
         [Test]
-        public void IsUpdateAdvised_WhenReleaseSameAsInstalled_ThenIsUpdateAdvisedReturnsFalse()
+        public void IsUpdateAdvised_WhenReleaseSameAsInstalled()
         {
             var install = CreateInstall();
 
@@ -253,7 +253,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile
         }
 
         [Test]
-        public void IsUpdateAdvised_WhenReleaseNewerAndUserOnCanaryTrack_ThenIsUpdateAdvisedReturnsTrueForCanaryTrackAndBelow()
+        public void IsUpdateAdvised_WhenReleaseNewerAndUserOnCanaryTrack()
         {
             var policy = new UpdatePolicy(
                 CreateSettingsRepository(true).Object,
@@ -281,7 +281,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile
         }
 
         [Test]
-        public void IsUpdateAdvised_WhenReleaseNewerAndUserOnNormalTrack_ThenIsUpdateAdvisedReturnsTrueForNormalAndBelow()
+        public void IsUpdateAdvised_WhenReleaseNewerAndUserOnNormalTrack()
         {
             var policy = new UpdatePolicy(
                 CreateSettingsRepository(true).Object,
@@ -309,7 +309,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile
         }
 
         [Test]
-        public void IsUpdateAdvised_WhenReleaseNewerAndUserOnCriticalTrack_ThenIsUpdateAdvisedReturnsTrueForCriticalOnly()
+        public void IsUpdateAdvised_WhenReleaseNewerAndUserOnCriticalTrack()
         {
             var policy = new UpdatePolicy(
                 CreateSettingsRepository(false).Object,
@@ -341,7 +341,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsUpdateCheckDue_WhenNotEnoughDaysElapsed_ThenIsUpdateCheckDueReturnsFalse()
+        public void IsUpdateCheckDue_WhenNotEnoughDaysElapsed()
         {
             var clock = SystemClock.Default;
             var now = clock.UtcNow;
@@ -361,7 +361,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile
         }
 
         [Test]
-        public void IsUpdateCheckDue_WhenTooManyDaysElapsed_ThenIsUpdateCheckDueReturnsTrue()
+        public void IsUpdateCheckDue_WhenTooManyDaysElapsed()
         {
             var clock = SystemClock.Default;
             var now = clock.UtcNow;

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Profile/TestUserProfile.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Profile/TestUserProfile.cs
@@ -37,7 +37,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsValidProfileName_WhenNameIsNullOrEmpty_ThenIsValidProfileNameReturnsFalse()
+        public void IsValidProfileName_WhenNameIsNullOrEmpty()
         {
             Assert.That(UserProfile.IsValidProfileName(null), Is.False);
             Assert.That(UserProfile.IsValidProfileName(string.Empty), Is.False);
@@ -45,32 +45,32 @@ namespace Google.Solutions.IapDesktop.Application.Test.Profile
         }
 
         [Test]
-        public void IsValidProfileName_WhenNameHasLeadingOrTrailingSpaces_ThenIsValidProfileNameReturnsFalse()
+        public void IsValidProfileName_WhenNameHasLeadingOrTrailingSpaces()
         {
             Assert.That(UserProfile.IsValidProfileName(" foo"), Is.False);
             Assert.That(UserProfile.IsValidProfileName("foo\t"), Is.False);
         }
 
         [Test]
-        public void IsValidProfileName_WhenNameContainsUmlauts_ThenIsValidProfileNameReturnsFalse()
+        public void IsValidProfileName_WhenNameContainsUmlauts()
         {
             Assert.That(UserProfile.IsValidProfileName("Föö"), Is.False);
         }
 
         [Test]
-        public void IsValidProfileName_WhenNameIsTooLong_ThenIsValidProfileNameReturnsFalse()
+        public void IsValidProfileName_WhenNameIsTooLong()
         {
             Assert.That(UserProfile.IsValidProfileName("This profile name is way too long"), Is.False);
         }
 
         [Test]
-        public void IsValidProfileName_WhenNameIsAlphanumeric_ThenIsValidProfileNameReturnsTrue()
+        public void IsValidProfileName_WhenNameIsAlphanumeric()
         {
             Assert.That(UserProfile.IsValidProfileName("This is a valid name"), Is.True);
         }
 
         [Test]
-        public void IsValidProfileName_WhenNameIsDefault_ThenIsValidProfileNameReturnsFalse()
+        public void IsValidProfileName_WhenNameIsDefault()
         {
             Assert.That(UserProfile.IsValidProfileName(UserProfile.DefaultName.ToLower()), Is.False);
         }

--- a/sources/Google.Solutions.IapDesktop.Application.Test/TestIapRdpUrl.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/TestIapRdpUrl.cs
@@ -126,7 +126,7 @@ namespace Google.Solutions.IapDesktop.Application.Test
         }
 
         [Test]
-        public void FromString_WhenTripleSlashUsed_ThenToStringReturnsSameString()
+        public void FromString_WhenTripleSlashUsed()
         {
             var url = "iap-rdp:///my-project/us-central1-a/my-instance";
             Assert.That(IapRdpUrl.FromString(url).ToString(false), Is.EqualTo(url));

--- a/sources/Google.Solutions.IapDesktop.Application.Test/TestIapRdpUrl.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/TestIapRdpUrl.cs
@@ -33,63 +33,63 @@ namespace Google.Solutions.IapDesktop.Application.Test
         //---------------------------------------------------------------------
 
         [Test]
-        public void FromString_WhenStringIsNull_ThenFromStringThrowsArgumentNullException()
+        public void FromString_WhenStringIsNull()
         {
             Assert.Throws<ArgumentNullException>(() => IapRdpUrl.FromString(null!));
         }
 
         [Test]
-        public void FromString_WhenStringIsEmpty_ThenFromStringThrowsUriFormatException()
+        public void FromString_WhenStringIsEmpty()
         {
             Assert.Throws<UriFormatException>(() => IapRdpUrl.FromString(string.Empty));
         }
 
         [Test]
-        public void FromString_WhenStringIsNotAUri_ThenFromStringThrowsUriFormatException()
+        public void FromString_WhenStringIsNotAUri()
         {
             Assert.Throws<UriFormatException>(() => IapRdpUrl.FromString("::"));
         }
 
         [Test]
-        public void FromString_WhenSchemeIsWrong_ThenFromStringThrowsIapRdpUrlFormatException()
+        public void FromString_WhenSchemeIsWrong()
         {
             Assert.Throws<IapRdpUrlFormatException>(() => IapRdpUrl.FromString("http://www/"));
         }
 
         [Test]
-        public void FromString_WhenHostNotEmpty_ThenFromStringThrowsIapRdpUrlFormatException()
+        public void FromString_WhenHostNotEmpty()
         {
             Assert.Throws<IapRdpUrlFormatException>(() => IapRdpUrl.FromString("iap-rdp://host/my-project/us-central1-a/my-instance"));
         }
 
         [Test]
-        public void FromString_WhenLeadingSlashMissing_ThenFromStringThrowsIapRdpUrlFormatException()
+        public void FromString_WhenLeadingSlashMissing()
         {
             Assert.Throws<IapRdpUrlFormatException>(() => IapRdpUrl.FromString("iap-rdp:my-project/us-central1-a/my-instance"));
         }
 
         [Test]
-        public void FromString_WhenTooManySlashed_ThenFromStringThrowsIapRdpUrlFormatException()
+        public void FromString_WhenTooManySlashed()
         {
             Assert.Throws<IapRdpUrlFormatException>(() => IapRdpUrl.FromString("iap-rdp:my-project/us-central1-a/my-instance/baz"));
         }
 
         [Test]
-        public void FromString_WhenProjectIdIsIsInvalid_ThenFromStringThrowsIapRdpUrlFormatException()
+        public void FromString_WhenProjectIdIsIsInvalid()
         {
             Assert.Throws<IapRdpUrlFormatException>(() =>
                 IapRdpUrl.FromString("iap-rdp:///__/us-central1-a/my-instance"));
         }
 
         [Test]
-        public void FromString_WhenZoneIdIsIsInvalid_ThenFromStringThrowsIapRdpUrlFormatException()
+        public void FromString_WhenZoneIdIsIsInvalid()
         {
             Assert.Throws<IapRdpUrlFormatException>(() =>
                 IapRdpUrl.FromString("iap-rdp:///my-project/__/my-instance"));
         }
 
         [Test]
-        public void FromString_WhenInstanceNameIsIsInvalid_ThenFromStringThrowsIapRdpUrlFormatException()
+        public void FromString_WhenInstanceNameIsIsInvalid()
         {
             Assert.Throws<IapRdpUrlFormatException>(() =>
                 IapRdpUrl.FromString("iap-rdp:///my-project/us-central1-a/__"));

--- a/sources/Google.Solutions.IapDesktop.Application.Test/ToolWindows/ProjectExplorer/TestProjectExplorerSettings.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/ToolWindows/ProjectExplorer/TestProjectExplorerSettings.cs
@@ -45,7 +45,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.ProjectExplor
         //---------------------------------------------------------------------
 
         [Test]
-        public void CollapsedProjects_WhenNoValueSaved_ThenCollapsedProjectsReturnsEmptySet()
+        public void CollapsedProjects_WhenNoValueSaved()
         {
             var settingsRepository = CreateSettingsRepository();
 
@@ -57,7 +57,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.ProjectExplor
         }
 
         [Test]
-        public void CollapsedProjects_WhenValueSaved_ThenCollapsedProjectsReturnsSavedValue()
+        public void CollapsedProjects_WhenValueSaved()
         {
             var settingsRepository = CreateSettingsRepository();
 

--- a/sources/Google.Solutions.IapDesktop.Application.Test/ToolWindows/Update/TestCheckForUpdateCommand.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/ToolWindows/Update/TestCheckForUpdateCommand.cs
@@ -151,7 +151,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.Update
         //---------------------------------------------------------------------
 
         [Test]
-        public void PromptForAction_WhenReleaseIsNull_ThenPromptForActionReturns()
+        public void PromptForAction_WhenReleaseIsNull()
         {
             var policy = new Mock<IUpdatePolicy>();
 
@@ -169,7 +169,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.Update
         }
 
         [Test]
-        public void PromptForAction_WhenPolicyDoesNotAdviseUpdate_ThenPromptForActionReturns()
+        public void PromptForAction_WhenPolicyDoesNotAdviseUpdate()
         {
             var policy = new Mock<IUpdatePolicy>();
 
@@ -187,7 +187,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.Update
         }
 
         [Test]
-        public void PromptForAction_WhenUserCancels_ThenPromptForActionReturns()
+        public void PromptForAction_WhenUserCancels()
         {
             var command = new CheckForUpdateCommand<IMainWindow>(
                 new Mock<IWin32Window>().Object,
@@ -279,7 +279,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.Update
         }
 
         [Test]
-        public void PromptForAction_WhenUserSelectsLater_ThenPromptForActionReturns()
+        public void PromptForAction_WhenUserSelectsLater()
         {
             var browser = new Mock<IBrowser>();
 
@@ -301,7 +301,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.Update
         //---------------------------------------------------------------------
 
         [Test]
-        public void PromptForAction_WhenReleaseHasNoSurvey_ThenPromptForActionReturns()
+        public void PromptForAction_WhenReleaseHasNoSurvey()
         {
             var release = new Mock<IRelease>();
             release.SetupGet(r => r.Survey).Returns((IReleaseSurvey?)null);
@@ -328,7 +328,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.Update
         }
 
         [Test]
-        public void PromptForAction_WhenReleaseHasSurveyButSurveysAreDisabled_ThenPromptForActionReturns()
+        public void PromptForAction_WhenReleaseHasSurveyButSurveysAreDisabled()
         {
             var survey = new Mock<IReleaseSurvey>();
             var release = new Mock<IRelease>();
@@ -356,7 +356,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.ToolWindows.Update
         }
 
         [Test]
-        public void PromptForAction_WhenReleaseHasSurveyButSurveysWasTakenBefore_ThenPromptForActionReturns()
+        public void PromptForAction_WhenReleaseHasSurveyButSurveysWasTakenBefore()
         {
             var lastVersion = new Version("2.1.3");
 

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Auth/TestAuthorizeOptionsViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Auth/TestAuthorizeOptionsViewModel.cs
@@ -56,7 +56,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Auth
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsOkButtonEnabled_WhenGaiaOptionChecked_ThenIsOkButtonEnabledReturnsTrue()
+        public void IsOkButtonEnabled_WhenGaiaOptionChecked()
         {
             var repository = CreateSettingsRepository(null);
             var viewModel = new AuthorizeOptionsViewModel(repository.Object);
@@ -67,7 +67,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Auth
         }
 
         [Test]
-        public void IsOkButtonEnabled_WhenWorkforcePoolOptionChecked_ThenIsOkButtonEnabledReturnsFalse()
+        public void IsOkButtonEnabled_WhenWorkforcePoolOptionChecked()
         {
             var repository = CreateSettingsRepository(null);
             var viewModel = new AuthorizeOptionsViewModel(repository.Object);
@@ -78,7 +78,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Auth
         }
 
         [Test]
-        public void IsOkButtonEnabled_WhenWorkforcePoolOptionCheckedAndDetailsProvided_ThenIsOkButtonEnabledReturnsTrue()
+        public void IsOkButtonEnabled_WhenWorkforcePoolOptionCheckedAndDetailsProvided()
         {
             var repository = CreateSettingsRepository(null);
             var viewModel = new AuthorizeOptionsViewModel(repository.Object);
@@ -135,7 +135,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Auth
         }
 
         [Test]
-        public void WorkforcePool_WhenLocatorSet_ThenIsWorkforcePoolOptionCheckedReturnsTrue()
+        public void WorkforcePool_WhenLocatorSet()
         {
             var repository = CreateSettingsRepository(SampleProviderLocator);
             var viewModel = new AuthorizeOptionsViewModel(repository.Object);

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Options/TestAccessOptionsViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Options/TestAccessOptionsViewModel.cs
@@ -324,7 +324,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Options
         }
 
         [Test]
-        public void ApplyChanges_WhenPscAndDcaEnabled_ThenApplyChangesThrowsException()
+        public void ApplyChanges_WhenPscAndDcaEnabled()
         {
             var settingsRepository = CreateSettingsRepository();
             var settings = settingsRepository.GetSettings();
@@ -342,7 +342,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Options
         }
 
         [Test]
-        public void ApplyChanges_WhenPscEndpointInvalid_ThenApplyChangesThrowsException()
+        public void ApplyChanges_WhenPscEndpointInvalid()
         {
             var settingsRepository = CreateSettingsRepository();
             var settings = settingsRepository.GetSettings();

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Options/TestGeneralOptionsViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Options/TestGeneralOptionsViewModel.cs
@@ -161,7 +161,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Options
         }
 
         [Test]
-        public void UpdateCheck_WhenLastCheckIsZero_ThenLastUpdateCheckReturnsNever()
+        public void UpdateCheck_WhenLastCheckIsZero()
         {
             var settingsRepository = CreateSettingsRepository();
             var viewModel = new GeneralOptionsViewModel(
@@ -173,7 +173,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Options
         }
 
         [Test]
-        public void UpdateCheck_WhenLastCheckIsNonZero_ThenLastUpdateCheckReturnsNever()
+        public void UpdateCheck_WhenLastCheckIsNonZero()
         {
             var settingsRepository = CreateSettingsRepository();
             var settings = settingsRepository.GetSettings();

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Options/TestNetworkOptionsViewModel.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Windows/Options/TestNetworkOptionsViewModel.cs
@@ -454,7 +454,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Options
         //---------------------------------------------------------------------
 
         [Test]
-        public void ApplyChanges_WhenProxyServerInvalid_ThenApplyChangesThrowsArgumentException()
+        public void ApplyChanges_WhenProxyServerInvalid()
         {
             using (var settingsKey = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings).CreateKey())
             {
@@ -473,7 +473,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Options
         }
 
         [Test]
-        public void ApplyChanges_WhenProxyPortIsZero_ThenApplyChangesThrowsArgumentException()
+        public void ApplyChanges_WhenProxyPortIsZero()
         {
             using (var settingsKey = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings).CreateKey())
             {
@@ -492,7 +492,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Options
         }
 
         [Test]
-        public void ApplyChanges_WhenProxyPortIsOutOfBounds_ThenApplyChangesThrowsArgumentException()
+        public void ApplyChanges_WhenProxyPortIsOutOfBounds()
         {
             using (var settingsKey = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings).CreateKey())
             {
@@ -511,7 +511,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Options
         }
 
         [Test]
-        public void ApplyChanges_WhenProxyAutoconfigUrlInvalid_ThenApplyChangesThrowsArgumentException()
+        public void ApplyChanges_WhenProxyAutoconfigUrlInvalid()
         {
             using (var settingsKey = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings).CreateKey())
             {
@@ -529,7 +529,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.Options
         }
 
         [Test]
-        public void ApplyChanges_WhenProxyAuthIncomplete_ThenApplyChangesThrowsArgumentException()
+        public void ApplyChanges_WhenProxyAuthIncomplete()
         {
             using (var settingsKey = RegistryKeyPath.ForCurrentTest(RegistryKeyPath.KeyType.Settings).CreateKey())
             {

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Windows/ProjectPicker/TestProjectPickerDialog.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Windows/ProjectPicker/TestProjectPickerDialog.cs
@@ -77,7 +77,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.ProjectPicker
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task ListProjects_WhenStaticModelProjectsIsNull_ThenListProjectsReturnsEmptyList()
+        public async Task ListProjects_WhenStaticModelProjectsIsNull()
         {
             var model = new Application.Windows.ProjectPicker.ProjectPickerDialog.StaticModel(null!);
 
@@ -89,7 +89,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.ProjectPicker
         }
 
         [Test]
-        public async Task ListProjects_WhenStaticModelFilterIsNull_ThenListProjectsReturnsAllProjects()
+        public async Task ListProjects_WhenStaticModelFilterIsNull()
         {
             var projects = new List<Project>()
             {
@@ -109,7 +109,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.ProjectPicker
         }
 
         [Test]
-        public async Task ListProjects_WhenStaticModelMaxResultsExceeded_ThenListProjectsReturnsTruncatedList()
+        public async Task ListProjects_WhenStaticModelMaxResultsExceeded()
         {
             var projects = new List<Project>()
             {
@@ -128,7 +128,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows.ProjectPicker
         }
 
         [Test]
-        public async Task ListProjects_WhenStaticModelFilterIsNotNull_ThenListProjectsReturnsMatchingProjects()
+        public async Task ListProjects_WhenStaticModelFilterIsNotNull()
         {
             var projects = new List<Project>()
             {

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Windows/TestSessionBroker.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Windows/TestSessionBroker.cs
@@ -81,7 +81,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsConnected_WhenNoSessionActive_ThenIsConnectedReturnsFalse()
+        public void IsConnected_WhenNoSessionActive()
         {
             using (var form = new TestMainForm())
             {
@@ -91,7 +91,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows
         }
 
         [Test]
-        public void IsConnected_WhenOnlyOtherSessionsFound_ThenIsConnectedReturnsFalse()
+        public void IsConnected_WhenOnlyOtherSessionsFound()
         {
             using (var form = new TestMainForm())
             {
@@ -107,7 +107,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows
         }
 
         [Test]
-        public void IsConnected_WhenMatchingSessionFound_ThenIsConnectedReturnsTrue()
+        public void IsConnected_WhenMatchingSessionFound()
         {
             using (var form = new TestMainForm())
             {
@@ -124,7 +124,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows
         }
 
         [Test]
-        public void IsConnected_WhenMatchingSessionIsClosing_ThenIsConnectedReturnsFalse()
+        public void IsConnected_WhenMatchingSessionIsClosing()
         {
             using (var form = new TestMainForm())
             {
@@ -145,7 +145,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows
         //---------------------------------------------------------------------
 
         [Test]
-        public void TryActivateSession_WhenNoSessionActive_ThenTryActivateReturnsFalse()
+        public void TryActivateSession_WhenNoSessionActive()
         {
 
             using (var form = new TestMainForm())
@@ -156,7 +156,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows
         }
 
         [Test]
-        public void TryActivateSession_WhenMatchingSessionFound_ThenTryActivateReturnsTrue()
+        public void TryActivateSession_WhenMatchingSessionFound()
         {
             using (var form = new TestMainForm())
             {
@@ -176,7 +176,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows
         }
 
         [Test]
-        public void TryActivateSession_WhenMatchingSessionIsClosing_ThenTryActivateReturnsFalse()
+        public void TryActivateSession_WhenMatchingSessionIsClosing()
         {
             using (var form = new TestMainForm())
             {

--- a/sources/Google.Solutions.IapDesktop.Application.Test/Windows/TestWaitDialog.cs
+++ b/sources/Google.Solutions.IapDesktop.Application.Test/Windows/TestWaitDialog.cs
@@ -77,7 +77,7 @@ namespace Google.Solutions.IapDesktop.Application.Test.Windows
         }
 
         [Test]
-        public void Wait_WhenDialogCancelled_ThenWaitThrowsException()
+        public void Wait_WhenDialogCancelled()
         {
             Assert.Throws<TaskCanceledException>(
                 () => WaitDialog.Wait(

--- a/sources/Google.Solutions.IapDesktop.Core.Test/ProjectModel/TestProjectWorkspace.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ProjectModel/TestProjectWorkspace.cs
@@ -685,7 +685,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ProjectModel
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task GetNode_WhenLocatorOfUnknownType_ThenGetNodeAsyncThrowsArgumentException()
+        public async Task GetNode_WhenLocatorOfUnknownType()
         {
             var workspace = new ProjectWorkspace(
                 CreateComputeEngineClientMock(SampleProjectId).Object,

--- a/sources/Google.Solutions.IapDesktop.Core.Test/ProjectModel/TestProjectWorkspace.cs
+++ b/sources/Google.Solutions.IapDesktop.Core.Test/ProjectModel/TestProjectWorkspace.cs
@@ -364,7 +364,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ProjectModel
         }
 
         [Test]
-        public async Task GetRootNode_WhenProjectsCached_ThenGetRootNodeAsyncReturnsCachedProjects()
+        public async Task GetRootNode_WhenProjectsCached()
         {
             var computeClient = CreateComputeEngineClientMock(SampleProjectId);
             var resourceManagerAdapter = CreateResourceManagerClientMock();
@@ -512,7 +512,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ProjectModel
         }
 
         [Test]
-        public async Task GetZoneNodes_WhenZonesCached_ThenGetZoneNodesAsyncReturnsCachedZones()
+        public async Task GetZoneNodes_WhenZonesCached()
         {
             var computeAdapter = CreateComputeEngineClientMock(
                 SampleProjectId,
@@ -703,7 +703,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ProjectModel
         }
 
         [Test]
-        public async Task GetNode_WhenProjectLocatorValid_ThenGetNodeAsyncReturnsNode()
+        public async Task GetNode_WhenProjectLocatorValid()
         {
             var workspace = new ProjectWorkspace(
                 CreateComputeEngineClientMock(SampleProjectId).Object,
@@ -732,7 +732,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ProjectModel
         }
 
         [Test]
-        public async Task GetNode_WhenZoneLocatorValid_ThenGetNodeAsyncReturnsNode()
+        public async Task GetNode_WhenZoneLocatorValid()
         {
             var workspace = new ProjectWorkspace(
                 CreateComputeEngineClientMock(
@@ -759,7 +759,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ProjectModel
         }
 
         [Test]
-        public async Task GetNode_WhenInstanceLocatorValid_ThenGetNodeAsyncReturnsNode()
+        public async Task GetNode_WhenInstanceLocatorValid()
         {
             var workspace = new ProjectWorkspace(
                 CreateComputeEngineClientMock(
@@ -787,7 +787,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ProjectModel
         }
 
         [Test]
-        public async Task GetNode_WhenProjectNotAddedButZoneLocatorValid_ThenGetNodeAsyncReturnsNull()
+        public async Task GetNode_WhenProjectNotAddedButZoneLocatorValid()
         {
             var workspace = new ProjectWorkspace(
                 CreateComputeEngineClientMock(
@@ -806,7 +806,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ProjectModel
         }
 
         [Test]
-        public async Task GetNode_WhenProjectNotAddedButInstanceLocatorValid_ThenGetNodeAsyncReturnsNull()
+        public async Task GetNode_WhenProjectNotAddedButInstanceLocatorValid()
         {
             var workspace = new ProjectWorkspace(
                 CreateComputeEngineClientMock(
@@ -830,7 +830,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ProjectModel
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task GetActiveNode_WhenNoActiveNodeSet_ThenGetActiveNodeAsyncReturnsRoot()
+        public async Task GetActiveNode_WhenNoActiveNodeSet()
         {
             var workspace = new ProjectWorkspace(
                 CreateComputeEngineClientMock(SampleProjectId).Object,
@@ -854,7 +854,7 @@ namespace Google.Solutions.IapDesktop.Core.Test.ProjectModel
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task SetActiveNode_WhenActiveNodeSet_ThenGetActiveNodeAsyncReturnsNode()
+        public async Task SetActiveNode_WhenActiveNodeSet()
         {
             var workspace = new ProjectWorkspace(
                 CreateComputeEngineClientMock(

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/Auditing/Events/Access/TestAuthorizeUserTunnelEvent.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/Auditing/Events/Access/TestAuthorizeUserTunnelEvent.cs
@@ -383,7 +383,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Test.Auditing.Events
         }
 
         [Test]
-        public void ToEvent_WhenRecordIsFromIapWeb_ThenIsAuthorizeUserEventReturnsFalse()
+        public void ToEvent_WhenRecordIsFromIapWeb()
         {
             var json = @"
              {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/Auditing/Events/Access/TestSetMetadataEvent.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/Auditing/Events/Access/TestSetMetadataEvent.cs
@@ -334,7 +334,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Test.Auditing.Events
         }
 
         [Test]
-        public void ToEvent_WhenRecordContainsOtherMetadataKeys_ThenIsResetWindowsUserEventReturnsFalse()
+        public void ToEvent_WhenRecordContainsOtherMetadataKeys()
         {
             var json = @"
              {

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/GuestOs/ActiveDirectory/TestDomainJoinService.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/GuestOs/ActiveDirectory/TestDomainJoinService.cs
@@ -149,7 +149,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Test.GuestOs.ActiveD
         }
 
         [Test]
-        public void JoinDomain_WhenJoinResponseContainsError_ThenJoinDomainThrowsException()
+        public void JoinDomain_WhenJoinResponseContainsError()
         {
             var operationId = Guid.NewGuid();
             var instance = new InstanceLocator("project-1", "zone-1", "instance-1");

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/GuestOs/Inventory/TestCentOsGuestOsInfo.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/GuestOs/Inventory/TestCentOsGuestOsInfo.cs
@@ -164,7 +164,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Test.GuestOs.Invento
             };
 
         [Test]
-        public void FromGuestAttributes_WhenGuestAttributesEmpty_ThenReturnsDefaults()
+        public void FromGuestAttributes_WhenGuestAttributesEmpty()
         {
             var attributes = GuestOsInfo.FromGuestAttributes(
                 SampleLocator,

--- a/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/GuestOs/Inventory/TestWindowsGuestOsInfo.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Management.Test/GuestOs/Inventory/TestWindowsGuestOsInfo.cs
@@ -135,7 +135,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Management.Test.GuestOs.Invento
             };
 
         [Test]
-        public void FromGuestAttributes_WhenGuestAttributesEmpty_ThenReturnsDefaults()
+        public void FromGuestAttributes_WhenGuestAttributesEmpty()
         {
             var attributes = GuestOsInfo.FromGuestAttributes(
                 SampleLocator,

--- a/sources/Google.Solutions.Mvvm.Test/Binding/Commands/TestContextCommand.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Binding/Commands/TestContextCommand.cs
@@ -32,7 +32,7 @@ namespace Google.Solutions.Mvvm.Test.Binding.Commands
         //---------------------------------------------------------------------
 
         [Test]
-        public void ActivityText_WhenActivityTextNotSet_ThenActivityTextReturnsText()
+        public void ActivityText_WhenActivityTextNotSet()
         {
             var command = new ContextCommand<string>(
                 "&Sample",
@@ -42,7 +42,7 @@ namespace Google.Solutions.Mvvm.Test.Binding.Commands
             Assert.That(command.ActivityText, Is.EqualTo("Sample"));
         }
         [Test]
-        public void ActivityText_WhenActivityTextSet_ThenActivityTextReturnsActivityText()
+        public void ActivityText_WhenActivityTextSet()
         {
             var command = new ContextCommand<string>(
                 "&Sample",

--- a/sources/Google.Solutions.Mvvm.Test/Binding/TestBindingExtensions.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Binding/TestBindingExtensions.cs
@@ -190,7 +190,7 @@ namespace Google.Solutions.Mvvm.Test.Binding
         }
 
         [Test]
-        public void OnControlPropertyChange_WhenControlHasNoAppropriateEvent_ThenOnControlPropertyChangeThrowsArgumentException()
+        public void OnControlPropertyChange_WhenControlHasNoAppropriateEvent()
         {
             var observed = new TextBox();
 

--- a/sources/Google.Solutions.Mvvm.Test/Binding/TestBound.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Binding/TestBound.cs
@@ -48,7 +48,7 @@ namespace Google.Solutions.Mvvm.Test.Binding
         //-----------------------------------------------------------
 
         [Test]
-        public void Value_WhenNotInitialized_ThenGetValueThrowsException()
+        public void Value_WhenNotInitialized()
         {
             var bound = new Bound<string>();
             Assert.Throws<InvalidOperationException>(() => bound.Value.ToString());
@@ -66,7 +66,7 @@ namespace Google.Solutions.Mvvm.Test.Binding
         }
 
         [Test]
-        public void Value_WhenInitialized_ThenSetValueThrowsException()
+        public void Value_WhenReinitialized()
         {
             var bound = new Bound<string>
             {
@@ -81,7 +81,7 @@ namespace Google.Solutions.Mvvm.Test.Binding
         //-----------------------------------------------------------
 
         [Test]
-        public void ConversionOp_WhenNotInitialized_ThenGetConversionThrowsException()
+        public void ConversionOp_WhenNotInitialized()
         {
             var bound = new Bound<string>();
             Assert.Throws<InvalidOperationException>(() => ((string)bound).ToString());

--- a/sources/Google.Solutions.Mvvm.Test/Binding/TestBound.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Binding/TestBound.cs
@@ -55,7 +55,7 @@ namespace Google.Solutions.Mvvm.Test.Binding
         }
 
         [Test]
-        public void Value_WhenInitialized_ThenGetValueReturns()
+        public void Value_WhenInitialized()
         {
             var bound = new Bound<string>
             {
@@ -88,7 +88,7 @@ namespace Google.Solutions.Mvvm.Test.Binding
         }
 
         [Test]
-        public void ConversionOp_WhenInitialized_ThenGetConversionReturns()
+        public void ConversionOp_WhenInitialized()
         {
             var bound = new Bound<string>
             {
@@ -104,14 +104,14 @@ namespace Google.Solutions.Mvvm.Test.Binding
         //-----------------------------------------------------------
 
         [Test]
-        public void ToString_WhenNotInitialized_ThenToStringReturnsEmpty()
+        public void ToString_WhenNotInitialized()
         {
             var bound = new Bound<string>();
             Assert.That(bound.ToString(), Is.EqualTo(""));
         }
 
         [Test]
-        public void ToString_WhenInitialized_ThenToStringReturnsValue()
+        public void ToString_WhenInitialized()
         {
             var bound = new Bound<string>
             {

--- a/sources/Google.Solutions.Mvvm.Test/Cache/TestLeastRecentlyUsedCache.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Cache/TestLeastRecentlyUsedCache.cs
@@ -29,7 +29,7 @@ namespace Google.Solutions.Mvvm.Test.Cache
     public class TestLeastRecentlyUsedCache
     {
         [Test]
-        public void Ctor_WhenCapacityTooSmall_ThenArgumentExceptionIsThrown()
+        public void Ctor_WhenCapacityTooSmall()
         {
             Assert.Throws<ArgumentException>(() => new LeastRecentlyUsedCache<string, string>(0));
         }

--- a/sources/Google.Solutions.Mvvm.Test/Cache/TestLeastRecentlyUsedCache.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Cache/TestLeastRecentlyUsedCache.cs
@@ -35,14 +35,14 @@ namespace Google.Solutions.Mvvm.Test.Cache
         }
 
         [Test]
-        public void Lookup_WhenLookupNonexistingItem_ThenNullIsReturned()
+        public void Lookup_WhenLookupNonexistingItem()
         {
             var cache = new LeastRecentlyUsedCache<string, string>(2);
             Assert.That(cache.Lookup("key"), Is.Null);
         }
 
         [Test]
-        public void Lookup_WhenLookupCachedItem_ThenItemIsReturned()
+        public void Lookup_WhenLookupCachedItem()
         {
             var cache = new LeastRecentlyUsedCache<string, string>(2);
             cache.Add("one", "ONE");

--- a/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowser.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Controls/TestFileBrowser.cs
@@ -121,7 +121,7 @@ namespace Google.Solutions.Mvvm.Test.Controls
         //---------------------------------------------------------------------
 
         [Test]
-        public void Bind_WhenBoundAlready_ThenBindThrowsException()
+        public void Bind_WhenBoundAlready()
         {
             using (var form = new Form()
             {

--- a/sources/Google.Solutions.Mvvm.Test/Controls/TestTaskDialog.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Controls/TestTaskDialog.cs
@@ -33,7 +33,7 @@ namespace Google.Solutions.Mvvm.Test.Controls
     public class TestTaskDialog
     {
         [Test]
-        public void WhenButtonsEmpty_ThenShowDialogThrowsException()
+        public void WhenButtonsEmpty()
         {
             var parameters = new TaskDialogParameters("heading", "caption", "text");
             Assert.Throws<InvalidOperationException>(

--- a/sources/Google.Solutions.Mvvm.Test/Controls/TestTaskDialog.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Controls/TestTaskDialog.cs
@@ -45,7 +45,7 @@ namespace Google.Solutions.Mvvm.Test.Controls
         //---------------------------------------------------------------------
 
         [Test]
-        public void ShowDialog_WhenOkClicked_ThenShowDialogReturnsOk()
+        public void ShowDialog_WhenOkClicked()
         {
             var parameters = new TaskDialogParameters("heading", "caption", "text");
             parameters.Buttons.Add(TaskDialogStandardButton.OK);
@@ -75,7 +75,7 @@ namespace Google.Solutions.Mvvm.Test.Controls
         }
 
         [Test]
-        public void ShowDialog_WhenCancelClicked_ThenShowDialogReturnsCancel()
+        public void ShowDialog_WhenCancelClicked()
         {
             var parameters = new TaskDialogParameters("heading", "caption", "text");
             parameters.Buttons.Add(TaskDialogStandardButton.Yes);

--- a/sources/Google.Solutions.Mvvm.Test/Drawing/TestBadgeIcon.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Drawing/TestBadgeIcon.cs
@@ -30,7 +30,7 @@ namespace Google.Solutions.Mvvm.Test.Drawing
     public class TestBadgeIcon
     {
         [Test]
-        public void ForTextInitial_WhenTextIsNullOrEmpty_ThenForTextInitialThrowsException()
+        public void ForTextInitial_WhenTextIsNullOrEmpty()
         {
             Assert.Throws<ArgumentNullException>(() => BadgeIcon.ForTextInitial(null!));
             Assert.Throws<ArgumentException>(() => BadgeIcon.ForTextInitial(string.Empty));

--- a/sources/Google.Solutions.Mvvm.Test/Drawing/TestHslColor.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Drawing/TestHslColor.cs
@@ -61,7 +61,7 @@ namespace Google.Solutions.Mvvm.Test.Drawing
         //---------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenValuesSame_ThenEqualsReturnTrue()
+        public void Equals_WhenValuesSame()
         {
             var c = new HslColor(1.0f, 1.0f, 1.0f);
 

--- a/sources/Google.Solutions.Mvvm.Test/Drawing/TestIconInverter.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Drawing/TestIconInverter.cs
@@ -109,7 +109,7 @@ namespace Google.Solutions.Mvvm.Test.Drawing
         //---------------------------------------------------------------------
 
         [Test]
-        public void Invert_WhenImageInvertedBefore_ThenInvertReturnsFalse()
+        public void Invert_WhenImageInvertedBefore()
         {
             var icon = Resources.Copy_16x;
             var inverter = new IconInverter()
@@ -123,7 +123,7 @@ namespace Google.Solutions.Mvvm.Test.Drawing
         }
 
         [Test]
-        public void Invert_WhenImageListInvertedBefore_ThenInvertReturnsFalse()
+        public void Invert_WhenImageListInvertedBefore()
         {
             var icon = Resources.Copy_16x;
             using (var imageList = new ImageList())

--- a/sources/Google.Solutions.Mvvm.Test/Format/TestMarkdownDocument.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Format/TestMarkdownDocument.cs
@@ -488,14 +488,14 @@ namespace Google.Solutions.Mvvm.Test.Format
         //---------------------------------------------------------------------
 
         [Test]
-        public void Tokenize_WhenTextEmpty_ThenTokenizeReturnsNoTokens()
+        public void Tokenize_WhenTextEmpty()
         {
             var tokens = MarkdownDocument.Token.Tokenize(string.Empty);
             Assert.That(tokens, Is.Empty);
         }
 
         [Test]
-        public void Tokenize_WhenTextHasNoDelimeter_ThenTokenizeReturnsSingleToken()
+        public void Tokenize_WhenTextHasNoDelimeter()
         {
             var tokens = MarkdownDocument.Token.Tokenize("t");
             Assert.That(
@@ -506,7 +506,7 @@ namespace Google.Solutions.Mvvm.Test.Format
         }
 
         [Test]
-        public void Tokenize_WhenTextHasDelimeters_ThenTokenizeReturnsTokens()
+        public void Tokenize_WhenTextHasDelimeters()
         {
             var tokens = MarkdownDocument.Token.Tokenize("t[a]()* *_ text");
             Assert.That(
@@ -527,7 +527,7 @@ namespace Google.Solutions.Mvvm.Test.Format
         }
 
         [Test]
-        public void Tokenize_WhenTokensEquivalent_ThenEqualsReturnsTrue()
+        public void Tokenize_WhenTokensEquivalent()
         {
             var token1 = new MarkdownDocument.Token(MarkdownDocument.TokenType.Text, "text");
             var token2 = new MarkdownDocument.Token(MarkdownDocument.TokenType.Text, "text");
@@ -537,7 +537,7 @@ namespace Google.Solutions.Mvvm.Test.Format
         }
 
         [Test]
-        public void Tokenize_WhenTokensNotEquivalent_ThenEqualsReturnsFalse()
+        public void Tokenize_WhenTokensNotEquivalent()
         {
             var token1 = new MarkdownDocument.Token(MarkdownDocument.TokenType.Text, "text");
             var token2 = new MarkdownDocument.Token(MarkdownDocument.TokenType.Delimiter, ")");

--- a/sources/Google.Solutions.Mvvm.Test/Interop/TestSubclassCallback.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Interop/TestSubclassCallback.cs
@@ -36,7 +36,7 @@ namespace Google.Solutions.Mvvm.Test.Interop
         //---------------------------------------------------------------------
 
         [Test]
-        public void Ctor_WhenArgumentInvalid_ThenConstructorThrowsException()
+        public void Ctor_WhenArgumentInvalid()
         {
             Assert.Throws<ArgumentNullException>(
                 () => new SubclassCallback(new Control(), null!));

--- a/sources/Google.Solutions.Mvvm.Test/Shell/TestStockIcons.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Shell/TestStockIcons.cs
@@ -31,7 +31,7 @@ namespace Google.Solutions.Mvvm.Test.Shell
     public class TestStockIcons
     {
         [Test]
-        public void GetIcon_WhenIdInvalid_ThenGetIconThrowsException()
+        public void GetIcon_WhenIdInvalid()
         {
             Assert.Throws<COMException>(
                 () => StockIcons.GetIcon(

--- a/sources/Google.Solutions.Mvvm.Test/Theme/TestControlTheme.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Theme/TestControlTheme.cs
@@ -32,7 +32,7 @@ namespace Google.Solutions.Mvvm.Test.Theme
     public class TestControlTheme
     {
         [Test]
-        public void WhenControlIsNull_ThenApplyToReturns()
+        public void WhenControlIsNull()
         {
             new ControlTheme().ApplyTo(null!);
         }

--- a/sources/Google.Solutions.Mvvm.Test/Theme/TestToolStripItemTheme.cs
+++ b/sources/Google.Solutions.Mvvm.Test/Theme/TestToolStripItemTheme.cs
@@ -32,14 +32,14 @@ namespace Google.Solutions.Mvvm.Test.Theme
     public class TestToolStripItemTheme
     {
         [Test]
-        public void WhenToolStripIsNull_ThenApplyToReturns()
+        public void WhenToolStripIsNull()
         {
             var theme = new ToolStripItemTheme(true);
             theme.ApplyTo(null!);
         }
 
         [Test]
-        public void WhenToolStripEmpty_ThenApplyToReturns()
+        public void WhenToolStripEmpty()
         {
             var theme = new ToolStripItemTheme(true);
             theme.ApplyTo(new MenuStrip());

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ChildProcessFactory.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ChildProcessFactory.cs
@@ -65,7 +65,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         //---------------------------------------------------------------------
 
         [Test]
-        public void Contains_WhenProcessFound_ThenContainsReturnsTrue()
+        public void Contains_WhenProcessFound()
         {
             using (var factory = new Win32ChildProcessFactory(true))
             using (var process = factory.CreateProcess(CmdExe, null))
@@ -76,7 +76,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public void Contains_WhenProcessNotFound_ThenContainsReturnsFalse()
+        public void Contains_WhenProcessNotFound()
         {
             using (var factory = new Win32ChildProcessFactory(true))
             {
@@ -89,7 +89,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task Close_WhenChildTerminated_ThenCloseReturns()
+        public async Task Close_WhenChildTerminated()
         {
             using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
             using (var factory = new Win32ChildProcessFactory(false))
@@ -108,7 +108,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public async Task Close_WhenChildRunning_ThenCloseReturns()
+        public async Task Close_WhenChildRunning()
         {
             using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5)))
             using (var factory = new Win32ChildProcessFactory(false))

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Job.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Job.cs
@@ -83,7 +83,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         //---------------------------------------------------------------------
 
         [Test]
-        public void Contains_WhenAdded_ThenContainsReturnsTrue()
+        public void Contains_WhenAdded()
         {
             var factory = new Win32ProcessFactory();
 
@@ -127,7 +127,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public void ProcessIds_WhenJobContainsProcesses_ThenProcessIdsReturnsId()
+        public void ProcessIds_WhenJobContainsProcesses()
         {
             var factory = new Win32ProcessFactory();
 
@@ -150,7 +150,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task WaitForProcesses_WhenJobEmpty_ThenWaitReturns()
+        public async Task WaitForProcesses_WhenJobEmpty()
         {
             using (var job = new Win32Job(true))
             {
@@ -178,7 +178,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public async Task WaitForProcesses_WhenProcessTerminates_ThenWaitReturns()
+        public async Task WaitForProcesses_WhenProcessTerminates()
         {
             var factory = new Win32ProcessFactory();
 

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Job.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Job.cs
@@ -104,7 +104,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public void Contains_WhenProcessDoesNotExist_ThenContainsThrowsException()
+        public void Contains_WhenProcessDoesNotExist()
         {
             using (var job = new Win32Job(true))
             {
@@ -161,7 +161,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public void WaitForProcesses_WhenTimeoutElapses_ThenWaitThrowsException()
+        public void WaitForProcesses_WhenTimeoutElapses()
         {
             var factory = new Win32ProcessFactory();
 

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Process.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Process.cs
@@ -228,7 +228,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         //---------------------------------------------------------------------
 
         [Test]
-        public async Task Close_WhenProcessHasNoWindows_ThenCloseReturnsTrue()
+        public async Task Close_WhenProcessHasNoWindows()
         {
             var factory = new Win32ProcessFactory();
 
@@ -247,7 +247,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public async Task Close_WhenProcessHasWindows_ThenCloseReturnsTrue()
+        public async Task Close_WhenProcessHasWindows()
         {
             var factory = new Win32ProcessFactory();
 
@@ -272,7 +272,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public async Task Close_WhenProcessTerminated_ThenCloseReturnsTrue()
+        public async Task Close_WhenProcessTerminated()
         {
             var factory = new Win32ProcessFactory();
 
@@ -355,7 +355,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         //---------------------------------------------------------------------
 
         [Test]
-        public void FromProcessId_WhenProcessAccessible_ThenFromProcessIdReturnsProcess()
+        public void FromProcessId_WhenProcessAccessible()
         {
             var factory = new Win32ProcessFactory();
 

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Process.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32Process.cs
@@ -177,7 +177,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         //---------------------------------------------------------------------
 
         [Test]
-        public void Terminate_WhenTerminatedAlready_ThenTerminateThrowsException()
+        public void Terminate_WhenTerminatedAlready()
         {
             var factory = new Win32ProcessFactory();
 
@@ -294,7 +294,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         //---------------------------------------------------------------------
 
         [Test]
-        public void Wait_WhenTimeoutElapses_ThenWaitThrowsException()
+        public void Wait_WhenTimeoutElapses()
         {
             var factory = new Win32ProcessFactory();
 
@@ -313,7 +313,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public void Wait_WhenCancelled_ThenWaitThrowsException()
+        public void Wait_WhenCancelled()
         {
             var factory = new Win32ProcessFactory();
 
@@ -377,7 +377,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public void FromProcessId_WhenProcessInccessible_ThenFromProcessThrowsException()
+        public void FromProcessId_WhenProcessInccessible()
         {
             var factory = new Win32ProcessFactory();
 
@@ -386,7 +386,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public void FromProcessId_WhenProcessOpenedById_ThenResumeThrowsException()
+        public void FromProcessId_WhenProcessOpenedById()
         {
             var factory = new Win32ProcessFactory();
 
@@ -406,7 +406,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public void FromProcessId_WhenProcessIdDoesNotExist_ThenFromProcessThrowsException()
+        public void FromProcessId_WhenProcessIdDoesNotExist()
         {
             var factory = new Win32ProcessFactory();
 

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ProcessFactory.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWin32ProcessFactory.cs
@@ -49,7 +49,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         //---------------------------------------------------------------------
 
         [Test]
-        public void CreateProcess_WhenExecutableNotFound_ThenCreateProcessThrowsException()
+        public void CreateProcess_WhenExecutableNotFound()
         {
             var factory = new Win32ProcessFactory();
 
@@ -96,7 +96,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         //---------------------------------------------------------------------
 
         [Test]
-        public void CreateProcessWithPseudoConsole_WhenExecutableNotFound_ThenThrowsException()
+        public void CreateProcessWithPseudoConsole_WhenExecutableNotFound()
         {
             var factory = new Win32ProcessFactory();
 
@@ -208,7 +208,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public void CreateProcessAsUser_WhenUsingInvalidLocalCredentialsForNetonlyLogon_ThenCreateProcessAsUserThrowsException()
+        public void CreateProcessAsUser_WhenUsingInvalidLocalCredentialsForNetonlyLogon()
         {
             var factory = new Win32ProcessFactory();
 

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWtsSession.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWtsSession.cs
@@ -50,7 +50,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         //---------------------------------------------------------------------
 
         [Test]
-        public void FromProcessId_WhenPidIsFromCurrentProcess_ThenFromProcessIdReturnsSession()
+        public void FromProcessId_WhenPidIsFromCurrentProcess()
         {
             var session = WtsSession.FromProcessId((uint)Process.GetCurrentProcess().Id);
             Assert.That(session, Is.Not.Null);

--- a/sources/Google.Solutions.Platform.Test/Dispatch/TestWtsSession.cs
+++ b/sources/Google.Solutions.Platform.Test/Dispatch/TestWtsSession.cs
@@ -58,7 +58,7 @@ namespace Google.Solutions.Platform.Test.Dispatch
         }
 
         [Test]
-        public void FromProcessId_WhenPidNotFound_ThenFromProcessIdThrowsException()
+        public void FromProcessId_WhenPidNotFound()
         {
             Assert.Throws<DispatchException>(
                 () => WtsSession.FromProcessId(uint.MaxValue));

--- a/sources/Google.Solutions.Platform.Test/IO/TestWin32Filename.cs
+++ b/sources/Google.Solutions.Platform.Test/IO/TestWin32Filename.cs
@@ -92,7 +92,7 @@ namespace Google.Solutions.Platform.Test.IO
         }
 
         [Test]
-        public void EscapeFilename_WhenFilenameNotWin32Compliant_ThenEscapeFilenameReturnsCompliantName()
+        public void EscapeFilename_WhenFilenameNotWin32Compliant()
         {
             Assert.That(Win32Filename.IsValidFilename(Win32Filename.EscapeFilename(".")), Is.True);
             Assert.That(Win32Filename.IsValidFilename(Win32Filename.EscapeFilename("file.")), Is.True);

--- a/sources/Google.Solutions.Platform.Test/Interop/TestSafeHandleExtensions.cs
+++ b/sources/Google.Solutions.Platform.Test/Interop/TestSafeHandleExtensions.cs
@@ -67,7 +67,7 @@ namespace Google.Solutions.Platform.Test.Interop
         //---------------------------------------------------------------------
 
         [Test]
-        public void Wait_WhenTimeoutElapses_ThenWaitAsyncThrowsException()
+        public void Wait_WhenTimeoutElapses()
         {
             using (var cts = new CancellationTokenSource())
             using (var ev = new ManualResetEvent(false))
@@ -80,7 +80,7 @@ namespace Google.Solutions.Platform.Test.Interop
         }
 
         [Test]
-        public void Wait_WhenCancelled_ThenWaitAsyncThrowsException()
+        public void Wait_WhenCancelled()
         {
             using (var ev = new ManualResetEvent(false))
             using (var cts = new CancellationTokenSource())

--- a/sources/Google.Solutions.Platform.Test/Interop/TestSafeHandleExtensions.cs
+++ b/sources/Google.Solutions.Platform.Test/Interop/TestSafeHandleExtensions.cs
@@ -37,7 +37,7 @@ namespace Google.Solutions.Platform.Test.Interop
         //---------------------------------------------------------------------
 
         [Test]
-        public void ToWaitHandle_WhenTransferOwnershipIsFalse_ThenToWaitHandleReturnsNonOwningHandle()
+        public void ToWaitHandle_WhenTransferOwnershipIsFalse()
         {
             using (var handle = Process.GetCurrentProcess().SafeHandle)
             {
@@ -51,7 +51,7 @@ namespace Google.Solutions.Platform.Test.Interop
         }
 
         [Test]
-        public void ToWaitHandle_WhenTransferOwnershipIsTrue_ThenToWaitHandleReturnsOwningHandle()
+        public void ToWaitHandle_WhenTransferOwnershipIsTrue()
         {
             var handle = Process.GetCurrentProcess().SafeHandle;
             var waitHandle = handle.ToWaitHandle(false);
@@ -94,7 +94,7 @@ namespace Google.Solutions.Platform.Test.Interop
         }
 
         [Test]
-        public async Task Wait_WhenSignalled_ThenWaitAsyncReturns()
+        public async Task Wait_WhenSignalled()
         {
             using (var ev = new ManualResetEvent(true))
             {

--- a/sources/Google.Solutions.Platform.Test/Net/TestBrowser.cs
+++ b/sources/Google.Solutions.Platform.Test/Net/TestBrowser.cs
@@ -28,13 +28,13 @@ namespace Google.Solutions.Platform.Test.Net
     public class TestBrowser
     {
         [Test]
-        public void Get_WhenPreferenceIsDefault_ThenGetReturnsDefaultBrowser()
+        public void Get_WhenPreferenceIsDefault()
         {
             Assert.That(Browser.Get(BrowserPreference.Default), Is.SameAs(Browser.Default));
         }
 
         [Test]
-        public void Get_WhenPreferenceIsChrome_ThenGetReturnsDefaultBrowser()
+        public void Get_WhenPreferenceIsChrome()
         {
             if (!ChromeBrowser.IsAvailable)
             {

--- a/sources/Google.Solutions.Platform.Test/Net/TestBrowserProtocolRegistry.cs
+++ b/sources/Google.Solutions.Platform.Test/Net/TestBrowserProtocolRegistry.cs
@@ -41,14 +41,14 @@ namespace Google.Solutions.Platform.Test.Net
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsRegistered_WhenProtocolNotRegistered_ThenIsRegisteredReturnsFalse()
+        public void IsRegistered_WhenProtocolNotRegistered()
         {
             var registry = new BrowserProtocolRegistry();
             Assert.That(registry.IsRegistered("unknown-scheme", "app.exe"), Is.False);
         }
 
         [Test]
-        public void IsRegistered_WhenProtocolRegisteredByDifferentApp_ThenIsRegisteredReturnsFalse()
+        public void IsRegistered_WhenProtocolRegisteredByDifferentApp()
         {
             var registry = new BrowserProtocolRegistry();
             registry.Register(TestScheme, "Test", "app.exe");
@@ -58,7 +58,7 @@ namespace Google.Solutions.Platform.Test.Net
         }
 
         [Test]
-        public void IsRegistered_WhenProtocolRegistered_ThenIsRegisteredReturnsTrue()
+        public void IsRegistered_WhenProtocolRegistered()
         {
             var registry = new BrowserProtocolRegistry();
             registry.Register(TestScheme, "Test", "app.exe");

--- a/sources/Google.Solutions.Platform.Test/Net/TestChromeCertificateSelector.cs
+++ b/sources/Google.Solutions.Platform.Test/Net/TestChromeCertificateSelector.cs
@@ -44,7 +44,7 @@ namespace Google.Solutions.Platform.Test.Net
         //---------------------------------------------------------------------
 
         [Test]
-        public void TryParse_WhenJsonMalformed_ThenTryParseReturnsFalse()
+        public void TryParse_WhenJsonMalformed()
         {
             Assert.That(ChromeCertificateSelector.TryParse(
                 "{asd'",
@@ -59,7 +59,7 @@ namespace Google.Solutions.Platform.Test.Net
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsMatch_WhenUrlMismatches_ThenIsMatchReturnsFalse()
+        public void IsMatch_WhenUrlMismatches()
         {
             var selector = ChromeCertificateSelector.Parse(
                 @"{
@@ -80,7 +80,7 @@ namespace Google.Solutions.Platform.Test.Net
         }
 
         [Test]
-        public void IsMatch_WhenUrlAndFilterEmpty_ThenIsMatchReturnsTrue()
+        public void IsMatch_WhenUrlAndFilterEmpty()
         {
             var selector = ChromeCertificateSelector.Parse(
                 @"{
@@ -99,7 +99,7 @@ namespace Google.Solutions.Platform.Test.Net
         }
 
         [Test]
-        public void IsMatch_WhenUrlMatchesAndFilterEmpty_ThenIsMatchReturnsTrue()
+        public void IsMatch_WhenUrlMatchesAndFilterEmpty()
         {
             var selector = ChromeCertificateSelector.Parse(
                 @"{
@@ -124,7 +124,7 @@ namespace Google.Solutions.Platform.Test.Net
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsMatch_WhenUrlAndIssuerMatchesBySingleField_ThenIsMatchReturnsTrue()
+        public void IsMatch_WhenUrlAndIssuerMatchesBySingleField()
         {
             var selector = ChromeCertificateSelector.Parse(
                 @"{
@@ -155,7 +155,7 @@ namespace Google.Solutions.Platform.Test.Net
         }
 
         [Test]
-        public void IsMatch_WhenUrlAndIssuerMatchByAllFields_ThenIsMatchReturnsTrue()
+        public void IsMatch_WhenUrlAndIssuerMatchByAllFields()
         {
             var selector = ChromeCertificateSelector.Parse(
                 @"{
@@ -191,7 +191,7 @@ namespace Google.Solutions.Platform.Test.Net
         }
 
         [Test]
-        public void IsMatch_WhenUrlAndIssuerMatchButSubjectMismatches_ThenIsMatchReturnsFalse()
+        public void IsMatch_WhenUrlAndIssuerMatchButSubjectMismatches()
         {
             var selector = ChromeCertificateSelector.Parse(
                 @"{
@@ -223,7 +223,7 @@ namespace Google.Solutions.Platform.Test.Net
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsMatch_WhenUrlAndSubjectMatchesBySingleField_ThenIsMatchReturnsTrue()
+        public void IsMatch_WhenUrlAndSubjectMatchesBySingleField()
         {
             var selector = ChromeCertificateSelector.Parse(
                 @"{
@@ -254,7 +254,7 @@ namespace Google.Solutions.Platform.Test.Net
         }
 
         [Test]
-        public void IsMatch_WhenUrlAndSubjectMatchByAllFields_ThenIsMatchReturnsTrue()
+        public void IsMatch_WhenUrlAndSubjectMatchByAllFields()
         {
             var selector = ChromeCertificateSelector.Parse(
                 @"{
@@ -294,7 +294,7 @@ namespace Google.Solutions.Platform.Test.Net
         //---------------------------------------------------------------------
 
         [Test]
-        public void IsMatch_WhenThumbprintMatches_ThenIsMatchReturnsTrue()
+        public void IsMatch_WhenThumbprintMatches()
         {
             var selector = ChromeCertificateSelector.Parse(
                 @"{
@@ -324,7 +324,7 @@ namespace Google.Solutions.Platform.Test.Net
         }
 
         [Test]
-        public void IsMatch_WhenThumbprintMatchesButSubjectDoesnt_ThenIsMatchReturnsFalse()
+        public void IsMatch_WhenThumbprintMatchesButSubjectDoesnt()
         {
             var selector = ChromeCertificateSelector.Parse(
                 @"{

--- a/sources/Google.Solutions.Platform.Test/Net/TestChromePolicyUrlPattern.cs
+++ b/sources/Google.Solutions.Platform.Test/Net/TestChromePolicyUrlPattern.cs
@@ -29,7 +29,7 @@ namespace Google.Solutions.Platform.Test.Net
     public class TestChromePolicyUrlPattern
     {
         [Test]
-        public void Parse_WhenPatternIsMalformed_ThenParseThrowsException()
+        public void Parse_WhenPatternIsMalformed()
         {
             Assert.Throws<ArgumentException>(
                 () => ChromePolicyUrlPattern.Parse("//"));

--- a/sources/Google.Solutions.Platform.Test/Net/TestNetworkCredentialExtensions.cs
+++ b/sources/Google.Solutions.Platform.Test/Net/TestNetworkCredentialExtensions.cs
@@ -33,7 +33,7 @@ namespace Google.Solutions.Platform.Test.Net
         //---------------------------------------------------------------------
 
         [Test]
-        public void Normalize_WhenUserInUpnFormat_ThenNormalizeReturnsCredential()
+        public void Normalize_WhenUserInUpnFormat()
         {
             var normalized = new NetworkCredential(
                 "user@example.org",
@@ -45,7 +45,7 @@ namespace Google.Solutions.Platform.Test.Net
         }
 
         [Test]
-        public void Normalize_WhenUserInNetBiosFormat_ThenNormalizeReturnsCredential()
+        public void Normalize_WhenUserInNetBiosFormat()
         {
             var normalized = new NetworkCredential(
                 "EXAMPLE\\user",
@@ -57,7 +57,7 @@ namespace Google.Solutions.Platform.Test.Net
         }
 
         [Test]
-        public void Normalize_WhenDomainSpecifiedSeparately_ThenNormalizeReturnsCredential()
+        public void Normalize_WhenDomainSpecifiedSeparately()
         {
             var normalized = new NetworkCredential(
                 "user",
@@ -69,7 +69,7 @@ namespace Google.Solutions.Platform.Test.Net
         }
 
         [Test]
-        public void Normalize_WhenDomainMissing_ThenNormalizeReturnsCredential()
+        public void Normalize_WhenDomainMissing()
         {
             var normalized = new NetworkCredential(
                 "user",

--- a/sources/Google.Solutions.Platform.Test/Net/TestTcpTable.cs
+++ b/sources/Google.Solutions.Platform.Test/Net/TestTcpTable.cs
@@ -29,7 +29,7 @@ namespace Google.Solutions.Platform.Test.Net
     public class TestTcpTable
     {
         [Test]
-        public void GetTcpTable2_WhenRunningOnWindows_ThenGetTcpTable2ReturnsEntryForRpcss()
+        public void GetTcpTable2_WhenRunningOnWindows()
         {
             var netlogonListeningPorts = TcpTable.GetTcpTable2()
                 .Where(r => r.State == TcpTable.MibTcpState.MIB_TCP_STATE_LISTEN)

--- a/sources/Google.Solutions.Platform.Test/Security/Cryptography/TestCertificateStore.cs
+++ b/sources/Google.Solutions.Platform.Test/Security/Cryptography/TestCertificateStore.cs
@@ -107,7 +107,7 @@ namespace Google.Solutions.Platform.Test.Security.Cryptography
         //---------------------------------------------------------------------
 
         [Test]
-        public void ListUserCertificates_WhenPredicateMatches_ThenListUserCertificatesReturnsUserCertificate()
+        public void ListUserCertificates_WhenPredicateMatches()
         {
             CertificateStore.AddUserCertitficate(ExampleCertificate);
 
@@ -124,7 +124,7 @@ namespace Google.Solutions.Platform.Test.Security.Cryptography
         }
 
         [Test]
-        public void ListUserCertificates_WhenPredicateDoesNotMatch_ThenListUserCertificatesReturnsEmpty()
+        public void ListUserCertificates_WhenPredicateDoesNotMatch()
         {
             CertificateStore.AddUserCertitficate(ExampleCertificate);
 

--- a/sources/Google.Solutions.Platform.Test/Security/Cryptography/TestKeyStore.cs
+++ b/sources/Google.Solutions.Platform.Test/Security/Cryptography/TestKeyStore.cs
@@ -90,7 +90,7 @@ namespace Google.Solutions.Platform.Test.Security.Cryptography
         }
 
         [Test]
-        public void OpenKey_WhenTypeIsInvalid_ThenOpenPersistentKeyThrowsException()
+        public void OpenKey_WhenTypeIsInvalid()
         {
             var keyType = new KeyType(CngAlgorithm.Rsa, 1);
 
@@ -152,7 +152,7 @@ namespace Google.Solutions.Platform.Test.Security.Cryptography
         }
 
         [Test]
-        public void OpenKey_WhenKeyFoundButAlgorithmMismatches_ThenOpenPersistentKeyThrowsException()
+        public void OpenKey_WhenKeyFoundButAlgorithmMismatches()
         {
             using (this.Store.OpenKey(
                 IntPtr.Zero,
@@ -172,7 +172,7 @@ namespace Google.Solutions.Platform.Test.Security.Cryptography
         }
 
         [Test]
-        public void OpenKey_WhenKeyFoundButSizeMismatches_ThenOpenPersistentKeyThrowsException()
+        public void OpenKey_WhenKeyFoundButSizeMismatches()
         {
             using (this.Store.OpenKey(
                 IntPtr.Zero,
@@ -192,7 +192,7 @@ namespace Google.Solutions.Platform.Test.Security.Cryptography
         }
 
         [Test]
-        public void OpenKey_WhenKeyFoundButUsageMismatches_ThenOpenPersistentKeyThrowsException()
+        public void OpenKey_WhenKeyFoundButUsageMismatches()
         {
             using (this.Store.OpenKey(
                 IntPtr.Zero,

--- a/sources/Google.Solutions.Platform.Test/TestUserEnvironment.cs
+++ b/sources/Google.Solutions.Platform.Test/TestUserEnvironment.cs
@@ -65,13 +65,13 @@ namespace Google.Solutions.Platform.Test
         //---------------------------------------------------------------------
 
         [Test]
-        public void TryResolveAppPath_WhenAppUnknown_ThenTryResolveAppPathReturnsFalse()
+        public void TryResolveAppPath_WhenAppUnknown()
         {
             Assert.That(UserEnvironment.TryResolveAppPath("doesnotexist.exe", out var _), Is.False);
         }
 
         [Test]
-        public void TryResolveAppPath_WhenAppRegistered_ThenTryResolveAppPathReturnsPath()
+        public void TryResolveAppPath_WhenAppRegistered()
         {
             Assert.That(UserEnvironment.TryResolveAppPath("Powershell.EXE", out var powershell), Is.True);
             Assert.That(powershell, Is.Not.Null);

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfBool.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfBool.cs
@@ -269,7 +269,7 @@ namespace Google.Solutions.Settings.Test
         }
 
         [Test]
-        public void SetAnyValue_WhenValueIsOfWrongType_ThenThrowsException()
+        public void SetAnyValue_WhenValueIsOfWrongType()
         {
             using (var key = CreateSettingsStore())
             {

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfEnum.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfEnum.cs
@@ -296,7 +296,7 @@ namespace Google.Solutions.Settings.Test
         }
 
         [Test]
-        public void SetAnyValue_WhenValueIsOfWrongType_ThenThrowsException()
+        public void SetAnyValue_WhenValueIsOfWrongType()
         {
             using (var key = CreateSettingsStore())
             {

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfEnumFlags.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfEnumFlags.cs
@@ -275,7 +275,7 @@ namespace Google.Solutions.Settings.Test
         }
 
         [Test]
-        public void SetAnyValue_WhenValueIsOfWrongType_ThenThrowsException()
+        public void SetAnyValue_WhenValueIsOfWrongType()
         {
             using (var key = CreateSettingsStore())
             {

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfInt.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfInt.cs
@@ -319,7 +319,7 @@ namespace Google.Solutions.Settings.Test
         }
 
         [Test]
-        public void SetAnyValue_WhenValueIsOfWrongType_ThenThrowsException()
+        public void SetAnyValue_WhenValueIsOfWrongType()
         {
             using (var key = CreateSettingsStore())
             {

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfLong.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfLong.cs
@@ -294,7 +294,7 @@ namespace Google.Solutions.Settings.Test
         }
 
         [Test]
-        public void SetAnyValue_WhenValueIsOfWrongType_ThenThrowsException()
+        public void SetAnyValue_WhenValueIsOfWrongType()
         {
             using (var key = CreateSettingsStore())
             {

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfSecureString.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfSecureString.cs
@@ -296,7 +296,7 @@ namespace Google.Solutions.Settings.Test
         //---------------------------------------------------------------------
 
         [Test]
-        public void SetAnyValue_WhenValueIsOfWrongType_ThenThrowsException()
+        public void SetAnyValue_WhenValueIsOfWrongType()
         {
             using (var key = CreateSettingsStore())
             {

--- a/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfString.cs
+++ b/sources/Google.Solutions.Settings.Test/RegistrySettingsStoreOfString.cs
@@ -250,7 +250,7 @@ namespace Google.Solutions.Settings.Test
         }
 
         [Test]
-        public void SetAnyValue_WhenValueIsOfWrongType_ThenThrowsException()
+        public void SetAnyValue_WhenValueIsOfWrongType()
         {
             using (var key = CreateSettingsStore())
             {

--- a/sources/Google.Solutions.Settings.Test/TestDictionaryValueAccessor.cs
+++ b/sources/Google.Solutions.Settings.Test/TestDictionaryValueAccessor.cs
@@ -58,7 +58,7 @@ namespace Google.Solutions.Settings.Test
             protected override SecureString SampleData => null;
 
             [Test]
-            public override void TryRead_WhenValueSet_ThenTryReadReturnsTrue()
+            public override void TryRead_WhenValueSet()
             {
                 var dictionary = new Dictionary<string, string>();
                 var accessor = CreateAccessor("test");

--- a/sources/Google.Solutions.Settings.Test/TestDictionaryValueAccessorBase.cs
+++ b/sources/Google.Solutions.Settings.Test/TestDictionaryValueAccessorBase.cs
@@ -39,7 +39,7 @@ namespace Google.Solutions.Settings.Test
         //---------------------------------------------------------------------
 
         [Test]
-        public void TryRead_WhenValueNotSet_ThenTryReadReturnsFalse()
+        public void TryRead_WhenValueNotSet()
         {
             var dictionary = new Dictionary<string, string>();
             var accessor = CreateAccessor("test");
@@ -48,7 +48,7 @@ namespace Google.Solutions.Settings.Test
         }
 
         [Test]
-        public virtual void TryRead_WhenValueSet_ThenTryReadReturnsTrue()
+        public virtual void TryRead_WhenValueSet()
         {
             var dictionary = new Dictionary<string, string>();
             var accessor = CreateAccessor("test");
@@ -63,7 +63,7 @@ namespace Google.Solutions.Settings.Test
         //---------------------------------------------------------------------
 
         [Test]
-        public void Delete_WhenValueNotSet_ThenDeleteReturns()
+        public void Delete_WhenValueNotSet()
         {
             var dictionary = new Dictionary<string, string>();
             var accessor = CreateAccessor("test");

--- a/sources/Google.Solutions.Settings.Test/TestRegistrySettingsStore.cs
+++ b/sources/Google.Solutions.Settings.Test/TestRegistrySettingsStore.cs
@@ -33,7 +33,7 @@ namespace Google.Solutions.Settings.Test
         //---------------------------------------------------------------------
 
         [Test]
-        public void Read_WhenTypeUnsupported_ThenReadThrowsException()
+        public void Read_WhenTypeUnsupported()
         {
             using (var key = new RegistrySettingsStore(
                 RegistryKeyPath.ForCurrentTest().CreateKey()))
@@ -105,7 +105,7 @@ namespace Google.Solutions.Settings.Test
         //---------------------------------------------------------------------
 
         [Test]
-        public void SetValue_WhenCustomValidationFails_ThenSetValueThrowsException()
+        public void SetValue_WhenCustomValidationFails()
         {
             using (var key = new RegistrySettingsStore(
                 RegistryKeyPath.ForCurrentTest().CreateKey()))

--- a/sources/Google.Solutions.Settings.Test/TestRegistryValueAccessor.cs
+++ b/sources/Google.Solutions.Settings.Test/TestRegistryValueAccessor.cs
@@ -85,7 +85,7 @@ namespace Google.Solutions.Settings.Test
             }
 
             [Test]
-            public override void TryRead_WhenValueSet_ThenTryReadReturnsTrue()
+            public override void TryRead_WhenValueSet()
             {
                 using (var key = RegistryKeyPath.ForCurrentTest().CreateKey())
                 {

--- a/sources/Google.Solutions.Settings.Test/TestRegistryValueAccessorBase.cs
+++ b/sources/Google.Solutions.Settings.Test/TestRegistryValueAccessorBase.cs
@@ -43,7 +43,7 @@ namespace Google.Solutions.Settings.Test
         //---------------------------------------------------------------------
 
         [Test]
-        public void TryRead_WhenValueNotSet_ThenTryReadReturnsFalse()
+        public void TryRead_WhenValueNotSet()
         {
             using (var key = RegistryKeyPath.ForCurrentTest().CreateKey())
             {
@@ -54,7 +54,7 @@ namespace Google.Solutions.Settings.Test
         }
 
         [Test]
-        public virtual void TryRead_WhenValueSet_ThenTryReadReturnsTrue()
+        public virtual void TryRead_WhenValueSet()
         {
             using (var key = RegistryKeyPath.ForCurrentTest().CreateKey())
             {
@@ -84,7 +84,7 @@ namespace Google.Solutions.Settings.Test
         //---------------------------------------------------------------------
 
         [Test]
-        public void Delete_WhenValueNotSet_ThenDeleteReturns()
+        public void Delete_WhenValueNotSet()
         {
             using (var key = RegistryKeyPath.ForCurrentTest().CreateKey())
             {

--- a/sources/Google.Solutions.Settings.Test/TestRegistryValueAccessorBase.cs
+++ b/sources/Google.Solutions.Settings.Test/TestRegistryValueAccessorBase.cs
@@ -67,7 +67,7 @@ namespace Google.Solutions.Settings.Test
         }
 
         [Test]
-        public void TryRead_WhenValueHasWrongKind_ThenTryReadThrowsException()
+        public void TryRead_WhenValueHasWrongKind()
         {
             using (var key = RegistryKeyPath.ForCurrentTest().CreateKey())
             {

--- a/sources/Google.Solutions.Ssh.Test/Cryptography/TestECPointEncoding.cs
+++ b/sources/Google.Solutions.Ssh.Test/Cryptography/TestECPointEncoding.cs
@@ -35,7 +35,7 @@ namespace Google.Solutions.Ssh.Test.Cryptography
         //--------------------------------------------------------------------
 
         [Test]
-        public void Encode_WhenKeySizeDoesNotMatchPoint_ThenEncodeThrowsException()
+        public void Encode_WhenKeySizeDoesNotMatchPoint()
         {
             using (var key = new ECDsaCng(ECCurve.NamedCurves.nistP256))
             {
@@ -74,7 +74,7 @@ namespace Google.Solutions.Ssh.Test.Cryptography
         }
 
         [Test]
-        public void Decode_WhenEncodedDataUncompressedButWithoutTag_ThenDecodeThrowsException()
+        public void Decode_WhenEncodedDataUncompressedButWithoutTag()
         {
             var uncompressedSizeData = new byte[256 / 8 * 2 + 1];
             uncompressedSizeData[0] = 1; // Junk.
@@ -84,7 +84,7 @@ namespace Google.Solutions.Ssh.Test.Cryptography
         }
 
         [Test]
-        public void Decode_WhenEncodedDataNotUncompressed_ThenDecodeThrowsException()
+        public void Decode_WhenEncodedDataNotUncompressed()
         {
             Assert.Throws<NotImplementedException>(
                 () => ECPointEncoding.Decode(

--- a/sources/Google.Solutions.Ssh.Test/Cryptography/TestPublicKey.cs
+++ b/sources/Google.Solutions.Ssh.Test/Cryptography/TestPublicKey.cs
@@ -80,7 +80,7 @@ namespace Google.Solutions.Ssh.Test.Cryptography
         //---------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenTypesDifferent_ThenEqualsReturnsFalse()
+        public void Equals_WhenTypesDifferent()
         {
             using (var lhs = new SamplePublicKey("type1", Convert.FromBase64String("ABCD")))
             using (var rhs = new SamplePublicKey("type2", Convert.FromBase64String("ABCD")))
@@ -91,7 +91,7 @@ namespace Google.Solutions.Ssh.Test.Cryptography
         }
 
         [Test]
-        public void Equals_WhenWireFormatDifferent_ThenEqualsReturnsFalse()
+        public void Equals_WhenWireFormatDifferent()
         {
             using (var lhs = new SamplePublicKey("type", Convert.FromBase64String("ABCD")))
             using (var rhs = new SamplePublicKey("type", Convert.FromBase64String("ABCE")))
@@ -102,7 +102,7 @@ namespace Google.Solutions.Ssh.Test.Cryptography
         }
 
         [Test]
-        public void Equals_WhenTypesAndWireFormatEqual_ThenEqualsReturnsTrue()
+        public void Equals_WhenTypesAndWireFormatEqual()
         {
             using (var lhs = new SamplePublicKey("type", Convert.FromBase64String("ABCD")))
             using (var rhs = new SamplePublicKey("type", Convert.FromBase64String("ABCD")))

--- a/sources/Google.Solutions.Ssh.Test/Cryptography/TestRsaSigner.cs
+++ b/sources/Google.Solutions.Ssh.Test/Cryptography/TestRsaSigner.cs
@@ -34,7 +34,7 @@ namespace Google.Solutions.Ssh.Test.Cryptography
         //---------------------------------------------------------------------
 
         [Test]
-        public void Sign_WhenChallengeRequiresSha512_ThenSignReturnsSignature()
+        public void Sign_WhenChallengeRequiresSha512()
         {
             var challengeBlob = Convert.FromBase64String(
                 "AAAAIEVr/Hy4lWvHE87XI+c+jchQ4kkz/gCEpWzdIYU+PLvjMgAAAAh0ZX" +
@@ -65,7 +65,7 @@ namespace Google.Solutions.Ssh.Test.Cryptography
         }
 
         [Test]
-        public void Sign_WhenChallengeRequiresSha256_ThenSignReturnsSignature()
+        public void Sign_WhenChallengeRequiresSha256()
         {
             var challengeBlob = Convert.FromBase64String(
                 "AAAAIEVr/Hy4lWvHE87XI+c+jchQ4kkz/gCEpWzdIYU+PLvjMgAAAAh0ZX" +

--- a/sources/Google.Solutions.Ssh.Test/Native/TestEnvironmentVariable.cs
+++ b/sources/Google.Solutions.Ssh.Test/Native/TestEnvironmentVariable.cs
@@ -32,7 +32,7 @@ namespace Google.Solutions.Ssh.Test.Native
         //----------------------------------------------------------------------
 
         [Test]
-        public void Equals_WhenVariablesAreEquivalent_ThenEqualsReturnsTrue()
+        public void Equals_WhenVariablesAreEquivalent()
         {
             var ref1 = new EnvironmentVariable("NAME", "value", false);
             var ref2 = new EnvironmentVariable("NAME", "value", false);
@@ -44,7 +44,7 @@ namespace Google.Solutions.Ssh.Test.Native
         }
 
         [Test]
-        public void Equals_WhenVariablesAreSame_ThenEqualsReturnsTrue()
+        public void Equals_WhenVariablesAreSame()
         {
             var ref1 = new EnvironmentVariable("NAME", "value", true);
             var ref2 = ref1;
@@ -56,7 +56,7 @@ namespace Google.Solutions.Ssh.Test.Native
         }
 
         [Test]
-        public void Equals_WhenVariablesAreNotEquivalent_ThenEqualsReturnsFalse()
+        public void Equals_WhenVariablesAreNotEquivalent()
         {
             var ref1 = new EnvironmentVariable("NAME", "", true);
             var ref2 = new EnvironmentVariable("NAME", "", false);

--- a/sources/Google.Solutions.Ssh.Test/Native/TestLibssh2Session.cs
+++ b/sources/Google.Solutions.Ssh.Test/Native/TestLibssh2Session.cs
@@ -43,7 +43,7 @@ namespace Google.Solutions.Ssh.Test.Native
         //---------------------------------------------------------------------
 
         [Test]
-        public void Handle_WhenNotInitialized_ThenHandleThrowsException()
+        public void Handle_WhenNotInitialized()
         {
             using (var session = CreateSession())
             {
@@ -232,7 +232,7 @@ namespace Google.Solutions.Ssh.Test.Native
         }
 
         [Test]
-        public void GetSupportedAlgorithms_WhenRequestingInvalidType_ThenSupportedAlgorithmsThrowsException()
+        public void GetSupportedAlgorithms_WhenRequestingInvalidType()
         {
             using (var session = CreateSession())
             {
@@ -288,7 +288,7 @@ namespace Google.Solutions.Ssh.Test.Native
         }
 
         [Test]
-        public void SetPreferredMethods_WhenPreferredMethodIsEmpty_ThenSetPreferredMethodsThrowsNotSupportedError()
+        public void SetPreferredMethods_WhenPreferredMethodIsEmpty()
         {
             using (var session = CreateSession())
             {
@@ -333,7 +333,7 @@ namespace Google.Solutions.Ssh.Test.Native
         }
 
         [Test]
-        public void Connect_WhenPortIsNotSsh_ThenHandshakeThrowsDisconnect()
+        public void Connect_WhenPortIsNotSsh()
         {
             using (var session = CreateSession())
             {

--- a/sources/Google.Solutions.Testing.Apis/EquatableFixtureBase.cs
+++ b/sources/Google.Solutions.Testing.Apis/EquatableFixtureBase.cs
@@ -50,7 +50,7 @@ namespace Google.Solutions.Testing.Apis
         //---------------------------------------------------------------------
 
         [Test]
-        public void WhenOtherIsNull_ThenEqualsReturnsFalse()
+        public void WhenOtherIsNull()
         {
             var obj = CreateInstance();
 
@@ -62,7 +62,7 @@ namespace Google.Solutions.Testing.Apis
         }
 
         [Test]
-        public void WhenOtherIsDifferent_ThenEqualsReturnsFalse()
+        public void WhenOtherIsDifferent()
         {
             var obj = CreateInstance();
 
@@ -70,7 +70,7 @@ namespace Google.Solutions.Testing.Apis
         }
 
         [Test]
-        public void WhenOtherIsOfDifferentType_ThenEqualsReturnsFalse()
+        public void WhenOtherIsOfDifferentType()
         {
             var obj = CreateInstance();
 
@@ -78,7 +78,7 @@ namespace Google.Solutions.Testing.Apis
         }
 
         [Test]
-        public void WhenObjectsAreSame_ThenEqualsReturnsTrue()
+        public void WhenObjectsAreSame()
         {
             var obj = CreateInstance();
             var other = obj;
@@ -88,7 +88,7 @@ namespace Google.Solutions.Testing.Apis
         }
 
         [Test]
-        public void WhenObjectsAreEquivalent_ThenEqualsReturnsTrue()
+        public void WhenObjectsAreEquivalent()
         {
             var obj1 = CreateInstance();
             var obj2 = CreateInstance();


### PR DESCRIPTION
Remove method name suffixes that merely indicate return values or
exception types.