### PR TITLE
b/526392902 Warn when applying display settings fails

### DIFF
--- a/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/RdpView.cs
+++ b/sources/Google.Solutions.IapDesktop.Extensions.Session/ToolWindows/Session/RdpView.cs
@@ -32,6 +32,7 @@ using Google.Solutions.IapDesktop.Core.ObjectModel;
 using Google.Solutions.IapDesktop.Extensions.Session.Properties;
 using Google.Solutions.IapDesktop.Extensions.Session.Protocol.Rdp;
 using Google.Solutions.Mvvm.Binding;
+using Google.Solutions.Mvvm.Controls;
 using Google.Solutions.Settings.Collection;
 using Google.Solutions.Terminal.Controls;
 using System;
@@ -55,6 +56,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
         private readonly IRepository<IApplicationSettings> settingsRepository;
 
         private Bound<RdpViewModel> viewModel;
+        private readonly ITaskDialog taskDialog;
 
         // For testing only.
         internal event EventHandler? AuthenticationWarningDisplayed;
@@ -92,6 +94,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
             ToolWindowStateRepository stateRepository,
             IEventQueue eventQueue,
             IExceptionDialog exceptionDialog,
+            ITaskDialog taskDialog,
             IBindingContext bindingContext)
             : base(
                   mainWindow,
@@ -100,6 +103,7 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
                   exceptionDialog,
                   bindingContext)
         {
+            this.taskDialog = taskDialog;
             this.settingsRepository = settingsRepository;
             this.Icon = Resources.ComputerBlue_16;
         }
@@ -155,6 +159,20 @@ namespace Google.Solutions.IapDesktop.Extensions.Session.ToolWindows.Session
                 this.Client!.MainWindow = (Form)this.MainWindow;
                 this.Client.ServerAuthenticationWarningDisplayed += (_, args)
                     => this.AuthenticationWarningDisplayed?.Invoke(this, args);
+                this.Client.DisplaySettingsConflict += (_, args)
+                    =>
+                {
+                    var dialog = new TaskDialogParameters(
+                        $"Display settings",
+                        "Problem adjusting display settings",
+                        args.Exception.Message)
+                    {
+                        Icon = TaskDialogIcon.Warning,
+                    };
+                    dialog.Buttons.Add(TaskDialogStandardButton.OK);
+
+                    this.taskDialog.ShowDialog(this, dialog);
+                };
 
                 //
                 // Basic connection settings.

--- a/sources/Google.Solutions.Terminal/Controls/RdpClient.cs
+++ b/sources/Google.Solutions.Terminal/Controls/RdpClient.cs
@@ -68,6 +68,8 @@ namespace Google.Solutions.Terminal.Controls
 
         private int keysSent = 0;
 
+        public event EventHandler<ExceptionEventArgs>? DisplaySettingsConflict;
+
         public RdpClient()
         {
             this.client = new Google.Solutions.Tsc.MsRdpClient
@@ -883,29 +885,24 @@ namespace Google.Solutions.Terminal.Controls
             // 
             try
             {
-                if (this.DesktopScaleFactor is var desktopFactor)
-                {
-                    this.clientExtendedSettings.set_Property(
-                        "DesktopScaleFactor",
-                        desktopFactor);
-                }
-
-                if (this.DeviceScaleFactor is var deviceFactor)
-                {
-                    this.clientExtendedSettings.set_Property(
-                        "DeviceScaleFactor",
-                        deviceFactor);
-                }
+                this.clientExtendedSettings.set_Property(
+                    "DesktopScaleFactor",
+                    this.DesktopScaleFactor);
+                this.clientExtendedSettings.set_Property(
+                    "DeviceScaleFactor",
+                    this.DeviceScaleFactor);
             }
-            catch (COMException e) when (e.HResult == (int)HRESULT.E_FAIL)
+            catch (COMException e) 
+            when (e.HResult == (int)HRESULT.E_FAIL ||
+                  e.HResult == (int)HRESULT.E_UNEXPECTED)
             {
                 //
                 // Applying the properties can fail spuriously. If that happens,
-                // rethrow with additional context information.
+                // raise an event, but don't abort the connection attempt.
                 //
-                var exception = new InvalidOperationException(
-                    $"The display scaling settings are invalid or could not be applied",
-                    e);
+                var exception = new RdpDisplaySettingsConflictException(
+                    "Some of your display scaling settings could not be " +
+                    "applied");
 
                 exception.Data["Attempt"] = this.connectionAttempt;
                 exception.Data["Desktop"] = this.DesktopScaleFactor;
@@ -913,7 +910,9 @@ namespace Google.Solutions.Terminal.Controls
                 exception.Data["Resize"] = this.EnableAutoResize;
                 exception.Data["Dpi"] = this.EnableDpiScaling;
 
-                throw exception;
+                this.DisplaySettingsConflict?.Invoke(
+                    this, 
+                    new ExceptionEventArgs(exception));
             }
 
             //

--- a/sources/Google.Solutions.Terminal/Controls/RdpExceptions.cs
+++ b/sources/Google.Solutions.Terminal/Controls/RdpExceptions.cs
@@ -259,4 +259,12 @@ namespace Google.Solutions.Terminal.Controls
             this.DisconnectReason = disconnectReason;
         }
     }
+
+    public class RdpDisplaySettingsConflictException : RdpException
+    {
+        internal RdpDisplaySettingsConflictException(string message) 
+            : base(message)
+        {
+        }
+    }
 }


### PR DESCRIPTION
Applying desktop/device scaling systems can fail
spuriously. If that happens, show a warning and
continue with defaults instead of crashing the
application.