### PR TITLE
b/526392902 Handle IAP 404 errors

### DIFF
--- a/sources/Google.Solutions.Iap/IapInstanceTarget.cs
+++ b/sources/Google.Solutions.Iap/IapInstanceTarget.cs
@@ -192,6 +192,18 @@ namespace Google.Solutions.Iap
                 //
                 throw new WebSocketConnectionDeniedException();
             }
+            catch (WebSocketException e)
+                when (e.InnerException is WebException webException &&
+                      webException?.Response is HttpWebResponse httpResponse &&
+                      httpResponse.StatusCode == HttpStatusCode.NotFound)
+            {
+                //
+                // Connection rejected because one of the resource
+                // coordinates (such as zone) doesn't exist.
+                //
+                throw new SshRelayBackendNotFoundException(
+                    "The zone or backend could not be found");
+            }
         }
 
         //---------------------------------------------------------------------


### PR DESCRIPTION
A valid zone now causes the IAP endpoint to
return a 404 error before allowing a WS connection to be established. Update logic accordingly.