### PR TITLE
Update external links to group policy reference

### DIFF
--- a/doc/site/sources/docs/toolwindow-connection-settings.md
+++ b/doc/site/sources/docs/toolwindow-connection-settings.md
@@ -238,13 +238,13 @@ These settings control which RDP security mechanism to apply.
                 When set to <b>Disabled</b>, IAP Desktop won't offer a <i>Remember me</i> option, and won't try
                 to log you in automatically unless you manually configure <a href="#windows-credentials">Windows credentials</a>.
                 <br><br>
-                Set this to <b>Disabled</b> for VMs that use the <a href="https://admx.help/?Category=Windows_10_2016&Policy=Microsoft.Policies.TerminalServer::TS_PASSWORD">Always prompt for password upon connection</a>
+                Set this to <b>Disabled</b> for VMs that use the <a href="https://gpsearch.azurewebsites.net/default.aspx?policyid=2471&lang=en-US#2471">Always prompt for password upon connection</a>
                 group policy setting to <a href="/iap-desktop/troubleshooting-rdp/#your-credentials-did-not-work-when-using-saved-credentials">
                 prevent duplicate password prompts</a>.
             </li>
             </ul>
             The setting is automatically set to <b>Disabled</b> if your local computer is subject to the 
-            <a href="https://admx.help/?Category=Windows_10_2016&Policy=Microsoft.Policies.TerminalServer::TS_CLIENT_DISABLE_PASSWORD_SAVING_2">
+            <a href="https://gpsearch.azurewebsites.net/default.aspx?policyid=2538&ref=1#2468">
             Do not allow passwords to be saved</a> group policy. 
         </td>
         <td>See description</td>

--- a/doc/site/sources/docs/toolwindow-connection-settings.md
+++ b/doc/site/sources/docs/toolwindow-connection-settings.md
@@ -238,13 +238,13 @@ These settings control which RDP security mechanism to apply.
                 When set to <b>Disabled</b>, IAP Desktop won't offer a <i>Remember me</i> option, and won't try
                 to log you in automatically unless you manually configure <a href="#windows-credentials">Windows credentials</a>.
                 <br><br>
-                Set this to <b>Disabled</b> for VMs that use the <a href="https://gpsearch.azurewebsites.net/default.aspx?policyid=2471&lang=en-US#2471">Always prompt for password upon connection</a>
+                Set this to <b>Disabled</b> for VMs that use the <a href="https://gpsearch.azurewebsites.net/default.aspx?policyid=2471">Always prompt for password upon connection</a>
                 group policy setting to <a href="/iap-desktop/troubleshooting-rdp/#your-credentials-did-not-work-when-using-saved-credentials">
                 prevent duplicate password prompts</a>.
             </li>
             </ul>
             The setting is automatically set to <b>Disabled</b> if your local computer is subject to the 
-            <a href="https://gpsearch.azurewebsites.net/default.aspx?policyid=2538&ref=1#2468">
+            <a href="https://gpsearch.azurewebsites.net/default.aspx?policyid=2468">
             Do not allow passwords to be saved</a> group policy. 
         </td>
         <td>See description</td>

--- a/doc/site/sources/docs/troubleshooting-rdp.md
+++ b/doc/site/sources/docs/troubleshooting-rdp.md
@@ -38,7 +38,7 @@ process is running, do the following:
 ### Check local policies
 
 If your local computer is managed by an organization, it's possible that your organization
-has [applied a policy that disables copy/paste for RDP :octicons-link-external-16:](https://gpsearch.azurewebsites.net/default.aspx?policyid=2471&lang=en-US#2508).
+has [applied a policy that disables copy/paste for RDP :octicons-link-external-16:](https://gpsearch.azurewebsites.net/default.aspx?policyid=2508).
 To check if this is the case, do the following:
 
 1.  On your local computer, right-click the **Start** button and select **Windows PowerShell**.
@@ -65,7 +65,7 @@ To check if this is the case, do the following:
 ### Check remote policies
 
 If the remote VM is managed by an organization, it's possible that your organization
-has [applied a policy that disables copy/paste for RDP :octicons-link-external-16:](https://gpsearch.azurewebsites.net/default.aspx?policyid=2471&lang=en-US#2508).
+has [applied a policy that disables copy/paste for RDP :octicons-link-external-16:](https://gpsearch.azurewebsites.net/default.aspx?policyid=2508).
 To check if this is the case, do the following:
 
 

--- a/doc/site/sources/docs/troubleshooting-rdp.md
+++ b/doc/site/sources/docs/troubleshooting-rdp.md
@@ -38,7 +38,7 @@ process is running, do the following:
 ### Check local policies
 
 If your local computer is managed by an organization, it's possible that your organization
-has [applied a policy that disables copy/paste for RDP :octicons-link-external-16:](https://learn.microsoft.com/en-us/azure/virtual-desktop/configure-device-redirections#disable-redirection-on-the-local-device).
+has [applied a policy that disables copy/paste for RDP :octicons-link-external-16:](https://gpsearch.azurewebsites.net/default.aspx?policyid=2471&lang=en-US#2508).
 To check if this is the case, do the following:
 
 1.  On your local computer, right-click the **Start** button and select **Windows PowerShell**.
@@ -65,7 +65,7 @@ To check if this is the case, do the following:
 ### Check remote policies
 
 If the remote VM is managed by an organization, it's possible that your organization
-has [applied a policy that disables copy/paste for RDP :octicons-link-external-16:](https://admx.help/?Category=Windows_10_2016&Policy=Microsoft.Policies.TerminalServer::TS_CLIENT_CLIPBOARD).
+has [applied a policy that disables copy/paste for RDP :octicons-link-external-16:](https://gpsearch.azurewebsites.net/default.aspx?policyid=2471&lang=en-US#2508).
 To check if this is the case, do the following:
 
 
@@ -106,7 +106,7 @@ by your current keyboard layout. Unsupported characters are replaced with `?`.
 After re-entering the same credentials again, the connection succeeds.
 
 This issue can be the intentional effect of the
-[Always prompt for password upon connection :octicons-link-external-16:](https://admx.help/?Category=Windows_10_2016&Policy=Microsoft.Policies.TerminalServer::TS_PASSWORD) 
+[Always prompt for password upon connection :octicons-link-external-16:](https://gpsearch.azurewebsites.net/default.aspx?policyid=2471&lang=en-US#2471) 
 group policy setting. This policy is configured by default on [CIS hardened images :octicons-link-external-16:](https://www.cisecurity.org/cis-hardened-images/google/).
 
 To mitigate this issue,  [disable automatic logons](toolwindow-connection-settings.md#remote-desktop-security-settings) in


### PR DESCRIPTION
Link to gpsearch.azurewebsites.net instead of admx.help as the latter is no longer available.